### PR TITLE
feat(cli): write-auth CLI — revoke-key, rotate-key, verify-tier (Plan-1 Tasks 10-12)

### DIFF
--- a/cli/src/robot_md/__main__.py
+++ b/cli/src/robot_md/__main__.py
@@ -747,9 +747,7 @@ def verify_tier(
         "--attestation-file",
         help="Path to a signed attestation JSON (required for manufacturer_verified).",
     ),
-    endpoint: str = typer.Option(
-        "https://robotregistryfoundation.org/v2/robots", "--endpoint"
-    ),
+    endpoint: str = typer.Option("https://robotregistryfoundation.org/v2/robots", "--endpoint"),
     yes: bool = typer.Option(False, "--yes", "-y", help="Skip the pre-flight confirmation prompt."),
 ) -> None:
     """Promote a robot's verification_status.

--- a/cli/src/robot_md/__main__.py
+++ b/cli/src/robot_md/__main__.py
@@ -730,6 +730,49 @@ def revoke_key(
         raise typer.Exit(code=rc)
 
 
+@app.command(name="verify-tier")
+def verify_tier(
+    rrn: str = typer.Argument(..., help="RRN to promote."),
+    target: str = typer.Option(
+        ..., "--target", help="Target tier: manufacturer_claimed or manufacturer_verified."
+    ),
+    dns_domain: str = typer.Option(
+        ..., "--dns-domain", help="Domain whose _rcan-verify TXT record proves ownership."
+    ),
+    ruri: str | None = typer.Option(
+        None, "--ruri", help="Robot's RURI base URL (required for manufacturer_verified)."
+    ),
+    attestation_file: Path | None = typer.Option(
+        None,
+        "--attestation-file",
+        help="Path to a signed attestation JSON (required for manufacturer_verified).",
+    ),
+    endpoint: str = typer.Option(
+        "https://robotregistryfoundation.org/v2/robots", "--endpoint"
+    ),
+    yes: bool = typer.Option(False, "--yes", "-y", help="Skip the pre-flight confirmation prompt."),
+) -> None:
+    """Promote a robot's verification_status.
+
+    manufacturer_claimed requires server-side DNS TXT verification;
+    manufacturer_verified also requires a signed attestation and a reachable
+    RURI /.well-known/rcan-manifest.json.
+    """
+    from robot_md.verify_tier import cli_verify_tier
+
+    rc = cli_verify_tier(
+        rrn,
+        target=target,
+        dns_domain=dns_domain,
+        ruri=ruri,
+        attestation_file=attestation_file,
+        endpoint=endpoint,
+        non_interactive=yes,
+    )
+    if rc != 0:
+        raise typer.Exit(code=rc)
+
+
 def _hardware_present() -> bool:
     """Heuristic: return True if any /dev/ttyACM* device is visible.
 

--- a/cli/src/robot_md/__main__.py
+++ b/cli/src/robot_md/__main__.py
@@ -682,6 +682,32 @@ def unregister(
         raise typer.Exit(code=rc)
 
 
+@app.command(name="revoke-key")
+def revoke_key(
+    rrn: str = typer.Argument(..., help="RRN to revoke, e.g. RRN-000000000042."),
+    reason: str | None = typer.Option(
+        None,
+        "--reason",
+        help="Optional human-readable reason recorded in the revocation entry.",
+    ),
+    endpoint: str = typer.Option(
+        "https://robotregistryfoundation.org/v2/robots",
+        "--endpoint",
+        help="RRF base URL. Override for staging / self-hosted.",
+    ),
+) -> None:
+    """Revoke a robot's signing key.
+
+    After revocation, all §22-26 compliance intakes for this RRN will be
+    refused with 403. This is a ONE-WAY operation.
+    """
+    from robot_md.revoke_key import cli_revoke_key
+
+    rc = cli_revoke_key(rrn, endpoint=endpoint, reason=reason)
+    if rc != 0:
+        raise typer.Exit(code=rc)
+
+
 def _hardware_present() -> bool:
     """Heuristic: return True if any /dev/ttyACM* device is visible.
 

--- a/cli/src/robot_md/__main__.py
+++ b/cli/src/robot_md/__main__.py
@@ -682,6 +682,28 @@ def unregister(
         raise typer.Exit(code=rc)
 
 
+@app.command(name="rotate-key")
+def rotate_key(
+    rrn: str = typer.Argument(..., help="RRN whose key you want to rotate."),
+    endpoint: str = typer.Option(
+        "https://robotregistryfoundation.org/v2/robots",
+        "--endpoint",
+        help="RRF base URL. Override for staging / self-hosted.",
+    ),
+) -> None:
+    """Rotate a robot's signing key.
+
+    Generates a new keypair locally, co-signs the rotation with old+new keys,
+    and POSTs to RRF. On success, archives the old keypair for recovery.
+    The archive can be used to revoke the old key if the new key is lost.
+    """
+    from robot_md.rotate_key import cli_rotate_key
+
+    rc = cli_rotate_key(rrn, endpoint=endpoint)
+    if rc != 0:
+        raise typer.Exit(code=rc)
+
+
 @app.command(name="revoke-key")
 def revoke_key(
     rrn: str = typer.Argument(..., help="RRN to revoke, e.g. RRN-000000000042."),

--- a/cli/src/robot_md/revoke_key.py
+++ b/cli/src/robot_md/revoke_key.py
@@ -1,0 +1,127 @@
+"""`robot-md revoke-key` — revoke a robot's signing key at the Robot Registry Foundation.
+
+After revocation all §22-26 compliance intakes for this RRN are refused with 403.
+This is a ONE-WAY operation.
+
+Usage via CLI:
+
+    robot-md revoke-key RRN-000000000042
+    robot-md revoke-key RRN-000000000042 --reason "decommissioned"
+    robot-md revoke-key RRN-000000000042 --endpoint https://staging.rrf...
+
+Exit codes: 0 success or already-revoked (409), non-zero on any failure.
+"""
+
+from __future__ import annotations
+
+import json
+import sys
+import urllib.error
+import urllib.request
+from typing import Any
+
+DEFAULT_ENDPOINT = "https://robotregistryfoundation.org/v2/robots"
+
+
+def build_revoke_body(rrn: str, reason: str | None) -> dict[str, Any]:
+    """Build the pre-signing revoke request body.
+
+    The 'reason' key is OMITTED entirely when not provided — the server
+    rejects non-string reason values so we must not send ``reason: None``.
+    """
+    body: dict[str, Any] = {"rrn": rrn, "action": "revoke"}
+    if reason is not None:
+        body["reason"] = reason
+    return body
+
+
+def post_revoke(
+    url: str, signed_body: dict[str, Any], *, timeout: float = 15.0
+) -> tuple[int, str]:
+    """POST signed_body as JSON to url.
+
+    Returns (status_code, response_text) on HTTP responses.
+    For network errors (URLError) returns (0, reason_str) as a sentinel.
+
+    NOTE: HTTPError must be caught before URLError because HTTPError is a
+    subclass of URLError.
+    """
+    data = json.dumps(signed_body).encode("utf-8")
+    req = urllib.request.Request(
+        url,
+        data=data,
+        method="POST",
+        headers={
+            "Content-Type": "application/json",
+            "Accept": "application/json",
+            "User-Agent": "robot-md-cli/0.9 (+https://robotmd.dev)",
+        },
+    )
+    try:
+        with urllib.request.urlopen(req, timeout=timeout) as resp:
+            text = resp.read().decode("utf-8")
+            return resp.status, text
+    except urllib.error.HTTPError as e:
+        err_text = e.read().decode("utf-8", errors="replace") if hasattr(e, "read") else str(e)
+        return e.code, err_text
+    except urllib.error.URLError as e:
+        return 0, str(e.reason)
+
+
+def cli_revoke_key(
+    rrn: str,
+    *,
+    endpoint: str = DEFAULT_ENDPOINT,
+    reason: str | None = None,
+) -> int:
+    """Revoke the signing key for ``rrn`` at ``endpoint``.
+
+    Returns exit code. 0 = success (204) or already-revoked (409).
+    Non-zero = any other failure.
+    """
+    from robot_md.signing import load_keypair, sign_body
+
+    kp = load_keypair(rrn)
+    if kp is None:
+        print(
+            f"No signing key for {rrn} at ~/.robot-md/keys/{rrn}.signing.json; "
+            "did you register with a v0.9.1+ client?",
+            file=sys.stderr,
+        )
+        return 1
+
+    body = build_revoke_body(rrn, reason)
+    signed = sign_body(kp, body)
+    url = f"{endpoint.rstrip('/')}/{rrn}/revoke-key"
+    status, text = post_revoke(url, signed)
+
+    # Network error sentinel
+    if status == 0:
+        print(f"Could not reach {url}: {text}", file=sys.stderr)
+        return 1
+
+    if status == 204:
+        print(f"Revoked: {rrn}")
+        return 0
+
+    if status == 409:
+        print(f"Already revoked: {rrn}")
+        return 0
+
+    if status == 401:
+        # Try to extract error message from JSON body
+        try:
+            obj = json.loads(text)
+            error_msg = obj.get("error", text.strip()[:200])
+        except (json.JSONDecodeError, AttributeError):
+            error_msg = text.strip()[:200]
+        print(f"Signature rejected by RRF: {error_msg}", file=sys.stderr)
+        return 1
+
+    if status == 404:
+        print(f"RRN not found at {endpoint}", file=sys.stderr)
+        return 1
+
+    # All other non-2xx
+    print(f"RRF returned {status}: {text.strip()[:500]}", file=sys.stderr)
+    return 1

--- a/cli/src/robot_md/revoke_key.py
+++ b/cli/src/robot_md/revoke_key.py
@@ -119,7 +119,11 @@ def cli_revoke_key(
         return 1
 
     if status == 404:
-        print(f"RRN not found at {endpoint}", file=sys.stderr)
+        # Include the server body excerpt so the operator can tell a wrong
+        # --endpoint apart from a missing registration.
+        body_excerpt = text.strip()[:200] if text else ""
+        suffix = f": {body_excerpt}" if body_excerpt else ""
+        print(f"RRN not found at {endpoint}{suffix}", file=sys.stderr)
         return 1
 
     # All other non-2xx

--- a/cli/src/robot_md/revoke_key.py
+++ b/cli/src/robot_md/revoke_key.py
@@ -35,9 +35,7 @@ def build_revoke_body(rrn: str, reason: str | None) -> dict[str, Any]:
     return body
 
 
-def post_revoke(
-    url: str, signed_body: dict[str, Any], *, timeout: float = 15.0
-) -> tuple[int, str]:
+def post_revoke(url: str, signed_body: dict[str, Any], *, timeout: float = 15.0) -> tuple[int, str]:
     """POST signed_body as JSON to url.
 
     Returns (status_code, response_text) on HTTP responses.

--- a/cli/src/robot_md/rotate_key.py
+++ b/cli/src/robot_md/rotate_key.py
@@ -1,0 +1,236 @@
+"""`robot-md rotate-key` — rotate a robot's signing key at the Robot Registry Foundation.
+
+Generates a new ML-DSA-65 + Ed25519 keypair locally, signs the rotation
+canonical body with BOTH the old key and the new key, and POSTs both
+signatures to RRF. On a 200 response the old keypair is archived and the
+keystore is updated atomically.
+
+Usage via CLI:
+
+    robot-md rotate-key RRN-000000000042
+    robot-md rotate-key RRN-000000000042 --endpoint https://staging.rrf...
+
+Exit codes:
+    0   — success (server accepted, local keystore updated)
+    1   — failure (pre-flight check, server error, network error)
+    2   — partial failure: server accepted BUT archive-write failed.
+          The server now expects the NEW key, but the local keystore still
+          has the OLD key. The operator must recover manually (see error
+          message printed to stderr). Re-running rotate-key will fail
+          because the server's current key is now the new one.
+
+Critical ordering constraint
+----------------------------
+The archive-write MUST succeed BEFORE the keystore replace. If the archive
+write fails (disk full, permissions), we bail out with exit code 2 and leave
+the old key in the keystore. The operator is instructed to contact support or
+manually recover by saving the new keypair to the keystore path.
+
+Failure modes:
+- Step 1 (archive) fails: old keystore is still valid; re-run revoke-key with
+  the old key to revoke if needed.
+- Step 2 (keystore replace) fails after step 1 succeeded: old key is in the
+  archive; new key is lost. Operator must manually copy archive → keystore.
+"""
+
+from __future__ import annotations
+
+import base64
+import json
+import os
+import sys
+import urllib.error
+import urllib.request
+from pathlib import Path
+from typing import Any
+
+DEFAULT_ENDPOINT = "https://robotregistryfoundation.org/v2/robots"
+
+
+def _archive_dir() -> Path:
+    """Return the archive directory path, honouring the current HOME."""
+    return Path.home() / ".robot-md" / "keys" / "archive"
+
+
+def _serialize_keypair(rrn: str, kp) -> dict:
+    """Serialize a SigningKeypair to the same JSON shape as save_keypair.
+
+    Inlined from signing.save_keypair to allow writing to an arbitrary path
+    (save_keypair always writes to the canonical keystore location).
+    """
+    from datetime import datetime, timezone
+
+    return {
+        "rrn": rrn,
+        "pq_kid": kp.pq_kid,
+        "ml_dsa": {
+            "pub": base64.b64encode(kp.ml_dsa.public_key_bytes).decode(),
+            "sec": base64.b64encode(kp.ml_dsa._secret_key).decode(),
+        },
+        "ed25519": {
+            "pub": base64.b64encode(kp.ed25519_pub).decode(),
+            "sec": base64.b64encode(kp.ed25519_sec).decode(),
+        },
+        "created_at": datetime.now(timezone.utc).strftime("%Y-%m-%dT%H:%M:%SZ"),
+    }
+
+
+def archive_old_keypair(rrn: str, old_kp) -> Path:
+    """Write old keypair JSON to archive dir, mode 0600. Write-to-tmp-then-rename.
+
+    Returns the path to the archive file.
+
+    Raises OSError if any I/O step fails. The caller must handle this and
+    leave the main keystore untouched if this raises.
+    """
+    from robot_md.signing import kid_from_pub
+
+    old_kid = kid_from_pub(old_kp.ml_dsa.public_key_bytes)
+    dest = _archive_dir() / f"{rrn}.{old_kid}.signing.json"
+    dest.parent.mkdir(parents=True, exist_ok=True)
+    tmp = dest.with_suffix(dest.suffix + ".tmp")
+    blob = _serialize_keypair(rrn, old_kp)
+    tmp.write_text(json.dumps(blob, indent=2))
+    os.chmod(tmp, 0o600)
+    tmp.replace(dest)
+    return dest
+
+
+def build_rotate_request(old_kp, new_kp, rrn: str) -> dict[str, Any]:
+    """Build the dual-signed rotation request body.
+
+    Both envelopes sign the same canonical dict (rrn, action, new key info),
+    but one is stamped with the old key's pq_signing_pub/pq_kid/sig and the
+    other with the new key's pq_signing_pub/pq_kid/sig. RRF verifies both to
+    confirm the old key authorises the rotation and the new key is live.
+    """
+    from robot_md.signing import kid_from_pub, sign_body
+
+    new_pub_b64 = base64.b64encode(new_kp.ml_dsa.public_key_bytes).decode("ascii")
+    new_kid = kid_from_pub(new_kp.ml_dsa.public_key_bytes)
+    canonical: dict[str, Any] = {
+        "rrn": rrn,
+        "action": "rotate",
+        "new_pq_signing_pub": new_pub_b64,
+        "new_pq_kid": new_kid,
+    }
+    return {
+        "by_old_key": sign_body(old_kp, canonical),
+        "by_new_key": sign_body(new_kp, canonical),
+    }
+
+
+def post_rotate(
+    url: str, body: dict[str, Any], *, timeout: float = 15.0
+) -> tuple[int, str]:
+    """POST body as JSON to url.
+
+    Returns (status_code, response_text) on HTTP responses.
+    For network errors (URLError) returns (0, reason_str) as a sentinel.
+
+    NOTE: HTTPError must be caught before URLError because HTTPError is a
+    subclass of URLError.
+    """
+    data = json.dumps(body).encode("utf-8")
+    req = urllib.request.Request(
+        url,
+        data=data,
+        method="POST",
+        headers={
+            "Content-Type": "application/json",
+            "Accept": "application/json",
+            "User-Agent": "robot-md-cli/0.9 (+https://robotmd.dev)",
+        },
+    )
+    try:
+        with urllib.request.urlopen(req, timeout=timeout) as resp:
+            text = resp.read().decode("utf-8")
+            return resp.status, text
+    except urllib.error.HTTPError as e:
+        err_text = e.read().decode("utf-8", errors="replace") if hasattr(e, "read") else str(e)
+        return e.code, err_text
+    except urllib.error.URLError as e:
+        return 0, str(e.reason)
+
+
+def _extract_error(text: str) -> str:
+    """Try to extract an 'error' field from a JSON body; fall back to raw text."""
+    try:
+        obj = json.loads(text)
+        return obj.get("error", text.strip()[:200])
+    except (json.JSONDecodeError, AttributeError):
+        return text.strip()[:200]
+
+
+def cli_rotate_key(
+    rrn: str,
+    *,
+    endpoint: str = DEFAULT_ENDPOINT,
+) -> int:
+    """Rotate the signing key for ``rrn`` at ``endpoint``.
+
+    Returns exit code:
+        0   — success
+        1   — pre-flight or server/network failure (keystore untouched)
+        2   — server accepted but archive-write failed (keystore still has old key)
+    """
+    from robot_md.signing import generate_keypair, load_keypair, save_keypair
+
+    old_kp = load_keypair(rrn)
+    if old_kp is None:
+        print(
+            f"No signing key for {rrn}; cannot rotate. "
+            "Did you register with a v0.9.1+ client?",
+            file=sys.stderr,
+        )
+        return 1
+
+    new_kp = generate_keypair()
+    req_body = build_rotate_request(old_kp, new_kp, rrn)
+    url = f"{endpoint.rstrip('/')}/{rrn}/rotate-key"
+    status, text = post_rotate(url, req_body)
+
+    # Network error sentinel
+    if status == 0:
+        print(f"Could not reach {url}: {text}", file=sys.stderr)
+        return 1
+
+    if status != 200:
+        error_msg = _extract_error(text)
+        if status == 400:
+            print(f"RRF rejected rotate: {error_msg}", file=sys.stderr)
+        elif status == 401:
+            print(f"Signature rejected by RRF: {error_msg}", file=sys.stderr)
+        elif status == 403:
+            print(f"Record is revoked: {rrn}", file=sys.stderr)
+        elif status == 404:
+            print(f"RRN not found at {endpoint}", file=sys.stderr)
+        else:
+            print(f"RRF returned {status}: {text.strip()[:500]}", file=sys.stderr)
+        return 1
+
+    # Server accepted (200). Archive old key FIRST — if this fails the old
+    # key is still in the keystore, which is the safest recovery state.
+    try:
+        archive_dest = archive_old_keypair(rrn, old_kp)
+    except OSError as e:
+        print(
+            f"Server rotated but archive-write failed: {e}. "
+            "Local keystore still has old key.",
+            file=sys.stderr,
+        )
+        print(
+            "Rotation is server-side complete; the server now expects the new key. "
+            "Recover by manually saving the new keypair to "
+            f"~/.robot-md/keys/{rrn}.signing.json, or contact support.",
+            file=sys.stderr,
+        )
+        return 2  # distinct non-zero code for this partial-failure mode
+
+    # Archive succeeded — now atomically replace the keystore.
+    save_keypair(rrn, new_kp)
+    print(
+        f"Rotated. Old key archived at {archive_dest} "
+        "(treat as backup credential — can still revoke if new key is lost)."
+    )
+    return 0

--- a/cli/src/robot_md/rotate_key.py
+++ b/cli/src/robot_md/rotate_key.py
@@ -35,6 +35,7 @@ rotation to recover from.
 from __future__ import annotations
 
 import base64
+import contextlib
 import json
 import os
 import sys
@@ -73,29 +74,23 @@ def _write_secret_file(path: Path, content: str) -> None:
     path.parent.mkdir(parents=True, exist_ok=True, mode=0o700)
     tmp = path.with_suffix(path.suffix + ".tmp")
     # Clear any stale tmp from a prior crashed invocation so O_EXCL succeeds.
-    try:
+    with contextlib.suppress(FileNotFoundError):
         tmp.unlink()
-    except FileNotFoundError:
-        pass
     fd = os.open(str(tmp), os.O_CREAT | os.O_WRONLY | os.O_EXCL, 0o600)
     try:
         with os.fdopen(fd, "w") as f:
             f.write(content)
         tmp.replace(path)
     except OSError:
-        try:
+        with contextlib.suppress(FileNotFoundError):
             tmp.unlink()
-        except FileNotFoundError:
-            pass
         raise
 
 
 def _silent_unlink(path: Path) -> None:
     """Remove a file if it exists; swallow errors (best-effort cleanup)."""
-    try:
+    with contextlib.suppress(FileNotFoundError, OSError):
         path.unlink()
-    except (FileNotFoundError, OSError):
-        pass
 
 
 def _serialize_keypair(rrn: str, kp) -> dict:

--- a/cli/src/robot_md/rotate_key.py
+++ b/cli/src/robot_md/rotate_key.py
@@ -157,9 +157,7 @@ def build_rotate_request(old_kp, new_kp, rrn: str) -> dict[str, Any]:
     }
 
 
-def post_rotate(
-    url: str, body: dict[str, Any], *, timeout: float = 15.0
-) -> tuple[int, str]:
+def post_rotate(url: str, body: dict[str, Any], *, timeout: float = 15.0) -> tuple[int, str]:
     """POST body as JSON to url.
 
     Returns (status_code, response_text) on HTTP responses.
@@ -216,8 +214,7 @@ def cli_rotate_key(
     old_kp = load_keypair(rrn)
     if old_kp is None:
         print(
-            f"No signing key for {rrn}; cannot rotate. "
-            "Did you register with a v0.9.1+ client?",
+            f"No signing key for {rrn}; cannot rotate. Did you register with a v0.9.1+ client?",
             file=sys.stderr,
         )
         return 1
@@ -276,8 +273,7 @@ def cli_rotate_key(
         archive_dest = archive_old_keypair(rrn, old_kp)
     except OSError as e:
         print(
-            f"Server rotated but archive-write failed: {e}. "
-            "Local keystore still has old key.",
+            f"Server rotated but archive-write failed: {e}. Local keystore still has old key.",
             file=sys.stderr,
         )
         print(

--- a/cli/src/robot_md/rotate_key.py
+++ b/cli/src/robot_md/rotate_key.py
@@ -13,24 +13,23 @@ Usage via CLI:
 Exit codes:
     0   — success (server accepted, local keystore updated)
     1   — failure (pre-flight check, server error, network error)
-    2   — partial failure: server accepted BUT archive-write failed.
-          The server now expects the NEW key, but the local keystore still
-          has the OLD key. The operator must recover manually (see error
-          message printed to stderr). Re-running rotate-key will fail
-          because the server's current key is now the new one.
+    2   — partial failure: server accepted BUT a local disk step failed
+          (archive-write OR keystore-save). The server now expects the NEW
+          key. The staged new keypair at ~/.robot-md/keys/<rrn>.NEW.signing.json
+          holds recoverable material; stderr prints the exact `mv` command.
 
 Critical ordering constraint
 ----------------------------
-The archive-write MUST succeed BEFORE the keystore replace. If the archive
-write fails (disk full, permissions), we bail out with exit code 2 and leave
-the old key in the keystore. The operator is instructed to contact support or
-manually recover by saving the new keypair to the keystore path.
+Before the POST: the freshly-generated new keypair is persisted to
+``~/.robot-md/keys/<rrn>.NEW.signing.json`` (mode 0o600) so that any
+exit-2 path has real key material to recover from.
 
-Failure modes:
-- Step 1 (archive) fails: old keystore is still valid; re-run revoke-key with
-  the old key to revoke if needed.
-- Step 2 (keystore replace) fails after step 1 succeeded: old key is in the
-  archive; new key is lost. Operator must manually copy archive → keystore.
+After a 200 response: archive the old keypair first. Only if that succeeds
+do we replace the main keystore. On either local-disk failure we leave the
+staging file intact and print a recovery command.
+
+On any non-200 / network error the staging file is removed — there's no
+rotation to recover from.
 """
 
 from __future__ import annotations
@@ -50,6 +49,53 @@ DEFAULT_ENDPOINT = "https://robotregistryfoundation.org/v2/robots"
 def _archive_dir() -> Path:
     """Return the archive directory path, honouring the current HOME."""
     return Path.home() / ".robot-md" / "keys" / "archive"
+
+
+def _new_staging_path(rrn: str) -> Path:
+    """Recovery-staging location for the freshly-generated keypair.
+
+    Written before the rotate POST so that if the canonical keystore write
+    fails after the server has accepted the rotation, the operator has a
+    real file to recover from.
+    """
+    return Path.home() / ".robot-md" / "keys" / f"{rrn}.NEW.signing.json"
+
+
+def _write_secret_file(path: Path, content: str) -> None:
+    """Atomically write secret content to path, mode 0600 from the start.
+
+    - Parent dir is created with mode 0o700 if missing.
+    - Temp file is created with O_CREAT|O_WRONLY|O_EXCL and mode 0o600, so
+      there is no window where the file is world-readable.
+    - Temp file is removed on failure so we never leave a stray copy of
+      secret material on disk.
+    """
+    path.parent.mkdir(parents=True, exist_ok=True, mode=0o700)
+    tmp = path.with_suffix(path.suffix + ".tmp")
+    # Clear any stale tmp from a prior crashed invocation so O_EXCL succeeds.
+    try:
+        tmp.unlink()
+    except FileNotFoundError:
+        pass
+    fd = os.open(str(tmp), os.O_CREAT | os.O_WRONLY | os.O_EXCL, 0o600)
+    try:
+        with os.fdopen(fd, "w") as f:
+            f.write(content)
+        tmp.replace(path)
+    except OSError:
+        try:
+            tmp.unlink()
+        except FileNotFoundError:
+            pass
+        raise
+
+
+def _silent_unlink(path: Path) -> None:
+    """Remove a file if it exists; swallow errors (best-effort cleanup)."""
+    try:
+        path.unlink()
+    except (FileNotFoundError, OSError):
+        pass
 
 
 def _serialize_keypair(rrn: str, kp) -> dict:
@@ -87,12 +133,8 @@ def archive_old_keypair(rrn: str, old_kp) -> Path:
 
     old_kid = kid_from_pub(old_kp.ml_dsa.public_key_bytes)
     dest = _archive_dir() / f"{rrn}.{old_kid}.signing.json"
-    dest.parent.mkdir(parents=True, exist_ok=True)
-    tmp = dest.with_suffix(dest.suffix + ".tmp")
     blob = _serialize_keypair(rrn, old_kp)
-    tmp.write_text(json.dumps(blob, indent=2))
-    os.chmod(tmp, 0o600)
-    tmp.replace(dest)
+    _write_secret_file(dest, json.dumps(blob, indent=2))
     return dest
 
 
@@ -186,16 +228,37 @@ def cli_rotate_key(
         return 1
 
     new_kp = generate_keypair()
+
+    # Persist new_kp to a recovery staging file BEFORE the POST so that any
+    # local-disk failure after the server has accepted the rotation leaves the
+    # operator with real key material to recover from (not just an in-memory
+    # keypair that's about to be garbage-collected).
+    staging_path = _new_staging_path(rrn)
+    try:
+        new_blob = _serialize_keypair(rrn, new_kp)
+        _write_secret_file(staging_path, json.dumps(new_blob, indent=2))
+    except OSError as e:
+        print(
+            f"Could not stage new keypair for recovery at {staging_path}: {e}",
+            file=sys.stderr,
+        )
+        return 1
+
     req_body = build_rotate_request(old_kp, new_kp, rrn)
     url = f"{endpoint.rstrip('/')}/{rrn}/rotate-key"
     status, text = post_rotate(url, req_body)
 
     # Network error sentinel
     if status == 0:
+        # Server never accepted; staging is pure waste and would confuse a
+        # future invocation. Remove it.
+        _silent_unlink(staging_path)
         print(f"Could not reach {url}: {text}", file=sys.stderr)
         return 1
 
     if status != 200:
+        # Server rejected; same reasoning — no rotation to recover from.
+        _silent_unlink(staging_path)
         error_msg = _extract_error(text)
         if status == 400:
             print(f"RRF rejected rotate: {error_msg}", file=sys.stderr)
@@ -209,8 +272,11 @@ def cli_rotate_key(
             print(f"RRF returned {status}: {text.strip()[:500]}", file=sys.stderr)
         return 1
 
-    # Server accepted (200). Archive old key FIRST — if this fails the old
-    # key is still in the keystore, which is the safest recovery state.
+    # Server accepted (200). From here on, exit-2 paths MUST leave the staging
+    # file in place so the operator has recoverable key material.
+
+    # Archive old key FIRST — if this fails the old key is still in the
+    # keystore, which is the safest recovery state.
     try:
         archive_dest = archive_old_keypair(rrn, old_kp)
     except OSError as e:
@@ -221,11 +287,11 @@ def cli_rotate_key(
         )
         print(
             "Rotation is server-side complete; the server now expects the new key. "
-            "Recover by manually saving the new keypair to "
-            f"~/.robot-md/keys/{rrn}.signing.json, or contact support.",
+            f"Recover by copying the staged new keypair into place:\n"
+            f"    mv {staging_path} {Path.home() / '.robot-md' / 'keys' / (rrn + '.signing.json')}",
             file=sys.stderr,
         )
-        return 2  # distinct non-zero code for this partial-failure mode
+        return 2
 
     # Archive succeeded — now atomically replace the keystore.
     try:
@@ -238,12 +304,15 @@ def cli_rotate_key(
         )
         print(
             "Rotation is server-side complete; the server now expects the new key. "
-            "Recover by manually saving the new keypair to "
-            f"~/.robot-md/keys/{rrn}.signing.json, or contact support.",
+            f"Recover by copying the staged new keypair into place:\n"
+            f"    mv {staging_path} {Path.home() / '.robot-md' / 'keys' / (rrn + '.signing.json')}",
             file=sys.stderr,
         )
         return 2
 
+    # Happy path: keystore now has new key, archive has old key. Staging is
+    # redundant; clean it up so future invocations don't trip over it.
+    _silent_unlink(staging_path)
     print(
         f"Rotated. Old key archived at {archive_dest} "
         "(treat as backup credential — can still revoke if new key is lost)."

--- a/cli/src/robot_md/rotate_key.py
+++ b/cli/src/robot_md/rotate_key.py
@@ -228,7 +228,22 @@ def cli_rotate_key(
         return 2  # distinct non-zero code for this partial-failure mode
 
     # Archive succeeded — now atomically replace the keystore.
-    save_keypair(rrn, new_kp)
+    try:
+        save_keypair(rrn, new_kp)
+    except OSError as e:
+        print(
+            f"Server rotated and archive written, but keystore save failed: {e}. "
+            f"Archive at {archive_dest} holds the old key.",
+            file=sys.stderr,
+        )
+        print(
+            "Rotation is server-side complete; the server now expects the new key. "
+            "Recover by manually saving the new keypair to "
+            f"~/.robot-md/keys/{rrn}.signing.json, or contact support.",
+            file=sys.stderr,
+        )
+        return 2
+
     print(
         f"Rotated. Old key archived at {archive_dest} "
         "(treat as backup credential — can still revoke if new key is lost)."

--- a/cli/src/robot_md/verify_tier.py
+++ b/cli/src/robot_md/verify_tier.py
@@ -168,8 +168,7 @@ def cli_verify_tier(
             return 1
         if size > MAX_ATTESTATION_BYTES:
             print(
-                f"Attestation file too large: {size} bytes "
-                f"(max {MAX_ATTESTATION_BYTES} = 1 MiB)",
+                f"Attestation file too large: {size} bytes (max {MAX_ATTESTATION_BYTES} = 1 MiB)",
                 file=sys.stderr,
             )
             return 1

--- a/cli/src/robot_md/verify_tier.py
+++ b/cli/src/robot_md/verify_tier.py
@@ -194,7 +194,8 @@ def cli_verify_tier(
     if status == 200:
         try:
             data = json.loads(text)
-            print(f"Promoted {rrn} to {target}.")
+            new_status = data.get("verification_status", target)
+            print(f"Promoted {rrn} to {new_status}.")
             binding = data.get("identity_binding", {})
             print(f"identity_binding: {json.dumps(binding, indent=2)}")
         except json.JSONDecodeError:

--- a/cli/src/robot_md/verify_tier.py
+++ b/cli/src/robot_md/verify_tier.py
@@ -1,0 +1,229 @@
+"""`robot-md verify-tier` — promote a robot's verification_status at the Robot Registry Foundation.
+
+Supports promotion to manufacturer_claimed (DNS TXT proof) and
+manufacturer_verified (DNS TXT + RURI /.well-known/rcan-manifest.json + signed attestation).
+
+Community tier is maintainer-curated via PR and cannot be promoted via this API.
+
+Usage via CLI:
+
+    robot-md verify-tier RRN-000000000042 \\
+        --target manufacturer_claimed \\
+        --dns-domain robotis.com
+
+    robot-md verify-tier RRN-000000000042 \\
+        --target manufacturer_verified \\
+        --dns-domain robotis.com \\
+        --ruri https://robotis.com \\
+        --attestation-file signed_attestation.json
+
+Exit codes: 0 success, non-zero on any failure.
+"""
+
+from __future__ import annotations
+
+import json
+import os
+import sys
+import urllib.error
+import urllib.request
+from pathlib import Path
+from typing import Any
+
+DEFAULT_ENDPOINT = "https://robotregistryfoundation.org/v2/robots"
+
+VALID_TARGETS = {"manufacturer_claimed", "manufacturer_verified"}
+
+
+def _is_interactive() -> bool:
+    if os.environ.get("ROBOT_MD_NONINTERACTIVE") == "1":
+        return False
+    return sys.stdin.isatty()
+
+
+def _preflight_message(rrn: str, target: str, dns_domain: str, ruri: str | None) -> str:
+    msg = [
+        f"About to request tier promotion for {rrn} to {target}.",
+        "",
+        "Before continuing, ensure this DNS TXT record exists:",
+        f'  _rcan-verify.{dns_domain}  TXT  "rrn={rrn};model=<your-model>"',
+    ]
+    if target == "manufacturer_verified":
+        msg += [
+            "",
+            f"Also ensure {ruri}/.well-known/rcan-manifest.json returns a JSON object",
+            f"with rrn={rrn} (RRF will fetch it during promotion).",
+        ]
+    msg += ["", "RRF will refuse promotion if any check fails.", ""]
+    return "\n".join(msg)
+
+
+def build_verify_tier_body(
+    rrn: str,
+    target: str,
+    dns_domain: str,
+    ruri: str | None,
+    attestation: dict[str, Any] | None,
+) -> dict[str, Any]:
+    """Build the pre-signing verify-tier request body."""
+    body: dict[str, Any] = {
+        "rrn": rrn,
+        "action": "verify-tier",
+        "target_tier": target,
+        "binding": {"type": "dns-txt", "value": dns_domain},
+    }
+    if target == "manufacturer_verified":
+        body["ruri"] = ruri
+        body["attestation"] = attestation
+    return body
+
+
+def post_verify_tier(
+    url: str, signed_body: dict[str, Any], *, timeout: float = 30.0
+) -> tuple[int, str]:
+    """POST signed_body as JSON to url.
+
+    Returns (status_code, response_text) on HTTP responses.
+    For network errors (URLError) returns (0, reason_str) as a sentinel.
+
+    NOTE: HTTPError must be caught before URLError because HTTPError is a
+    subclass of URLError.
+    """
+    data = json.dumps(signed_body).encode("utf-8")
+    req = urllib.request.Request(
+        url,
+        data=data,
+        method="POST",
+        headers={
+            "Content-Type": "application/json",
+            "Accept": "application/json",
+            "User-Agent": "robot-md-cli/1.0 (+https://robotmd.dev)",
+        },
+    )
+    try:
+        with urllib.request.urlopen(req, timeout=timeout) as resp:
+            text = resp.read().decode("utf-8", errors="replace")
+            return resp.status, text
+    except urllib.error.HTTPError as e:
+        err_text = e.read().decode("utf-8", errors="replace") if hasattr(e, "read") else str(e)
+        return e.code, err_text
+    except urllib.error.URLError as e:
+        return 0, str(e.reason)
+
+
+def _extract_error(text: str) -> str:
+    try:
+        return json.loads(text).get("error", text[:200])
+    except (json.JSONDecodeError, AttributeError, TypeError):
+        return text[:200]
+
+
+def cli_verify_tier(
+    rrn: str,
+    *,
+    target: str,
+    dns_domain: str,
+    ruri: str | None = None,
+    attestation_file: Path | None = None,
+    endpoint: str = DEFAULT_ENDPOINT,
+    non_interactive: bool = False,
+) -> int:
+    """Promote the verification_status for ``rrn`` at ``endpoint``.
+
+    Returns exit code. 0 = success. Non-zero = any failure.
+    """
+    # 1. target validation
+    if target == "community":
+        print(
+            "community tier is maintainer-curated via PR, not promotable via API.",
+            file=sys.stderr,
+        )
+        return 1
+    if target not in VALID_TARGETS:
+        print(f"Unknown target_tier: {target}", file=sys.stderr)
+        return 1
+
+    # 2. manufacturer_verified requires ruri + attestation_file
+    attestation: dict[str, Any] | None = None
+    if target == "manufacturer_verified":
+        if ruri is None or attestation_file is None:
+            print(
+                "manufacturer_verified requires --ruri and --attestation-file",
+                file=sys.stderr,
+            )
+            return 1
+        if not attestation_file.exists():
+            print(f"Attestation file not found: {attestation_file}", file=sys.stderr)
+            return 1
+        try:
+            attestation = json.loads(attestation_file.read_text())
+        except (OSError, json.JSONDecodeError) as e:
+            print(f"Attestation file is not valid JSON: {e}", file=sys.stderr)
+            return 1
+        if not isinstance(attestation, dict):
+            print("Attestation file must contain a JSON object", file=sys.stderr)
+            return 1
+
+    # 3. load signing keypair
+    from robot_md.signing import load_keypair, sign_body
+
+    kp = load_keypair(rrn)
+    if kp is None:
+        print(
+            f"No signing key for {rrn} at ~/.robot-md/keys/{rrn}.signing.json",
+            file=sys.stderr,
+        )
+        return 1
+
+    # 4. pre-flight prompt (skippable)
+    if not non_interactive and _is_interactive():
+        print(_preflight_message(rrn, target, dns_domain, ruri))
+        try:
+            input("Press Enter to continue, or Ctrl-C to cancel... ")
+        except (KeyboardInterrupt, EOFError):
+            print("\nCancelled.", file=sys.stderr)
+            return 1
+
+    # 5. build + sign + post
+    body = build_verify_tier_body(rrn, target, dns_domain, ruri, attestation)
+    signed = sign_body(kp, body)
+    url = f"{endpoint.rstrip('/')}/{rrn}/verify-tier"
+    status, text = post_verify_tier(url, signed)
+
+    # 6. response handling
+    if status == 200:
+        try:
+            data = json.loads(text)
+            print(f"Promoted {rrn} to {target}.")
+            binding = data.get("identity_binding", {})
+            print(f"identity_binding: {json.dumps(binding, indent=2)}")
+        except json.JSONDecodeError:
+            print(f"Promoted {rrn} to {target}. (Response was not JSON: {text[:200]})")
+        return 0
+
+    if status == 400:
+        print(f"RRF rejected: {_extract_error(text)}", file=sys.stderr)
+        return 1
+
+    if status == 401:
+        print(f"Signature rejected by RRF: {_extract_error(text)}", file=sys.stderr)
+        return 1
+
+    if status == 403:
+        print(f"Record is revoked: {rrn}", file=sys.stderr)
+        return 1
+
+    if status == 404:
+        print(f"RRN not found at {endpoint}: {rrn}", file=sys.stderr)
+        return 1
+
+    if status == 409:
+        print(f"Promotion state conflict: {_extract_error(text)}", file=sys.stderr)
+        return 1
+
+    if status == 0:
+        print(f"Could not reach {url}: {text}", file=sys.stderr)
+        return 1
+
+    print(f"RRF returned {status}: {text[:500]}", file=sys.stderr)
+    return 1

--- a/cli/src/robot_md/verify_tier.py
+++ b/cli/src/robot_md/verify_tier.py
@@ -34,6 +34,12 @@ DEFAULT_ENDPOINT = "https://robotregistryfoundation.org/v2/robots"
 
 VALID_TARGETS = {"manufacturer_claimed", "manufacturer_verified"}
 
+# Hard cap on attestation payload size. Attestations are signed JSON blobs
+# holding a public key + a few digests — a sane real one is well under 10 KiB.
+# The cap guards against operator mistakes (pointing at a log file) and
+# adversarial input.
+MAX_ATTESTATION_BYTES = 1 * 1024 * 1024  # 1 MiB
+
 
 def _is_interactive() -> bool:
     if os.environ.get("ROBOT_MD_NONINTERACTIVE") == "1":
@@ -156,8 +162,25 @@ def cli_verify_tier(
             print(f"Attestation file not found: {attestation_file}", file=sys.stderr)
             return 1
         try:
-            attestation = json.loads(attestation_file.read_text())
-        except (OSError, json.JSONDecodeError) as e:
+            size = attestation_file.stat().st_size
+        except OSError as e:
+            print(f"Could not stat attestation file: {e}", file=sys.stderr)
+            return 1
+        if size > MAX_ATTESTATION_BYTES:
+            print(
+                f"Attestation file too large: {size} bytes "
+                f"(max {MAX_ATTESTATION_BYTES} = 1 MiB)",
+                file=sys.stderr,
+            )
+            return 1
+        try:
+            raw = attestation_file.read_text()
+        except OSError as e:
+            print(f"Could not read attestation file: {e}", file=sys.stderr)
+            return 1
+        try:
+            attestation = json.loads(raw)
+        except json.JSONDecodeError as e:
             print(f"Attestation file is not valid JSON: {e}", file=sys.stderr)
             return 1
         if not isinstance(attestation, dict):

--- a/cli/tests/test_revoke_key.py
+++ b/cli/tests/test_revoke_key.py
@@ -12,8 +12,6 @@ import urllib.error
 from pathlib import Path
 from unittest.mock import MagicMock, patch
 
-import pytest
-
 from robot_md.signing import generate_keypair, save_keypair
 
 RRN = "RRN-000000000042"

--- a/cli/tests/test_revoke_key.py
+++ b/cli/tests/test_revoke_key.py
@@ -1,0 +1,262 @@
+"""Tests for `robot-md revoke-key` — signed POST to revoke a robot's signing key.
+
+TDD: tests written before implementation; run pytest to confirm RED, then
+implement revoke_key.py to get GREEN.
+"""
+
+from __future__ import annotations
+
+import io
+import json
+import urllib.error
+from pathlib import Path
+from unittest.mock import MagicMock, patch
+
+import pytest
+
+from robot_md.signing import generate_keypair, save_keypair
+
+RRN = "RRN-000000000042"
+
+
+def _make_keystore(tmp_path: Path) -> Path:
+    """Create ~/.robot-md/keys/ under tmp_path and return it."""
+    keys_dir = tmp_path / ".robot-md" / "keys"
+    keys_dir.mkdir(parents=True)
+    return keys_dir
+
+
+def _save_test_keypair(tmp_path: Path) -> None:
+    """Generate and save a signing keypair for RRN under tmp HOME."""
+    kp = generate_keypair()
+    save_keypair(RRN, kp)
+
+
+def _mock_200_ish(status: int, body: bytes = b"") -> MagicMock:
+    """Build a context-manager mock for a successful (non-error) HTTP response."""
+    resp = MagicMock()
+    resp.status = status
+    resp.read.return_value = body
+    resp.__enter__ = lambda s: s
+    resp.__exit__ = lambda *a: None
+    return resp
+
+
+def _http_error(status: int, body: bytes = b"") -> urllib.error.HTTPError:
+    """Build an HTTPError with a readable fp."""
+    return urllib.error.HTTPError(
+        url=f"https://example.com/{RRN}/revoke-key",
+        code=status,
+        msg="HTTP Error",
+        hdrs={},  # type: ignore[arg-type]
+        fp=io.BytesIO(body),
+    )
+
+
+# ---------------------------------------------------------------------------
+# Test 1: Happy path — 204
+# ---------------------------------------------------------------------------
+
+
+def test_revoke_key_204_success(tmp_path, monkeypatch, capsys):
+    """204 from RRF → exit 0, stdout contains 'Revoked: <rrn>'."""
+    monkeypatch.setenv("HOME", str(tmp_path))
+    _make_keystore(tmp_path)
+    _save_test_keypair(tmp_path)
+
+    mock_resp = _mock_200_ish(204)
+
+    from robot_md.revoke_key import cli_revoke_key
+
+    with patch("urllib.request.urlopen", return_value=mock_resp):
+        rc = cli_revoke_key(RRN)
+
+    assert rc == 0
+    out = capsys.readouterr().out
+    assert "Revoked:" in out
+    assert RRN in out
+
+
+# ---------------------------------------------------------------------------
+# Test 2: Already revoked — 409 (idempotent, exit 0)
+# ---------------------------------------------------------------------------
+
+
+def test_revoke_key_409_already_revoked(tmp_path, monkeypatch, capsys):
+    """409 from RRF → exit 0 (idempotent), stdout contains 'Already revoked'."""
+    monkeypatch.setenv("HOME", str(tmp_path))
+    _make_keystore(tmp_path)
+    _save_test_keypair(tmp_path)
+
+    from robot_md.revoke_key import cli_revoke_key
+
+    with patch(
+        "urllib.request.urlopen",
+        side_effect=_http_error(409, b'{"error": "already revoked"}'),
+    ):
+        rc = cli_revoke_key(RRN)
+
+    assert rc == 0
+    out = capsys.readouterr().out
+    assert "Already revoked" in out
+    assert RRN in out
+
+
+# ---------------------------------------------------------------------------
+# Test 3: Unauthorized — 401
+# ---------------------------------------------------------------------------
+
+
+def test_revoke_key_401_signature_rejected(tmp_path, monkeypatch, capsys):
+    """401 from RRF → non-zero exit, message mentions 'Signature rejected'."""
+    monkeypatch.setenv("HOME", str(tmp_path))
+    _make_keystore(tmp_path)
+    _save_test_keypair(tmp_path)
+
+    body = json.dumps({"error": "Signature verification failed"}).encode()
+
+    from robot_md.revoke_key import cli_revoke_key
+
+    with patch(
+        "urllib.request.urlopen",
+        side_effect=_http_error(401, body),
+    ):
+        rc = cli_revoke_key(RRN)
+
+    assert rc != 0
+    captured = capsys.readouterr()
+    combined = captured.out + captured.err
+    assert "Signature rejected" in combined
+
+
+# ---------------------------------------------------------------------------
+# Test 4: Not found — 404
+# ---------------------------------------------------------------------------
+
+
+def test_revoke_key_404_not_found(tmp_path, monkeypatch, capsys):
+    """404 from RRF → non-zero exit, message mentions 'not found'."""
+    monkeypatch.setenv("HOME", str(tmp_path))
+    _make_keystore(tmp_path)
+    _save_test_keypair(tmp_path)
+
+    from robot_md.revoke_key import cli_revoke_key
+
+    with patch(
+        "urllib.request.urlopen",
+        side_effect=_http_error(404, b'{"error": "not found"}'),
+    ):
+        rc = cli_revoke_key(RRN)
+
+    assert rc != 0
+    captured = capsys.readouterr()
+    combined = captured.out + captured.err
+    assert "not found" in combined.lower()
+
+
+# ---------------------------------------------------------------------------
+# Test 5: No local signing key — friendly error, no urlopen call
+# ---------------------------------------------------------------------------
+
+
+def test_revoke_key_no_signing_key(tmp_path, monkeypatch, capsys):
+    """When keystore has no signing key for RRN: non-zero exit, friendly message, no HTTP call."""
+    monkeypatch.setenv("HOME", str(tmp_path))
+    _make_keystore(tmp_path)
+    # Intentionally do NOT save any keypair
+
+    from robot_md.revoke_key import cli_revoke_key
+
+    with patch("urllib.request.urlopen") as mock_urlopen:
+        rc = cli_revoke_key(RRN)
+        mock_urlopen.assert_not_called()
+
+    assert rc != 0
+    captured = capsys.readouterr()
+    combined = captured.out + captured.err
+    assert RRN in combined
+    # Friendly hint that they need to re-register with v0.9.1+
+    assert "signing.json" in combined or "v0.9.1" in combined
+
+
+# ---------------------------------------------------------------------------
+# Test 6: Request body shape (with and without --reason)
+# ---------------------------------------------------------------------------
+
+
+def test_revoke_key_body_shape_with_reason(tmp_path, monkeypatch):
+    """Signed POST body contains rrn, action, reason, pq_signing_pub, pq_kid, sig."""
+    monkeypatch.setenv("HOME", str(tmp_path))
+    _make_keystore(tmp_path)
+    _save_test_keypair(tmp_path)
+
+    captured_body: dict = {}
+
+    def fake_urlopen(req, timeout=15.0):
+        # Parse the sent body
+        captured_body.update(json.loads(req.data.decode("utf-8")))
+        return _mock_200_ish(204)
+
+    from robot_md.revoke_key import cli_revoke_key
+
+    with patch("urllib.request.urlopen", side_effect=fake_urlopen):
+        rc = cli_revoke_key(RRN, reason="test reason")
+
+    assert rc == 0
+    assert captured_body["rrn"] == RRN
+    assert captured_body["action"] == "revoke"
+    assert captured_body["reason"] == "test reason"
+    assert "pq_signing_pub" in captured_body
+    assert "pq_kid" in captured_body
+    assert "sig" in captured_body
+
+
+def test_revoke_key_body_shape_without_reason(tmp_path, monkeypatch):
+    """When --reason is omitted, the 'reason' key must be absent entirely (not None)."""
+    monkeypatch.setenv("HOME", str(tmp_path))
+    _make_keystore(tmp_path)
+    _save_test_keypair(tmp_path)
+
+    captured_body: dict = {}
+
+    def fake_urlopen(req, timeout=15.0):
+        captured_body.update(json.loads(req.data.decode("utf-8")))
+        return _mock_200_ish(204)
+
+    from robot_md.revoke_key import cli_revoke_key
+
+    with patch("urllib.request.urlopen", side_effect=fake_urlopen):
+        rc = cli_revoke_key(RRN, reason=None)
+
+    assert rc == 0
+    assert captured_body["rrn"] == RRN
+    assert captured_body["action"] == "revoke"
+    assert "reason" not in captured_body  # key must be absent, not None
+    assert "pq_signing_pub" in captured_body
+    assert "pq_kid" in captured_body
+    assert "sig" in captured_body
+
+
+# ---------------------------------------------------------------------------
+# Test 7: Network error (URLError)
+# ---------------------------------------------------------------------------
+
+
+def test_revoke_key_network_error(tmp_path, monkeypatch, capsys):
+    """URLError → non-zero exit, message mentions 'Could not reach'."""
+    monkeypatch.setenv("HOME", str(tmp_path))
+    _make_keystore(tmp_path)
+    _save_test_keypair(tmp_path)
+
+    from robot_md.revoke_key import cli_revoke_key
+
+    with patch(
+        "urllib.request.urlopen",
+        side_effect=urllib.error.URLError("Connection refused"),
+    ):
+        rc = cli_revoke_key(RRN)
+
+    assert rc != 0
+    captured = capsys.readouterr()
+    combined = captured.out + captured.err
+    assert "Could not reach" in combined or "could not reach" in combined.lower()

--- a/cli/tests/test_revoke_key.py
+++ b/cli/tests/test_revoke_key.py
@@ -144,7 +144,7 @@ def test_revoke_key_404_not_found(tmp_path, monkeypatch, capsys):
 
     with patch(
         "urllib.request.urlopen",
-        side_effect=_http_error(404, b'{"error": "not found"}'),
+        side_effect=_http_error(404, b'{"error": "Unknown RRN"}'),
     ):
         rc = cli_revoke_key(RRN)
 
@@ -152,6 +152,9 @@ def test_revoke_key_404_not_found(tmp_path, monkeypatch, capsys):
     captured = capsys.readouterr()
     combined = captured.out + captured.err
     assert "not found" in combined.lower()
+    # Server body excerpt is surfaced so operators can distinguish a wrong
+    # --endpoint from an RRN typo.
+    assert "Unknown RRN" in combined
 
 
 # ---------------------------------------------------------------------------
@@ -191,10 +194,12 @@ def test_revoke_key_body_shape_with_reason(tmp_path, monkeypatch):
     _save_test_keypair(tmp_path)
 
     captured_body: dict = {}
+    captured_url: list = []
 
     def fake_urlopen(req, timeout=15.0):
         # Parse the sent body
         captured_body.update(json.loads(req.data.decode("utf-8")))
+        captured_url.append(req.full_url)
         return _mock_200_ish(204)
 
     from robot_md.revoke_key import cli_revoke_key
@@ -209,6 +214,9 @@ def test_revoke_key_body_shape_with_reason(tmp_path, monkeypatch):
     assert "pq_signing_pub" in captured_body
     assert "pq_kid" in captured_body
     assert "sig" in captured_body
+    # URL path is part of the contract — a typo in the segment would
+    # only surface as a silent 404 in production.
+    assert captured_url[0].endswith(f"/{RRN}/revoke-key")
 
 
 def test_revoke_key_body_shape_without_reason(tmp_path, monkeypatch):

--- a/cli/tests/test_rotate_key.py
+++ b/cli/tests/test_rotate_key.py
@@ -88,6 +88,10 @@ def test_rotate_key_200_success(tmp_path, monkeypatch, capsys):
     file_mode = stat.S_IMODE(archive_path.stat().st_mode)
     assert file_mode == 0o600, f"archive mode is {oct(file_mode)}, expected 0o600"
 
+    # Staging file is cleaned up on the happy path
+    staging = tmp_path / ".robot-md" / "keys" / f"{RRN}.NEW.signing.json"
+    assert not staging.exists(), "staging file must be removed after successful rotation"
+
 
 # ---------------------------------------------------------------------------
 # Test 2: Request body shape
@@ -171,6 +175,10 @@ def test_rotate_key_401_rejected(tmp_path, monkeypatch, capsys):
     archive_dir = tmp_path / ".robot-md" / "keys" / "archive"
     assert not archive_dir.exists()
 
+    # Staging file cleaned up — nothing to recover when server rejected
+    staging = tmp_path / ".robot-md" / "keys" / f"{RRN}.NEW.signing.json"
+    assert not staging.exists()
+
 
 # ---------------------------------------------------------------------------
 # Test 4: 403 — record revoked
@@ -201,6 +209,9 @@ def test_rotate_key_403_revoked(tmp_path, monkeypatch, capsys):
     archive_dir = tmp_path / ".robot-md" / "keys" / "archive"
     assert not archive_dir.exists()
 
+    staging = tmp_path / ".robot-md" / "keys" / f"{RRN}.NEW.signing.json"
+    assert not staging.exists()
+
 
 # ---------------------------------------------------------------------------
 # Test 5: 404 — not found
@@ -230,6 +241,9 @@ def test_rotate_key_404_not_found(tmp_path, monkeypatch, capsys):
 
     archive_dir = tmp_path / ".robot-md" / "keys" / "archive"
     assert not archive_dir.exists()
+
+    staging = tmp_path / ".robot-md" / "keys" / f"{RRN}.NEW.signing.json"
+    assert not staging.exists()
 
 
 # ---------------------------------------------------------------------------
@@ -285,6 +299,9 @@ def test_rotate_key_network_error(tmp_path, monkeypatch, capsys):
     archive_dir = tmp_path / ".robot-md" / "keys" / "archive"
     assert not archive_dir.exists()
 
+    staging = tmp_path / ".robot-md" / "keys" / f"{RRN}.NEW.signing.json"
+    assert not staging.exists()
+
 
 # ---------------------------------------------------------------------------
 # Test 8: Archive-write failure — partial state (server rotated, archive failed)
@@ -312,7 +329,14 @@ def test_rotate_key_archive_write_failure(tmp_path, monkeypatch, capsys):
         with patch.object(rk_mod, "archive_old_keypair", side_effect=raise_ioerror):
             rc = cli_rotate_key(RRN)
 
-    assert rc != 0  # non-zero — something went wrong
+    # Exit 2 is the documented signal for "server rotated, local disk failed"
+    assert rc == 2
+
+    # Staging file exists so operator can recover
+    staging = tmp_path / ".robot-md" / "keys" / f"{RRN}.NEW.signing.json"
+    assert staging.exists(), "staged new keypair must persist for exit-2 recovery"
+    # Staging file has mode 0o600
+    assert stat.S_IMODE(staging.stat().st_mode) == 0o600
 
     # Keystore still has the OLD keypair — we did not replace it
     current_kp = load_keypair(RRN)

--- a/cli/tests/test_rotate_key.py
+++ b/cli/tests/test_rotate_key.py
@@ -1,0 +1,324 @@
+"""Tests for `robot-md rotate-key` — co-signed key rotation at RRF with local archive.
+
+TDD: tests written before implementation; run pytest to confirm RED, then
+implement rotate_key.py to get GREEN.
+"""
+
+from __future__ import annotations
+
+import io
+import json
+import stat
+import urllib.error
+from pathlib import Path
+from unittest.mock import MagicMock, patch
+
+import pytest
+
+from robot_md.signing import generate_keypair, kid_from_pub, load_keypair, save_keypair
+
+RRN = "RRN-000000000042"
+
+
+def _make_keystore(tmp_path: Path) -> Path:
+    """Create ~/.robot-md/keys/ under tmp_path and return it."""
+    keys_dir = tmp_path / ".robot-md" / "keys"
+    keys_dir.mkdir(parents=True)
+    return keys_dir
+
+
+def _save_test_keypair(tmp_path: Path):
+    """Generate and save a signing keypair for RRN under tmp HOME. Returns the keypair."""
+    kp = generate_keypair()
+    save_keypair(RRN, kp)
+    return kp
+
+
+def _mock_200(body: bytes = b'{"ok": true}') -> MagicMock:
+    """Build a context-manager mock for a successful 200 HTTP response."""
+    resp = MagicMock()
+    resp.status = 200
+    resp.read.return_value = body
+    resp.__enter__ = lambda s: s
+    resp.__exit__ = lambda *a: None
+    return resp
+
+
+def _http_error(status: int, body: bytes = b"") -> urllib.error.HTTPError:
+    """Build an HTTPError with a readable fp."""
+    return urllib.error.HTTPError(
+        url=f"https://example.com/{RRN}/rotate-key",
+        code=status,
+        msg="HTTP Error",
+        hdrs={},  # type: ignore[arg-type]
+        fp=io.BytesIO(body),
+    )
+
+
+# ---------------------------------------------------------------------------
+# Test 1: Happy path — 200
+# ---------------------------------------------------------------------------
+
+
+def test_rotate_key_200_success(tmp_path, monkeypatch, capsys):
+    """200 from RRF → exit 0, stdout contains 'Rotated', archive path in message, files updated."""
+    monkeypatch.setenv("HOME", str(tmp_path))
+    _make_keystore(tmp_path)
+    old_kp = _save_test_keypair(tmp_path)
+    old_kid = kid_from_pub(old_kp.ml_dsa.public_key_bytes)
+
+    from robot_md.rotate_key import cli_rotate_key
+
+    with patch("urllib.request.urlopen", return_value=_mock_200()):
+        rc = cli_rotate_key(RRN)
+
+    assert rc == 0
+    out = capsys.readouterr().out
+    assert "Rotated" in out
+    assert "archive" in out.lower()
+
+    # Keystore now has the NEW keypair (different pub bytes)
+    new_kp = load_keypair(RRN)
+    assert new_kp is not None
+    assert new_kp.ml_dsa.public_key_bytes != old_kp.ml_dsa.public_key_bytes
+
+    # Archive file exists with correct name and mode 0600
+    archive_path = tmp_path / ".robot-md" / "keys" / "archive" / f"{RRN}.{old_kid}.signing.json"
+    assert archive_path.exists(), f"archive not found at {archive_path}"
+    file_mode = stat.S_IMODE(archive_path.stat().st_mode)
+    assert file_mode == 0o600, f"archive mode is {oct(file_mode)}, expected 0o600"
+
+
+# ---------------------------------------------------------------------------
+# Test 2: Request body shape
+# ---------------------------------------------------------------------------
+
+
+def test_rotate_key_request_body_shape(tmp_path, monkeypatch):
+    """POST body has by_old_key and by_new_key; both envelopes have expected fields."""
+    monkeypatch.setenv("HOME", str(tmp_path))
+    _make_keystore(tmp_path)
+    _save_test_keypair(tmp_path)
+
+    captured_body: dict = {}
+
+    def fake_urlopen(req, timeout=15.0):
+        captured_body.update(json.loads(req.data.decode("utf-8")))
+        return _mock_200()
+
+    from robot_md.rotate_key import cli_rotate_key
+
+    with patch("urllib.request.urlopen", side_effect=fake_urlopen):
+        rc = cli_rotate_key(RRN)
+
+    assert rc == 0
+
+    # Top-level structure
+    assert "by_old_key" in captured_body
+    assert "by_new_key" in captured_body
+
+    old_env = captured_body["by_old_key"]
+    new_env = captured_body["by_new_key"]
+
+    # Both envelopes reference the same canonical payload fields
+    for env in (old_env, new_env):
+        assert env["rrn"] == RRN
+        assert env["action"] == "rotate"
+        assert "new_pq_signing_pub" in env
+        assert "new_pq_kid" in env
+        # sign_body stamps these onto the envelope
+        assert "sig" in env
+        assert "pq_signing_pub" in env
+        assert "pq_kid" in env
+
+    # The two envelopes use different keys — different pq_signing_pub (old vs new key)
+    assert old_env["pq_signing_pub"] != new_env["pq_signing_pub"]
+
+    # Both reference the same new key info
+    assert old_env["new_pq_signing_pub"] == new_env["new_pq_signing_pub"]
+    assert old_env["new_pq_kid"] == new_env["new_pq_kid"]
+
+
+# ---------------------------------------------------------------------------
+# Test 3: 401 — signature rejected
+# ---------------------------------------------------------------------------
+
+
+def test_rotate_key_401_rejected(tmp_path, monkeypatch, capsys):
+    """401 from RRF → non-zero exit, keystore UNTOUCHED, archive NOT created."""
+    monkeypatch.setenv("HOME", str(tmp_path))
+    _make_keystore(tmp_path)
+    old_kp = _save_test_keypair(tmp_path)
+
+    body = json.dumps({"error": "Signature verification failed"}).encode()
+
+    from robot_md.rotate_key import cli_rotate_key
+
+    with patch("urllib.request.urlopen", side_effect=_http_error(401, body)):
+        rc = cli_rotate_key(RRN)
+
+    assert rc != 0
+    captured = capsys.readouterr()
+    combined = captured.out + captured.err
+    assert "Signature rejected" in combined or "rejected" in combined.lower()
+
+    # Keystore is untouched — still has old keypair
+    current_kp = load_keypair(RRN)
+    assert current_kp is not None
+    assert current_kp.ml_dsa.public_key_bytes == old_kp.ml_dsa.public_key_bytes
+
+    # Archive directory not created
+    archive_dir = tmp_path / ".robot-md" / "keys" / "archive"
+    assert not archive_dir.exists()
+
+
+# ---------------------------------------------------------------------------
+# Test 4: 403 — record revoked
+# ---------------------------------------------------------------------------
+
+
+def test_rotate_key_403_revoked(tmp_path, monkeypatch, capsys):
+    """403 from RRF → non-zero exit, keystore UNTOUCHED, no archive."""
+    monkeypatch.setenv("HOME", str(tmp_path))
+    _make_keystore(tmp_path)
+    old_kp = _save_test_keypair(tmp_path)
+
+    from robot_md.rotate_key import cli_rotate_key
+
+    with patch("urllib.request.urlopen", side_effect=_http_error(403, b"revoked")):
+        rc = cli_rotate_key(RRN)
+
+    assert rc != 0
+    captured = capsys.readouterr()
+    combined = captured.out + captured.err
+    assert "revoked" in combined.lower() or RRN in combined
+
+    # Keystore untouched
+    current_kp = load_keypair(RRN)
+    assert current_kp is not None
+    assert current_kp.ml_dsa.public_key_bytes == old_kp.ml_dsa.public_key_bytes
+
+    archive_dir = tmp_path / ".robot-md" / "keys" / "archive"
+    assert not archive_dir.exists()
+
+
+# ---------------------------------------------------------------------------
+# Test 5: 404 — not found
+# ---------------------------------------------------------------------------
+
+
+def test_rotate_key_404_not_found(tmp_path, monkeypatch, capsys):
+    """404 from RRF → non-zero exit, keystore UNTOUCHED, no archive."""
+    monkeypatch.setenv("HOME", str(tmp_path))
+    _make_keystore(tmp_path)
+    old_kp = _save_test_keypair(tmp_path)
+
+    from robot_md.rotate_key import cli_rotate_key
+
+    with patch("urllib.request.urlopen", side_effect=_http_error(404, b"not found")):
+        rc = cli_rotate_key(RRN)
+
+    assert rc != 0
+    captured = capsys.readouterr()
+    combined = captured.out + captured.err
+    assert "not found" in combined.lower()
+
+    # Keystore untouched
+    current_kp = load_keypair(RRN)
+    assert current_kp is not None
+    assert current_kp.ml_dsa.public_key_bytes == old_kp.ml_dsa.public_key_bytes
+
+    archive_dir = tmp_path / ".robot-md" / "keys" / "archive"
+    assert not archive_dir.exists()
+
+
+# ---------------------------------------------------------------------------
+# Test 6: No local signing key
+# ---------------------------------------------------------------------------
+
+
+def test_rotate_key_no_signing_key(tmp_path, monkeypatch, capsys):
+    """No key for RRN → non-zero exit, no HTTP call attempted."""
+    monkeypatch.setenv("HOME", str(tmp_path))
+    _make_keystore(tmp_path)
+    # Intentionally do NOT save any keypair
+
+    from robot_md.rotate_key import cli_rotate_key
+
+    with patch("urllib.request.urlopen") as mock_urlopen:
+        rc = cli_rotate_key(RRN)
+        mock_urlopen.assert_not_called()
+
+    assert rc != 0
+    captured = capsys.readouterr()
+    combined = captured.out + captured.err
+    assert RRN in combined or "signing key" in combined.lower()
+
+
+# ---------------------------------------------------------------------------
+# Test 7: Network error — URLError
+# ---------------------------------------------------------------------------
+
+
+def test_rotate_key_network_error(tmp_path, monkeypatch, capsys):
+    """URLError → non-zero exit, keystore UNTOUCHED, no archive."""
+    monkeypatch.setenv("HOME", str(tmp_path))
+    _make_keystore(tmp_path)
+    old_kp = _save_test_keypair(tmp_path)
+
+    from robot_md.rotate_key import cli_rotate_key
+
+    with patch(
+        "urllib.request.urlopen",
+        side_effect=urllib.error.URLError("Connection refused"),
+    ):
+        rc = cli_rotate_key(RRN)
+
+    assert rc != 0
+
+    # Keystore untouched
+    current_kp = load_keypair(RRN)
+    assert current_kp is not None
+    assert current_kp.ml_dsa.public_key_bytes == old_kp.ml_dsa.public_key_bytes
+
+    # No archive
+    archive_dir = tmp_path / ".robot-md" / "keys" / "archive"
+    assert not archive_dir.exists()
+
+
+# ---------------------------------------------------------------------------
+# Test 8: Archive-write failure — partial state (server rotated, archive failed)
+# ---------------------------------------------------------------------------
+
+
+def test_rotate_key_archive_write_failure(tmp_path, monkeypatch, capsys):
+    """If archive-write raises IOError after successful POST, keystore is untouched.
+
+    The server has accepted the rotation but local persistence of the archive failed.
+    The implementation must NOT proceed to save the new keypair in this case.
+    The old key remains in the keystore so the operator can at least try revoke.
+    """
+    monkeypatch.setenv("HOME", str(tmp_path))
+    _make_keystore(tmp_path)
+    old_kp = _save_test_keypair(tmp_path)
+
+    def raise_ioerror(rrn, kp):
+        raise IOError("disk full")
+
+    from robot_md.rotate_key import cli_rotate_key
+    import robot_md.rotate_key as rk_mod
+
+    with patch("urllib.request.urlopen", return_value=_mock_200()):
+        with patch.object(rk_mod, "archive_old_keypair", side_effect=raise_ioerror):
+            rc = cli_rotate_key(RRN)
+
+    assert rc != 0  # non-zero — something went wrong
+
+    # Keystore still has the OLD keypair — we did not replace it
+    current_kp = load_keypair(RRN)
+    assert current_kp is not None
+    assert current_kp.ml_dsa.public_key_bytes == old_kp.ml_dsa.public_key_bytes
+
+    # Archive directory was not created (the mock raised before any write)
+    archive_dir = tmp_path / ".robot-md" / "keys" / "archive"
+    assert not archive_dir.exists()

--- a/cli/tests/test_rotate_key.py
+++ b/cli/tests/test_rotate_key.py
@@ -322,3 +322,45 @@ def test_rotate_key_archive_write_failure(tmp_path, monkeypatch, capsys):
     # Archive directory was not created (the mock raised before any write)
     archive_dir = tmp_path / ".robot-md" / "keys" / "archive"
     assert not archive_dir.exists()
+
+
+# ---------------------------------------------------------------------------
+# Test 9: Archive succeeded but keystore save failed — exit code 2
+# ---------------------------------------------------------------------------
+
+
+def test_rotate_key_keystore_save_failure_after_archive(tmp_path, monkeypatch, capsys):
+    """Server rotated, archive succeeded, but writing the new keystore raised.
+
+    This is the partial-failure path the code signals with exit code 2. The old
+    key must still be present in the main keystore (so the operator can still
+    act on the robot), and the archive must exist as provenance of the old key.
+    """
+    monkeypatch.setenv("HOME", str(tmp_path))
+    _make_keystore(tmp_path)
+    old_kp = _save_test_keypair(tmp_path)
+    old_kid = kid_from_pub(old_kp.ml_dsa.public_key_bytes)
+
+    from robot_md.rotate_key import cli_rotate_key
+
+    def raise_on_save(rrn, kp):
+        raise OSError("disk full writing keystore")
+
+    with patch("urllib.request.urlopen", return_value=_mock_200()):
+        with patch("robot_md.signing.save_keypair", side_effect=raise_on_save):
+            rc = cli_rotate_key(RRN)
+
+    # Exit code 2 signals "server rotated, local state inconsistent"
+    assert rc == 2
+
+    # Main keystore still has the OLD key (save raised before replacing it)
+    current_kp = load_keypair(RRN)
+    assert current_kp is not None
+    assert current_kp.ml_dsa.public_key_bytes == old_kp.ml_dsa.public_key_bytes
+
+    # Archive exists with the old kid — provenance is preserved
+    archive_path = tmp_path / ".robot-md" / "keys" / "archive" / f"{RRN}.{old_kid}.signing.json"
+    assert archive_path.exists()
+    archived = json.loads(archive_path.read_text())
+    # Archive contains a keypair blob (not empty)
+    assert archived

--- a/cli/tests/test_rotate_key.py
+++ b/cli/tests/test_rotate_key.py
@@ -13,8 +13,6 @@ import urllib.error
 from pathlib import Path
 from unittest.mock import MagicMock, patch
 
-import pytest
-
 from robot_md.signing import generate_keypair, kid_from_pub, load_keypair, save_keypair
 
 RRN = "RRN-000000000042"
@@ -320,14 +318,16 @@ def test_rotate_key_archive_write_failure(tmp_path, monkeypatch, capsys):
     old_kp = _save_test_keypair(tmp_path)
 
     def raise_ioerror(rrn, kp):
-        raise IOError("disk full")
+        raise OSError("disk full")
 
-    from robot_md.rotate_key import cli_rotate_key
     import robot_md.rotate_key as rk_mod
+    from robot_md.rotate_key import cli_rotate_key
 
-    with patch("urllib.request.urlopen", return_value=_mock_200()):
-        with patch.object(rk_mod, "archive_old_keypair", side_effect=raise_ioerror):
-            rc = cli_rotate_key(RRN)
+    with (
+        patch("urllib.request.urlopen", return_value=_mock_200()),
+        patch.object(rk_mod, "archive_old_keypair", side_effect=raise_ioerror),
+    ):
+        rc = cli_rotate_key(RRN)
 
     # Exit 2 is the documented signal for "server rotated, local disk failed"
     assert rc == 2
@@ -370,9 +370,11 @@ def test_rotate_key_keystore_save_failure_after_archive(tmp_path, monkeypatch, c
     def raise_on_save(rrn, kp):
         raise OSError("disk full writing keystore")
 
-    with patch("urllib.request.urlopen", return_value=_mock_200()):
-        with patch("robot_md.signing.save_keypair", side_effect=raise_on_save):
-            rc = cli_rotate_key(RRN)
+    with (
+        patch("urllib.request.urlopen", return_value=_mock_200()),
+        patch("robot_md.signing.save_keypair", side_effect=raise_on_save),
+    ):
+        rc = cli_rotate_key(RRN)
 
     # Exit code 2 signals "server rotated, local state inconsistent"
     assert rc == 2

--- a/cli/tests/test_verify_tier.py
+++ b/cli/tests/test_verify_tier.py
@@ -33,7 +33,7 @@ def _save_test_keypair(tmp_path: Path) -> None:
     save_keypair(RRN, kp)
 
 
-def _mock_200(body: bytes = b'{"identity_binding": {"type": "dns-txt", "domain": "robotis.com"}}') -> MagicMock:
+def _mock_200(body: bytes = b'{"verification_status": "manufacturer_claimed", "identity_binding": {"type": "dns-txt", "domain": "robotis.com"}}') -> MagicMock:
     """Build a context-manager mock for a successful 200 HTTP response."""
     resp = MagicMock()
     resp.status = 200
@@ -99,7 +99,8 @@ def test_verify_tier_manufacturer_verified_200_success(tmp_path, monkeypatch, ca
 
     from robot_md.verify_tier import cli_verify_tier
 
-    with patch("urllib.request.urlopen", return_value=_mock_200()):
+    mv_body = b'{"verification_status": "manufacturer_verified", "identity_binding": {"type": "attestation"}}'
+    with patch("urllib.request.urlopen", return_value=_mock_200(body=mv_body)):
         rc = cli_verify_tier(
             RRN,
             target="manufacturer_verified",

--- a/cli/tests/test_verify_tier.py
+++ b/cli/tests/test_verify_tier.py
@@ -347,3 +347,233 @@ def test_verify_tier_no_signing_key(tmp_path, monkeypatch, capsys):
     captured = capsys.readouterr()
     combined = captured.out + captured.err
     assert RRN in combined or "signing key" in combined.lower()
+
+
+# ---------------------------------------------------------------------------
+# Test 10: 401 — signature rejected
+# ---------------------------------------------------------------------------
+
+
+def test_verify_tier_401_rejected(tmp_path, monkeypatch, capsys):
+    """401 from RRF → non-zero exit, error string mentions signature."""
+    monkeypatch.setenv("HOME", str(tmp_path))
+    _make_keystore(tmp_path)
+    _save_test_keypair(tmp_path)
+
+    body = json.dumps({"error": "bad sig"}).encode()
+
+    from robot_md.verify_tier import cli_verify_tier
+
+    with patch("urllib.request.urlopen", side_effect=_http_error(401, body)):
+        rc = cli_verify_tier(
+            RRN,
+            target="manufacturer_claimed",
+            dns_domain=DNS_DOMAIN,
+            non_interactive=True,
+        )
+
+    assert rc != 0
+    captured = capsys.readouterr()
+    combined = captured.out + captured.err
+    assert "Signature rejected" in combined
+
+
+# ---------------------------------------------------------------------------
+# Test 11: 403 — record revoked
+# ---------------------------------------------------------------------------
+
+
+def test_verify_tier_403_revoked(tmp_path, monkeypatch, capsys):
+    """403 → non-zero exit, error mentions 'revoked'."""
+    monkeypatch.setenv("HOME", str(tmp_path))
+    _make_keystore(tmp_path)
+    _save_test_keypair(tmp_path)
+
+    from robot_md.verify_tier import cli_verify_tier
+
+    with patch("urllib.request.urlopen", side_effect=_http_error(403, b"")):
+        rc = cli_verify_tier(
+            RRN,
+            target="manufacturer_claimed",
+            dns_domain=DNS_DOMAIN,
+            non_interactive=True,
+        )
+
+    assert rc != 0
+    captured = capsys.readouterr()
+    assert "revoked" in (captured.out + captured.err).lower()
+
+
+# ---------------------------------------------------------------------------
+# Test 12: 404 — RRN not found
+# ---------------------------------------------------------------------------
+
+
+def test_verify_tier_404_not_found(tmp_path, monkeypatch, capsys):
+    """404 → non-zero exit, error mentions 'not found' and the RRN."""
+    monkeypatch.setenv("HOME", str(tmp_path))
+    _make_keystore(tmp_path)
+    _save_test_keypair(tmp_path)
+
+    from robot_md.verify_tier import cli_verify_tier
+
+    with patch("urllib.request.urlopen", side_effect=_http_error(404, b"")):
+        rc = cli_verify_tier(
+            RRN,
+            target="manufacturer_claimed",
+            dns_domain=DNS_DOMAIN,
+            non_interactive=True,
+        )
+
+    assert rc != 0
+    combined = capsys.readouterr().err
+    assert "not found" in combined.lower()
+    assert RRN in combined
+
+
+# ---------------------------------------------------------------------------
+# Test 13: 409 — promotion state conflict
+# ---------------------------------------------------------------------------
+
+
+def test_verify_tier_409_conflict(tmp_path, monkeypatch, capsys):
+    """409 from RRF → non-zero exit with 'conflict' in the message."""
+    monkeypatch.setenv("HOME", str(tmp_path))
+    _make_keystore(tmp_path)
+    _save_test_keypair(tmp_path)
+
+    body = json.dumps({"error": "tier is already manufacturer_verified"}).encode()
+
+    from robot_md.verify_tier import cli_verify_tier
+
+    with patch("urllib.request.urlopen", side_effect=_http_error(409, body)):
+        rc = cli_verify_tier(
+            RRN,
+            target="manufacturer_claimed",
+            dns_domain=DNS_DOMAIN,
+            non_interactive=True,
+        )
+
+    assert rc != 0
+    combined = capsys.readouterr().err
+    assert "conflict" in combined.lower()
+
+
+# ---------------------------------------------------------------------------
+# Test 14: Network error — URLError
+# ---------------------------------------------------------------------------
+
+
+def test_verify_tier_network_error(tmp_path, monkeypatch, capsys):
+    """URLError → non-zero exit with 'reach' in the message."""
+    monkeypatch.setenv("HOME", str(tmp_path))
+    _make_keystore(tmp_path)
+    _save_test_keypair(tmp_path)
+
+    from robot_md.verify_tier import cli_verify_tier
+
+    with patch(
+        "urllib.request.urlopen",
+        side_effect=urllib.error.URLError("Connection refused"),
+    ):
+        rc = cli_verify_tier(
+            RRN,
+            target="manufacturer_claimed",
+            dns_domain=DNS_DOMAIN,
+            non_interactive=True,
+        )
+
+    assert rc != 0
+    combined = capsys.readouterr().err
+    assert "reach" in combined.lower() or "Could not" in combined
+
+
+# ---------------------------------------------------------------------------
+# Test 15: --yes (non_interactive=True) suppresses prompt even on a TTY
+# ---------------------------------------------------------------------------
+
+
+def test_verify_tier_non_interactive_suppresses_prompt(tmp_path, monkeypatch):
+    """non_interactive=True must bypass input() even when stdin is a TTY."""
+    monkeypatch.setenv("HOME", str(tmp_path))
+    _make_keystore(tmp_path)
+    _save_test_keypair(tmp_path)
+
+    from robot_md.verify_tier import cli_verify_tier
+    import robot_md.verify_tier as vt_mod
+
+    # Pretend we're running on a real terminal so _is_interactive() would
+    # otherwise prompt.
+    with patch.object(vt_mod, "_is_interactive", return_value=True):
+        with patch("builtins.input") as mock_input:
+            with patch("urllib.request.urlopen", return_value=_mock_200()):
+                rc = cli_verify_tier(
+                    RRN,
+                    target="manufacturer_claimed",
+                    dns_domain=DNS_DOMAIN,
+                    non_interactive=True,
+                )
+            mock_input.assert_not_called()
+
+    assert rc == 0
+
+
+# ---------------------------------------------------------------------------
+# Test 16: Interactive mode DOES call input() when non_interactive=False
+# ---------------------------------------------------------------------------
+
+
+def test_verify_tier_interactive_prompts_for_confirmation(tmp_path, monkeypatch):
+    """non_interactive=False + TTY → input() is called before the POST."""
+    monkeypatch.setenv("HOME", str(tmp_path))
+    _make_keystore(tmp_path)
+    _save_test_keypair(tmp_path)
+
+    from robot_md.verify_tier import cli_verify_tier
+    import robot_md.verify_tier as vt_mod
+
+    with patch.object(vt_mod, "_is_interactive", return_value=True):
+        with patch("builtins.input", return_value="") as mock_input:
+            with patch("urllib.request.urlopen", return_value=_mock_200()):
+                rc = cli_verify_tier(
+                    RRN,
+                    target="manufacturer_claimed",
+                    dns_domain=DNS_DOMAIN,
+                    non_interactive=False,
+                )
+            mock_input.assert_called_once()
+
+    assert rc == 0
+
+
+# ---------------------------------------------------------------------------
+# Test 17: Oversized attestation file is rejected before parsing
+# ---------------------------------------------------------------------------
+
+
+def test_verify_tier_attestation_file_too_large(tmp_path, monkeypatch, capsys):
+    """Attestation file larger than MAX_ATTESTATION_BYTES → exit 1, no HTTP call."""
+    monkeypatch.setenv("HOME", str(tmp_path))
+    _make_keystore(tmp_path)
+    _save_test_keypair(tmp_path)
+
+    from robot_md.verify_tier import cli_verify_tier, MAX_ATTESTATION_BYTES
+
+    # Produce a syntactically-valid but oversized JSON file
+    big = tmp_path / "big_attestation.json"
+    padding = "x" * (MAX_ATTESTATION_BYTES + 1024)
+    big.write_text(json.dumps({"pad": padding}))
+
+    with patch("urllib.request.urlopen") as mock_urlopen:
+        rc = cli_verify_tier(
+            RRN,
+            target="manufacturer_verified",
+            dns_domain=DNS_DOMAIN,
+            ruri="https://robotis.com",
+            attestation_file=big,
+            non_interactive=True,
+        )
+        mock_urlopen.assert_not_called()
+
+    assert rc == 1
+    assert "too large" in capsys.readouterr().err.lower()

--- a/cli/tests/test_verify_tier.py
+++ b/cli/tests/test_verify_tier.py
@@ -12,8 +12,6 @@ import urllib.error
 from pathlib import Path
 from unittest.mock import MagicMock, patch
 
-import pytest
-
 from robot_md.signing import generate_keypair, save_keypair
 
 RRN = "RRN-000000000042"
@@ -33,7 +31,13 @@ def _save_test_keypair(tmp_path: Path) -> None:
     save_keypair(RRN, kp)
 
 
-def _mock_200(body: bytes = b'{"verification_status": "manufacturer_claimed", "identity_binding": {"type": "dns-txt", "domain": "robotis.com"}}') -> MagicMock:
+_DEFAULT_MOCK_200_BODY = (
+    b'{"verification_status": "manufacturer_claimed",'
+    b' "identity_binding": {"type": "dns-txt", "domain": "robotis.com"}}'
+)
+
+
+def _mock_200(body: bytes = _DEFAULT_MOCK_200_BODY) -> MagicMock:
     """Build a context-manager mock for a successful 200 HTTP response."""
     resp = MagicMock()
     resp.status = 200
@@ -99,7 +103,10 @@ def test_verify_tier_manufacturer_verified_200_success(tmp_path, monkeypatch, ca
 
     from robot_md.verify_tier import cli_verify_tier
 
-    mv_body = b'{"verification_status": "manufacturer_verified", "identity_binding": {"type": "attestation"}}'
+    mv_body = (
+        b'{"verification_status": "manufacturer_verified",'
+        b' "identity_binding": {"type": "attestation"}}'
+    )
     with patch("urllib.request.urlopen", return_value=_mock_200(body=mv_body)):
         rc = cli_verify_tier(
             RRN,
@@ -231,7 +238,7 @@ def test_verify_tier_reject_community(tmp_path, monkeypatch, capsys):
 # ---------------------------------------------------------------------------
 
 
-def test_verify_tier_manufacturer_verified_missing_attestation_file_arg(tmp_path, monkeypatch, capsys):
+def test_verify_tier_mv_missing_attestation_file_arg(tmp_path, monkeypatch, capsys):
     """manufacturer_verified without attestation_file → exit non-zero; no HTTP call."""
     monkeypatch.setenv("HOME", str(tmp_path))
     _make_keystore(tmp_path)
@@ -261,8 +268,8 @@ def test_verify_tier_manufacturer_verified_missing_attestation_file_arg(tmp_path
 # ---------------------------------------------------------------------------
 
 
-def test_verify_tier_manufacturer_verified_attestation_file_not_found(tmp_path, monkeypatch, capsys):
-    """manufacturer_verified with a non-existent file → exit non-zero; message about 'Attestation file not found'."""
+def test_verify_tier_mv_attestation_file_not_found(tmp_path, monkeypatch, capsys):
+    """manufacturer_verified + missing file: stderr says 'Attestation file not found'."""
     monkeypatch.setenv("HOME", str(tmp_path))
     _make_keystore(tmp_path)
     _save_test_keypair(tmp_path)
@@ -499,21 +506,23 @@ def test_verify_tier_non_interactive_suppresses_prompt(tmp_path, monkeypatch):
     _make_keystore(tmp_path)
     _save_test_keypair(tmp_path)
 
-    from robot_md.verify_tier import cli_verify_tier
     import robot_md.verify_tier as vt_mod
+    from robot_md.verify_tier import cli_verify_tier
 
     # Pretend we're running on a real terminal so _is_interactive() would
     # otherwise prompt.
-    with patch.object(vt_mod, "_is_interactive", return_value=True):
-        with patch("builtins.input") as mock_input:
-            with patch("urllib.request.urlopen", return_value=_mock_200()):
-                rc = cli_verify_tier(
-                    RRN,
-                    target="manufacturer_claimed",
-                    dns_domain=DNS_DOMAIN,
-                    non_interactive=True,
-                )
-            mock_input.assert_not_called()
+    with (
+        patch.object(vt_mod, "_is_interactive", return_value=True),
+        patch("builtins.input") as mock_input,
+        patch("urllib.request.urlopen", return_value=_mock_200()),
+    ):
+        rc = cli_verify_tier(
+            RRN,
+            target="manufacturer_claimed",
+            dns_domain=DNS_DOMAIN,
+            non_interactive=True,
+        )
+        mock_input.assert_not_called()
 
     assert rc == 0
 
@@ -529,19 +538,21 @@ def test_verify_tier_interactive_prompts_for_confirmation(tmp_path, monkeypatch)
     _make_keystore(tmp_path)
     _save_test_keypair(tmp_path)
 
-    from robot_md.verify_tier import cli_verify_tier
     import robot_md.verify_tier as vt_mod
+    from robot_md.verify_tier import cli_verify_tier
 
-    with patch.object(vt_mod, "_is_interactive", return_value=True):
-        with patch("builtins.input", return_value="") as mock_input:
-            with patch("urllib.request.urlopen", return_value=_mock_200()):
-                rc = cli_verify_tier(
-                    RRN,
-                    target="manufacturer_claimed",
-                    dns_domain=DNS_DOMAIN,
-                    non_interactive=False,
-                )
-            mock_input.assert_called_once()
+    with (
+        patch.object(vt_mod, "_is_interactive", return_value=True),
+        patch("builtins.input", return_value="") as mock_input,
+        patch("urllib.request.urlopen", return_value=_mock_200()),
+    ):
+        rc = cli_verify_tier(
+            RRN,
+            target="manufacturer_claimed",
+            dns_domain=DNS_DOMAIN,
+            non_interactive=False,
+        )
+        mock_input.assert_called_once()
 
     assert rc == 0
 
@@ -557,7 +568,7 @@ def test_verify_tier_attestation_file_too_large(tmp_path, monkeypatch, capsys):
     _make_keystore(tmp_path)
     _save_test_keypair(tmp_path)
 
-    from robot_md.verify_tier import cli_verify_tier, MAX_ATTESTATION_BYTES
+    from robot_md.verify_tier import MAX_ATTESTATION_BYTES, cli_verify_tier
 
     # Produce a syntactically-valid but oversized JSON file
     big = tmp_path / "big_attestation.json"

--- a/cli/tests/test_verify_tier.py
+++ b/cli/tests/test_verify_tier.py
@@ -1,0 +1,348 @@
+"""Tests for `robot-md verify-tier` — signed POST to promote a robot's verification tier.
+
+TDD: tests written before implementation; run pytest to confirm RED, then
+implement verify_tier.py to get GREEN.
+"""
+
+from __future__ import annotations
+
+import io
+import json
+import urllib.error
+from pathlib import Path
+from unittest.mock import MagicMock, patch
+
+import pytest
+
+from robot_md.signing import generate_keypair, save_keypair
+
+RRN = "RRN-000000000042"
+DNS_DOMAIN = "robotis.com"
+
+
+def _make_keystore(tmp_path: Path) -> Path:
+    """Create ~/.robot-md/keys/ under tmp_path and return it."""
+    keys_dir = tmp_path / ".robot-md" / "keys"
+    keys_dir.mkdir(parents=True)
+    return keys_dir
+
+
+def _save_test_keypair(tmp_path: Path) -> None:
+    """Generate and save a signing keypair for RRN under tmp HOME."""
+    kp = generate_keypair()
+    save_keypair(RRN, kp)
+
+
+def _mock_200(body: bytes = b'{"identity_binding": {"type": "dns-txt", "domain": "robotis.com"}}') -> MagicMock:
+    """Build a context-manager mock for a successful 200 HTTP response."""
+    resp = MagicMock()
+    resp.status = 200
+    resp.read.return_value = body
+    resp.__enter__ = lambda s: s
+    resp.__exit__ = lambda *a: None
+    return resp
+
+
+def _http_error(status: int, body: bytes = b"") -> urllib.error.HTTPError:
+    """Build an HTTPError with a readable fp."""
+    return urllib.error.HTTPError(
+        url=f"https://example.com/{RRN}/verify-tier",
+        code=status,
+        msg="HTTP Error",
+        hdrs={},  # type: ignore[arg-type]
+        fp=io.BytesIO(body),
+    )
+
+
+# ---------------------------------------------------------------------------
+# Test 1: manufacturer_claimed happy path (200)
+# ---------------------------------------------------------------------------
+
+
+def test_verify_tier_manufacturer_claimed_200_success(tmp_path, monkeypatch, capsys):
+    """200 from RRF → exit 0; stdout contains 'Promoted' and 'manufacturer_claimed'."""
+    monkeypatch.setenv("HOME", str(tmp_path))
+    _make_keystore(tmp_path)
+    _save_test_keypair(tmp_path)
+
+    from robot_md.verify_tier import cli_verify_tier
+
+    with patch("urllib.request.urlopen", return_value=_mock_200()):
+        rc = cli_verify_tier(
+            RRN,
+            target="manufacturer_claimed",
+            dns_domain=DNS_DOMAIN,
+            non_interactive=True,
+        )
+
+    assert rc == 0
+    out = capsys.readouterr().out
+    assert "Promoted" in out
+    assert "manufacturer_claimed" in out
+
+
+# ---------------------------------------------------------------------------
+# Test 2: manufacturer_verified happy path (200)
+# ---------------------------------------------------------------------------
+
+
+def test_verify_tier_manufacturer_verified_200_success(tmp_path, monkeypatch, capsys):
+    """200 from RRF with manufacturer_verified → exit 0; stdout contains 'manufacturer_verified'."""
+    monkeypatch.setenv("HOME", str(tmp_path))
+    _make_keystore(tmp_path)
+    _save_test_keypair(tmp_path)
+
+    # Write a fake attestation JSON file
+    attestation_data = {"type": "rcan-attestation-v1", "rrn": RRN, "sig": "fakesig"}
+    attestation_file = tmp_path / "attestation.json"
+    attestation_file.write_text(json.dumps(attestation_data))
+
+    from robot_md.verify_tier import cli_verify_tier
+
+    with patch("urllib.request.urlopen", return_value=_mock_200()):
+        rc = cli_verify_tier(
+            RRN,
+            target="manufacturer_verified",
+            dns_domain=DNS_DOMAIN,
+            ruri="https://robotis.com",
+            attestation_file=attestation_file,
+            non_interactive=True,
+        )
+
+    assert rc == 0
+    out = capsys.readouterr().out
+    assert "manufacturer_verified" in out
+
+
+# ---------------------------------------------------------------------------
+# Test 3: Request body shape for manufacturer_claimed
+# ---------------------------------------------------------------------------
+
+
+def test_verify_tier_body_shape_manufacturer_claimed(tmp_path, monkeypatch):
+    """Body has rrn, action, target_tier, binding; no ruri, no attestation."""
+    monkeypatch.setenv("HOME", str(tmp_path))
+    _make_keystore(tmp_path)
+    _save_test_keypair(tmp_path)
+
+    captured_body: dict = {}
+
+    def fake_urlopen(req, timeout=30.0):
+        captured_body.update(json.loads(req.data.decode("utf-8")))
+        return _mock_200()
+
+    from robot_md.verify_tier import cli_verify_tier
+
+    with patch("urllib.request.urlopen", side_effect=fake_urlopen):
+        rc = cli_verify_tier(
+            RRN,
+            target="manufacturer_claimed",
+            dns_domain=DNS_DOMAIN,
+            non_interactive=True,
+        )
+
+    assert rc == 0
+    assert captured_body["rrn"] == RRN
+    assert captured_body["action"] == "verify-tier"
+    assert captured_body["target_tier"] == "manufacturer_claimed"
+    assert captured_body["binding"] == {"type": "dns-txt", "value": DNS_DOMAIN}
+    # sign_body stamps these
+    assert "sig" in captured_body
+    assert "pq_signing_pub" in captured_body
+    assert "pq_kid" in captured_body
+    # No ruri or attestation
+    assert "ruri" not in captured_body
+    assert "attestation" not in captured_body
+
+
+# ---------------------------------------------------------------------------
+# Test 4: Request body shape for manufacturer_verified
+# ---------------------------------------------------------------------------
+
+
+def test_verify_tier_body_shape_manufacturer_verified(tmp_path, monkeypatch):
+    """Body additionally has ruri and attestation (verbatim dict from file)."""
+    monkeypatch.setenv("HOME", str(tmp_path))
+    _make_keystore(tmp_path)
+    _save_test_keypair(tmp_path)
+
+    attestation_data = {"type": "rcan-attestation-v1", "rrn": RRN, "sig": "fakesig"}
+    attestation_file = tmp_path / "attestation.json"
+    attestation_file.write_text(json.dumps(attestation_data))
+
+    captured_body: dict = {}
+
+    def fake_urlopen(req, timeout=30.0):
+        captured_body.update(json.loads(req.data.decode("utf-8")))
+        return _mock_200()
+
+    from robot_md.verify_tier import cli_verify_tier
+
+    with patch("urllib.request.urlopen", side_effect=fake_urlopen):
+        rc = cli_verify_tier(
+            RRN,
+            target="manufacturer_verified",
+            dns_domain=DNS_DOMAIN,
+            ruri="https://robotis.com",
+            attestation_file=attestation_file,
+            non_interactive=True,
+        )
+
+    assert rc == 0
+    assert captured_body["rrn"] == RRN
+    assert captured_body["action"] == "verify-tier"
+    assert captured_body["target_tier"] == "manufacturer_verified"
+    assert captured_body["binding"] == {"type": "dns-txt", "value": DNS_DOMAIN}
+    assert captured_body["ruri"] == "https://robotis.com"
+    assert captured_body["attestation"] == attestation_data
+
+
+# ---------------------------------------------------------------------------
+# Test 5: Reject community target
+# ---------------------------------------------------------------------------
+
+
+def test_verify_tier_reject_community(tmp_path, monkeypatch, capsys):
+    """community tier → exit non-zero; message mentions 'maintainer-curated'; no HTTP call."""
+    monkeypatch.setenv("HOME", str(tmp_path))
+    _make_keystore(tmp_path)
+    _save_test_keypair(tmp_path)
+
+    from robot_md.verify_tier import cli_verify_tier
+
+    with patch("urllib.request.urlopen") as mock_urlopen:
+        rc = cli_verify_tier(
+            RRN,
+            target="community",
+            dns_domain=DNS_DOMAIN,
+            non_interactive=True,
+        )
+        mock_urlopen.assert_not_called()
+
+    assert rc != 0
+    captured = capsys.readouterr()
+    combined = captured.out + captured.err
+    assert "maintainer-curated" in combined
+
+
+# ---------------------------------------------------------------------------
+# Test 6: manufacturer_verified without --attestation-file
+# ---------------------------------------------------------------------------
+
+
+def test_verify_tier_manufacturer_verified_missing_attestation_file_arg(tmp_path, monkeypatch, capsys):
+    """manufacturer_verified without attestation_file → exit non-zero; no HTTP call."""
+    monkeypatch.setenv("HOME", str(tmp_path))
+    _make_keystore(tmp_path)
+    _save_test_keypair(tmp_path)
+
+    from robot_md.verify_tier import cli_verify_tier
+
+    with patch("urllib.request.urlopen") as mock_urlopen:
+        rc = cli_verify_tier(
+            RRN,
+            target="manufacturer_verified",
+            dns_domain=DNS_DOMAIN,
+            ruri="https://robotis.com",
+            attestation_file=None,  # missing
+            non_interactive=True,
+        )
+        mock_urlopen.assert_not_called()
+
+    assert rc != 0
+    captured = capsys.readouterr()
+    combined = captured.out + captured.err
+    assert "attestation" in combined.lower() or "manufacturer_verified" in combined
+
+
+# ---------------------------------------------------------------------------
+# Test 7: manufacturer_verified with missing attestation file on disk
+# ---------------------------------------------------------------------------
+
+
+def test_verify_tier_manufacturer_verified_attestation_file_not_found(tmp_path, monkeypatch, capsys):
+    """manufacturer_verified with a non-existent file → exit non-zero; message about 'Attestation file not found'."""
+    monkeypatch.setenv("HOME", str(tmp_path))
+    _make_keystore(tmp_path)
+    _save_test_keypair(tmp_path)
+
+    missing_file = tmp_path / "does_not_exist.json"
+
+    from robot_md.verify_tier import cli_verify_tier
+
+    with patch("urllib.request.urlopen") as mock_urlopen:
+        rc = cli_verify_tier(
+            RRN,
+            target="manufacturer_verified",
+            dns_domain=DNS_DOMAIN,
+            ruri="https://robotis.com",
+            attestation_file=missing_file,
+            non_interactive=True,
+        )
+        mock_urlopen.assert_not_called()
+
+    assert rc != 0
+    captured = capsys.readouterr()
+    combined = captured.out + captured.err
+    assert "Attestation file not found" in combined
+
+
+# ---------------------------------------------------------------------------
+# Test 8: 400 RRF response
+# ---------------------------------------------------------------------------
+
+
+def test_verify_tier_400_rrf_rejected(tmp_path, monkeypatch, capsys):
+    """400 from RRF → exit non-zero; message contains 'RRF rejected' and the error detail."""
+    monkeypatch.setenv("HOME", str(tmp_path))
+    _make_keystore(tmp_path)
+    _save_test_keypair(tmp_path)
+
+    error_body = json.dumps({"error": "DNS verification failed: TXT record not found"}).encode()
+
+    from robot_md.verify_tier import cli_verify_tier
+
+    with patch(
+        "urllib.request.urlopen",
+        side_effect=_http_error(400, error_body),
+    ):
+        rc = cli_verify_tier(
+            RRN,
+            target="manufacturer_claimed",
+            dns_domain=DNS_DOMAIN,
+            non_interactive=True,
+        )
+
+    assert rc != 0
+    captured = capsys.readouterr()
+    combined = captured.out + captured.err
+    assert "RRF rejected" in combined
+    assert "DNS verification failed: TXT record not found" in combined
+
+
+# ---------------------------------------------------------------------------
+# Test 9: No local signing key
+# ---------------------------------------------------------------------------
+
+
+def test_verify_tier_no_signing_key(tmp_path, monkeypatch, capsys):
+    """No signing key for RRN → exit non-zero; no HTTP call."""
+    monkeypatch.setenv("HOME", str(tmp_path))
+    _make_keystore(tmp_path)
+    # Intentionally do NOT save any keypair
+
+    from robot_md.verify_tier import cli_verify_tier
+
+    with patch("urllib.request.urlopen") as mock_urlopen:
+        rc = cli_verify_tier(
+            RRN,
+            target="manufacturer_claimed",
+            dns_domain=DNS_DOMAIN,
+            non_interactive=True,
+        )
+        mock_urlopen.assert_not_called()
+
+    assert rc != 0
+    captured = capsys.readouterr()
+    combined = captured.out + captured.err
+    assert RRN in combined or "signing key" in combined.lower()


### PR DESCRIPTION
## Summary

Adds three CLI subcommands that consume the RRF write-auth endpoints shipped in [RobotRegistryFoundation#67](https://github.com/craigm26/RobotRegistryFoundation/pull/67):

- \`robot-md revoke-key <rrn> [--reason TEXT] [--endpoint URL]\` — signed POST to \`/v2/robots/<rrn>/revoke-key\`. 204 prints \`Revoked: <rrn>\`; 409 prints \`Already revoked\` (exit 0 — idempotent).
- \`robot-md rotate-key <rrn> [--endpoint URL]\` — generates a new ML-DSA + Ed25519 keypair, co-signs a rotation request with both the old and new keys, and on a 200 response: archives the old keypair to \`~/.robot-md/keys/archive/<rrn>.<old_kid>.signing.json\` then atomically replaces the canonical keystore. The freshly-generated new keypair is staged to disk **before** the POST so that any post-200 disk failure leaves recoverable material.
- \`robot-md verify-tier <rrn> --target {manufacturer_claimed|manufacturer_verified} [options]\` — promotes a robot's tier via signed POST. \`community\` is rejected (maintainer-curated via PR per design decision 4). Interactive pre-flight prompt; \`--yes\` / \`ROBOT_MD_NONINTERACTIVE=1\` / non-TTY skips it.

Paired with the RRF server shipped in [RobotRegistryFoundation#67](https://github.com/craigm26/RobotRegistryFoundation/pull/67). The server-side contract uses a **two-envelope** rotation design (\`{by_old_key, by_new_key}\`, each a complete \`signBody()\` envelope); the CLI matches that contract.

## Plan

Tasks 10-12 of [\`docs/superpowers/plans/2026-04-24-rrf-tier-gated-write-auth.md\`](https://github.com/RobotRegistryFoundation/robot-md/blob/feat/write-auth-cli/docs/superpowers/plans/2026-04-24-rrf-tier-gated-write-auth.md).

## Test plan

- \`cd cli && python -m pytest tests/test_revoke_key.py tests/test_rotate_key.py tests/test_verify_tier.py\` — 34 passing (was 26 before review fixes added 8).
- Spec-compliance and code-quality reviewers ran against each committed task (7 commits total: 3 features + 4 review-fix commits).
- Integration smoke (Task 13) is deferred to a follow-up PR; staging RRF isn't reachable from this branch.

## Review fixes bundled in this PR

Code review surfaced five non-trivial issues — fixed in the last three commits.

**Critical (rotate-key):**
- \`new_kp\` was in-memory only. Both exit-2 branches told the operator to recover by saving the new keypair to disk — but at return time the keypair had already been garbage-collected. Now the new keypair is serialized to \`~/.robot-md/keys/<rrn>.NEW.signing.json\` (mode 0600) **before** the POST, and exit-2 stderr prints the exact \`mv\` command to promote it.
- Archive tmp file was created via \`tmp.write_text(...)\` then \`chmod(0o600)\`, leaving a window where ML-DSA + Ed25519 secret keys were world-readable. Replaced with \`os.open(..., O_CREAT|O_WRONLY|O_EXCL, 0o600)\` (atomic creation at mode 0600).

**Important:**
- Archive directory now created with \`mode=0o700\` (was umask-derived).
- \`_write_secret_file\` unlinks the tmp file if \`tmp.replace(dest)\` raises, so no stray secret copies are left behind.
- \`verify-tier\` caps attestation file at 1 MiB before read/parse (was unbounded).
- \`verify-tier\`'s non-interactive bypass is now pinned by a test that patches \`_is_interactive\` to True (previously the prompt path was invisible to pytest because stdin isn't a TTY).
- Added error-branch tests for 401, 403, 404, 409, and URLError on \`verify-tier\` (only 200 and 400 were covered).
- \`revoke-key\` 404 now surfaces the server body excerpt so operators can tell a wrong \`--endpoint\` apart from a missing registration.
- \`revoke-key\` body-shape test now asserts the URL path ends with \`/<rrn>/revoke-key\`.
- \`test_rotate_key_archive_write_failure\` now pins \`rc == 2\` (was \`rc != 0\`).

## Manual verification
- [ ] Run \`robot-md revoke-key\` against a registered throwaway robot on staging RRF, confirm 204.
- [ ] Run \`robot-md rotate-key\` twice, confirm archive file mode is 0600 and staging is cleaned up.
- [ ] Run \`robot-md verify-tier --target manufacturer_claimed\` with a valid TXT record, confirm tier promotion.

🤖 Generated with [Claude Code](https://claude.com/claude-code)