### PR TITLE
feat(presets): six new robot-md init presets — humanoid, mobile-manipulator, classroom

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,34 @@ Format follows [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 
 ## [Unreleased]
 
+### Added
+
+- Six new `robot-md init --preset` targets in
+  `cli/src/robot_md/presets/`. Brings the bundled count from 11 to 17:
+  - `reachy2` — Pollen Robotics open-source humanoid (bimanual 7-DoF
+    arms + 3-DoF Orbita neck + Zuuu holonomic mobile base + 4-camera
+    head/wrist stack). `physics.type: humanoid`. First preset to drive
+    the `reachy2_sdk` gRPC interface (port `50051`); same surface for
+    real robot and the `pollenrobotics/reachy2` Docker simulator.
+  - `stretch3` — Hello Robot Stretch 3 mobile manipulator (vertical
+    lift + telescoping arm + 3-DoF wrist + pan/tilt head + diff-drive
+    base + tri-RealSense vision). `physics.type: arm_manipulator`.
+  - `lekiwi` — HuggingFace LeRobot LeKiwi mobile manipulator (6-DoF
+    Feetech arm on a 3-omni-wheel holonomic base, single shared
+    Feetech bus). `physics.type: arm_manipulator`.
+  - `lego-spike-prime` — ported from `opencastor`'s
+    `config/presets/lego_spike_prime.rcan.yaml`. Differential-drive
+    classroom build over the SPIKE hub serial protocol.
+  - `lego-ev3` — ported from `opencastor`'s
+    `config/presets/lego_mindstorms_ev3.rcan.yaml`. Differential-drive
+    via `ev3dev` over SSH/RNDIS; common in second-hand classroom kits.
+  - `turtlebot3-burger` — ported from `opencastor`'s
+    `config/presets/turtlebot3_burger.rcan.yaml`. ROS 2 + LDS-01 lidar;
+    complements the existing `turtlebot4` preset.
+
+  All six pass the standard round-trip
+  (`robot-md init … --non-interactive | robot-md validate`).
+
 ---
 
 ## [1.1.1] — 2026-04-24

--- a/cli/src/robot_md/presets/lego_ev3.yaml
+++ b/cli/src/robot_md/presets/lego_ev3.yaml
@@ -1,0 +1,102 @@
+# robot-md preset — LEGO MINDSTORMS EV3 (legacy educational robot).
+# Ported from OpenCastor's lego_mindstorms_ev3.rcan.yaml.
+#
+# MINDSTORMS EV3 ships with the ev3dev Linux distribution and is the
+# pre-SPIKE generation of LEGO classroom robotics. Reference build:
+# 2 large motors on outA/outD for differential drive, medium motor on
+# outB for arm, touch/color/ultrasonic/gyro sensors on in1–in4. The
+# OpenCastor `ev3dev_driver` speaks `ev3dev_tacho_motor`/`ev3dev_sensor`
+# over an SSH/RNDIS link to the EV3 brick running ev3dev.
+
+match:
+  drivers:
+    protocol: ev3dev_tacho_motor
+  name_hints: ["ev3", "mindstorms", "lego"]
+
+physics:
+  type: wheeled
+  dof: 2
+  solver:
+    convention: custom                 # differential drive
+    base_frame: { up: z, forward: x }
+    encoder:
+      steps_per_rev: 360               # ev3dev tacho counts in degrees
+  kinematics:
+    - id: left_wheel
+      axis: y
+      length_mm: 0
+      a_mm: 0
+      d_mm: 0
+    - id: right_wheel
+      axis: y
+      length_mm: 0
+      a_mm: 0
+      d_mm: 0
+
+drivers:
+  - id: left_motor
+    protocol: ev3dev_tacho_motor
+    port: outA
+    model: lego-ev3-l-motor
+  - id: right_motor
+    protocol: ev3dev_tacho_motor
+    port: outD
+    model: lego-ev3-l-motor
+  - id: arm_motor
+    protocol: ev3dev_tacho_motor
+    port: outB
+    model: lego-ev3-m-motor
+  - id: touch_sensor
+    protocol: ev3dev_sensor
+    port: in1
+    model: lego-ev3-touch
+  - id: color_sensor
+    protocol: ev3dev_sensor
+    port: in2
+    model: lego-ev3-color
+  - id: ultrasonic_sensor
+    protocol: ev3dev_sensor
+    port: in3
+    model: lego-ev3-us
+  - id: gyro_sensor
+    protocol: ev3dev_sensor
+    port: in4
+    model: lego-ev3-gyro
+
+capabilities:
+  - nav.go_to
+  - nav.stop
+  - nav.rotate
+  - status.report
+
+safety:
+  p66_enabled: true
+  loa_enforcement: true
+  max_linear_velocity_ms: 0.4
+  workspace_bounds_m: [3, 3, 1]
+  estop:
+    hardware: false                    # EV3 has a brick button — software-mediated
+    software: true
+    response_ms: 200                   # ev3dev/SSH path is slower than USB-CDC
+  failsafe_behavior: stop
+  hitl_gates:
+    - scope: destructive
+      require_auth: true
+
+body_hints:
+  identity: |
+    LEGO MINDSTORMS EV3 — legacy educational robot brick running ev3dev
+    Linux. Reference build: differential drive (large motors outA/outD)
+    + arm (medium motor outB) + touch/color/ultrasonic/gyro sensors on
+    in1–in4. Wheel base ~130 mm, wheel radius ~28 mm. Common in school
+    surplus and second-hand markets.
+  capabilities: |
+    Navigate within a small workspace using differential drive. Touch
+    sensor for bump detection, color for line-following, ultrasonic for
+    obstacle distance, gyro for heading. Network link is SSH/RNDIS over
+    USB or WiFi dongle.
+  safety: |
+    No hardware E-stop. Software stop responds within ~200 ms (slower
+    than USB-direct platforms because commands traverse SSH/ev3dev).
+    Educational platform — supervise around fragile classroom equipment
+    and other students.

--- a/cli/src/robot_md/presets/lego_spike_prime.yaml
+++ b/cli/src/robot_md/presets/lego_spike_prime.yaml
@@ -1,0 +1,99 @@
+# robot-md preset — LEGO SPIKE Prime (educational classroom robot).
+# Ported from OpenCastor's lego_spike_prime.rcan.yaml. Adjust port-letter
+# assignments per build — the SPIKE hub's 6 ports (A–F) are interchangeable.
+#
+# SPIKE Prime is the modern classroom successor to MINDSTORMS EV3:
+# a single hub with 6 multi-function ports, USB or BLE link, MicroPython
+# REPL. This preset assumes a 2-motor differential-drive build (A/B
+# drive, C arm) with force/color/distance sensors on D/E/F. The
+# OpenCastor `spike_driver` speaks `spike_hub_serial` over USB-CDC.
+
+match:
+  drivers:
+    protocol: spike_hub_serial
+  name_hints: ["spike", "lego"]
+  usb_hints: ["LEGO Hub"]
+
+physics:
+  type: wheeled
+  dof: 2
+  solver:
+    convention: custom                 # differential drive
+    base_frame: { up: z, forward: x }
+    encoder:
+      steps_per_rev: 360               # SPIKE motors report degrees
+  kinematics:
+    - id: left_wheel
+      axis: y
+      length_mm: 0
+      a_mm: 0
+      d_mm: 0
+    - id: right_wheel
+      axis: y
+      length_mm: 0
+      a_mm: 0
+      d_mm: 0
+
+drivers:
+  - id: left_motor
+    protocol: spike_hub_serial
+    port: A
+    model: spike_angular_motor
+  - id: right_motor
+    protocol: spike_hub_serial
+    port: B
+    model: spike_angular_motor
+  - id: arm_motor
+    protocol: spike_hub_serial
+    port: C
+    model: spike_medium_motor
+  - id: force_sensor
+    protocol: spike_hub_serial
+    port: D
+    model: spike_force_sensor
+  - id: color_sensor
+    protocol: spike_hub_serial
+    port: E
+    model: spike_color_sensor
+  - id: distance_sensor
+    protocol: spike_hub_serial
+    port: F
+    model: spike_distance_sensor
+  - id: imu
+    protocol: spike_hub_internal
+    model: spike_imu
+
+capabilities:
+  - nav.go_to
+  - nav.stop
+  - nav.rotate
+  - status.report
+
+safety:
+  p66_enabled: true
+  loa_enforcement: true
+  max_linear_velocity_ms: 0.5
+  workspace_bounds_m: [3, 3, 1]
+  estop:
+    hardware: false                    # SPIKE hub has a center button — software-mediated
+    software: true
+    response_ms: 100
+  failsafe_behavior: stop
+  hitl_gates:
+    - scope: destructive
+      require_auth: true
+
+body_hints:
+  identity: |
+    LEGO SPIKE Prime — classroom-grade robot hub with 6 multi-function
+    ports (A–F), USB-C link, and MicroPython REPL. Reference build:
+    differential drive on A/B, arm motor on C, force/color/distance
+    sensors on D/E/F. Wheel base ~140 mm, wheel radius ~32 mm.
+  capabilities: |
+    Navigate within a small workspace (~3×3 m) using differential drive.
+    Sensors include force, color, and distance for reactive behaviors.
+    Suitable for STEM exercises and contained-environment teleop.
+  safety: |
+    No hardware E-stop (center button on hub is software-mediated).
+    Linear velocity capped at 0.5 m/s. Educational platform — supervise
+    when running near other students or fragile classroom equipment.

--- a/cli/src/robot_md/presets/lekiwi.yaml
+++ b/cli/src/robot_md/presets/lekiwi.yaml
@@ -1,0 +1,185 @@
+# robot-md preset — LeKiwi (HuggingFace LeRobot mobile manipulator).
+# Apply with: robot-md init --preset lekiwi
+#
+# LeKiwi is the LeRobot project's open-source mobile manipulator: a
+# 6-DoF SO-100/SO-ARM-class Feetech arm mounted on a 3-omni-wheel
+# holonomic base. All actuators are Feetech STS3215 servos on a single
+# bus, controlled via the `lerobot` Python SDK over USB. Designed as a
+# low-cost teach-by-teleop platform for the LeRobot dataset format.
+
+match:
+  drivers:
+    protocol: feetech
+    count: 9                            # 6 arm + 3 base wheels on shared Feetech bus
+  name_hints: ["lekiwi", "lerobot"]
+  negative_hints: ["leader"]            # don't fight so_arm101_leader on a teleop bench
+
+physics:
+  type: arm_manipulator
+  dof: 10                               # 6 arm + 1 gripper + 3 base wheels
+  solver:
+    convention: DH
+    base_frame: { up: z, forward: x }
+    encoder:
+      steps_per_rev: 4096
+    cameras:
+      - driver_id: wrist_cam
+        primary_stream: rgb
+        mount: world
+        extrinsic: null
+      - driver_id: base_cam
+        primary_stream: rgb
+        mount: world
+        extrinsic: null
+    gripper:
+      joint_id: gripper
+      tip_offset_mm: [30, 0, 0]
+      open_steps: 1700
+      close_steps: 1200
+  kinematics:
+    # Arm — same chain as so_arm101, mirrored from LeRobot reference geometry
+    - id: shoulder_pan
+      axis: z
+      limits_deg: [-180, 180]
+      length_mm: 60
+      a_mm: 0
+      d_mm: 60
+      servo_id: 1
+      encoder_sign: 1
+      zero_pose_steps: 2048
+    - id: shoulder_lift
+      axis: y
+      limits_deg: [-90, 90]
+      length_mm: 125
+      a_mm: 125
+      d_mm: 0
+      servo_id: 2
+      encoder_sign: 1
+      zero_pose_steps: 2048
+    - id: elbow_flex
+      axis: y
+      limits_deg: [-90, 90]
+      length_mm: 125
+      a_mm: 125
+      d_mm: 0
+      servo_id: 3
+      encoder_sign: 1
+      zero_pose_steps: 2048
+    - id: wrist_flex
+      axis: y
+      limits_deg: [-90, 90]
+      length_mm: 60
+      a_mm: 60
+      d_mm: 0
+      servo_id: 4
+      encoder_sign: 1
+      zero_pose_steps: 2048
+    - id: wrist_roll
+      axis: x
+      limits_deg: [-180, 180]
+      length_mm: 30
+      a_mm: 30
+      d_mm: 0
+      servo_id: 5
+      encoder_sign: 1
+      zero_pose_steps: 2048
+    - id: gripper
+      axis: y
+      limits_deg: [0, 90]
+      length_mm: 40
+      a_mm: 0
+      d_mm: 0
+      servo_id: 6
+      encoder_sign: 1
+      zero_pose_steps: 1200
+    # Holonomic base — 3 omni wheels at 120° spacing
+    - id: base_wheel_front
+      axis: y
+      length_mm: 0
+      a_mm: 0
+      d_mm: 0
+      servo_id: 7
+      encoder_sign: 1
+      zero_pose_steps: 2048
+    - id: base_wheel_back_left
+      axis: y
+      length_mm: 0
+      a_mm: 0
+      d_mm: 0
+      servo_id: 8
+      encoder_sign: 1
+      zero_pose_steps: 2048
+    - id: base_wheel_back_right
+      axis: y
+      length_mm: 0
+      a_mm: 0
+      d_mm: 0
+      servo_id: 9
+      encoder_sign: 1
+      zero_pose_steps: 2048
+
+drivers:
+  - id: lekiwi_servos
+    protocol: feetech
+    port: /dev/ttyACM0
+    baud_rate: 1000000
+    model: STS3215
+    count: 9
+  - id: wrist_cam
+    protocol: uvc
+    model: Logitech C270                # LeRobot reference cam — operator may swap
+    path: /dev/video0
+  - id: base_cam
+    protocol: uvc
+    model: Logitech C270
+    path: /dev/video2
+
+capabilities:
+  - arm.pick
+  - arm.place
+  - arm.reach
+  - arm.home
+  - nav.go_to
+  - nav.stop
+  - nav.rotate
+  - teleop.follow                       # primary use case: LeRobot dataset capture
+  - vision.describe
+  - status.report
+
+safety:
+  p66_enabled: true
+  loa_enforcement: true
+  max_joint_velocity_dps: 180
+  max_linear_velocity_ms: 0.4
+  payload_kg: 0.5
+  workspace_bounds_m: [5, 5, 1]
+  estop:
+    hardware: false                      # operator wires external if needed
+    software: true
+    response_ms: 100
+  failsafe_behavior: stop
+  hitl_gates:
+    - scope: destructive
+      require_auth: true
+    - scope: mobile_base
+      require_auth: true
+    - scope: teleop_record
+      require_auth: false                # dataset capture is the happy path
+
+body_hints:
+  identity: |
+    LeKiwi — LeRobot project's open-source mobile manipulator. 6-DoF
+    Feetech-servo arm (SO-100/SO-ARM-class) on a 3-omni-wheel holonomic
+    base. All 9 actuators share one Feetech bus over USB; controlled by
+    the `lerobot` Python SDK. Wrist + base cameras feed the LeRobot
+    dataset format for imitation-learning capture.
+  capabilities: |
+    Tabletop pick/place plus drive-to-goal navigation. Primary intended
+    workflow is teleop-to-dataset capture using a leader arm; the
+    `teleop.follow` capability is the happy path. Workspace ~5×5 m,
+    payload ≤ 500 g.
+  safety: |
+    No hardware E-stop ships with the kit — operator should wire one
+    on the power rail. Software stop responds in 100 ms. Mobile-base
+    motion routes through an HITL gate; teleop dataset capture does
+    not (intended-use mode).

--- a/cli/src/robot_md/presets/reachy2.yaml
+++ b/cli/src/robot_md/presets/reachy2.yaml
@@ -1,0 +1,255 @@
+# robot-md preset — Reachy 2 (Pollen Robotics open-source humanoid).
+# Apply with: robot-md init --preset reachy2
+#
+# Reachy 2 is a stationary-or-mobile humanoid: two 7-DoF arms with parallel
+# grippers, a 3-DoF Orbita neck, a 4-camera head/wrist vision stack, and a
+# Zuuu holonomic mobile base (3 omni-wheels). Control is over the Pollen
+# `reachy2-sdk` (gRPC :50051), which the published `pollenrobotics/reachy2`
+# Docker image exposes for both real-robot and MuJoCo-simulator targets.
+# This preset covers the simulator-or-robot interface; the underlying
+# driver is OpenCastor's reachy_driver.
+
+match:
+  drivers:
+    protocol: reachy2_sdk
+  name_hints: ["reachy", "pollen"]
+
+physics:
+  type: humanoid
+  dof: 22                              # 14 arms + 3 neck + 2 grippers + 3 base wheels
+  solver:
+    convention: DH
+    base_frame: { up: z, forward: x }
+    encoder:
+      steps_per_rev: 4096              # SDK exposes float radians; 4096 used for parity with Dynamixel-class chains
+    cameras:
+      - driver_id: head_left
+        primary_stream: rgb
+        mount: world
+        extrinsic: null
+      - driver_id: head_right
+        primary_stream: rgb
+        mount: world
+        extrinsic: null
+      - driver_id: wrist_left
+        primary_stream: rgb
+        mount: world
+        extrinsic: null
+      - driver_id: wrist_right
+        primary_stream: rgb
+        mount: world
+        extrinsic: null
+    gripper:
+      joint_id: r_gripper              # right by convention; mirror to l_gripper as needed
+      tip_offset_mm: [60, 0, 0]
+      open_steps: 100
+      close_steps: 0
+  kinematics:
+    # Left arm (7 DoF, Pollen Reachy 2 reference geometry)
+    - id: l_shoulder_pitch
+      axis: y
+      limits_deg: [-180, 90]
+      length_mm: 0
+      a_mm: 0
+      d_mm: 190
+    - id: l_shoulder_roll
+      axis: x
+      limits_deg: [-180, 10]
+      length_mm: 0
+      a_mm: 0
+      d_mm: 0
+    - id: l_arm_yaw
+      axis: z
+      limits_deg: [-90, 90]
+      length_mm: 0
+      a_mm: 0
+      d_mm: 280
+    - id: l_elbow_pitch
+      axis: y
+      limits_deg: [-125, 0]
+      length_mm: 280
+      a_mm: 280
+      d_mm: 0
+    - id: l_forearm_yaw
+      axis: z
+      limits_deg: [-100, 100]
+      length_mm: 0
+      a_mm: 0
+      d_mm: 250
+    - id: l_wrist_pitch
+      axis: y
+      limits_deg: [-45, 45]
+      length_mm: 0
+      a_mm: 0
+      d_mm: 0
+    - id: l_wrist_roll
+      axis: x
+      limits_deg: [-45, 45]
+      length_mm: 70
+      a_mm: 70
+      d_mm: 0
+    # Right arm (mirrors left)
+    - id: r_shoulder_pitch
+      axis: y
+      limits_deg: [-180, 90]
+      length_mm: 0
+      a_mm: 0
+      d_mm: 190
+    - id: r_shoulder_roll
+      axis: x
+      limits_deg: [-10, 180]
+      length_mm: 0
+      a_mm: 0
+      d_mm: 0
+    - id: r_arm_yaw
+      axis: z
+      limits_deg: [-90, 90]
+      length_mm: 0
+      a_mm: 0
+      d_mm: 280
+    - id: r_elbow_pitch
+      axis: y
+      limits_deg: [-125, 0]
+      length_mm: 280
+      a_mm: 280
+      d_mm: 0
+    - id: r_forearm_yaw
+      axis: z
+      limits_deg: [-100, 100]
+      length_mm: 0
+      a_mm: 0
+      d_mm: 250
+    - id: r_wrist_pitch
+      axis: y
+      limits_deg: [-45, 45]
+      length_mm: 0
+      a_mm: 0
+      d_mm: 0
+    - id: r_wrist_roll
+      axis: x
+      limits_deg: [-45, 45]
+      length_mm: 70
+      a_mm: 70
+      d_mm: 0
+    # Orbita 3-DoF neck (head pitch/roll/yaw, single Orbita actuator)
+    - id: neck_roll
+      axis: x
+      limits_deg: [-30, 30]
+      length_mm: 0
+      a_mm: 0
+      d_mm: 0
+    - id: neck_pitch
+      axis: y
+      limits_deg: [-40, 40]
+      length_mm: 0
+      a_mm: 0
+      d_mm: 0
+    - id: neck_yaw
+      axis: z
+      limits_deg: [-90, 90]
+      length_mm: 100
+      a_mm: 0
+      d_mm: 100
+    # Grippers (1 DoF each)
+    - id: l_gripper
+      axis: y
+      limits_deg: [0, 90]
+      length_mm: 0
+      a_mm: 0
+      d_mm: 0
+    - id: r_gripper
+      axis: y
+      limits_deg: [0, 90]
+      length_mm: 0
+      a_mm: 0
+      d_mm: 0
+    # Zuuu holonomic mobile base (3 omni wheels — actuated DoF, not Cartesian)
+    - id: base_wheel_front
+      axis: y
+      length_mm: 0
+      a_mm: 0
+      d_mm: 0
+    - id: base_wheel_back_left
+      axis: y
+      length_mm: 0
+      a_mm: 0
+      d_mm: 0
+    - id: base_wheel_back_right
+      axis: y
+      length_mm: 0
+      a_mm: 0
+      d_mm: 0
+
+drivers:
+  - id: reachy
+    protocol: reachy2_sdk
+    port: localhost:50051             # Pollen reachy2-sdk default — Docker image exposes :50051
+    model: reachy2
+  - id: head_left
+    protocol: reachy2_sdk
+    model: head_left_camera
+  - id: head_right
+    protocol: reachy2_sdk
+    model: head_right_camera
+  - id: wrist_left
+    protocol: reachy2_sdk
+    model: wrist_left_camera
+  - id: wrist_right
+    protocol: reachy2_sdk
+    model: wrist_right_camera
+
+capabilities:
+  - arm.pick
+  - arm.place
+  - arm.reach
+  - arm.home
+  - bimanual.handover
+  - nav.go_to                          # Zuuu mobile base
+  - nav.stop
+  - nav.rotate
+  - head.look_at
+  - vision.describe
+  - status.report
+
+safety:
+  p66_enabled: true
+  loa_enforcement: true
+  max_joint_velocity_dps: 90           # Reachy 2 is intentionally slow around humans
+  max_linear_velocity_ms: 0.7          # Zuuu base default cap
+  payload_kg: 3.0                      # per arm, per Pollen spec
+  workspace_bounds_m: [10, 10, 2]      # nominal indoor ops envelope; refine per deployment
+  estop:
+    hardware: true                     # Reachy 2 ships with physical E-stop on torso
+    software: true
+    response_ms: 50
+  failsafe_behavior: stop
+  hitl_gates:
+    - scope: destructive
+      require_auth: true
+    - scope: bimanual
+      require_auth: true               # coordinated arm motion can self-collide
+    - scope: mobile_base
+      require_auth: true               # base motion in human-shared space is risky
+    - scope: reach_high
+      require_auth: true               # extended-arm poses cross face/eye height of nearby humans
+
+body_hints:
+  identity: |
+    Reachy 2 — Pollen Robotics open-source humanoid: two 7-DoF arms, 3-DoF
+    Orbita neck, parallel-gripper hands, 4-camera vision stack (head L/R +
+    wrist L/R), and a Zuuu 3-wheel holonomic mobile base. Control via the
+    `reachy2-sdk` Python package over gRPC `:50051`. The same interface
+    drives the real robot and the MuJoCo-based simulator from the
+    `pollenrobotics/reachy2` Docker image.
+  capabilities: |
+    Single-arm pick/place/reach, coordinated bimanual handovers, head
+    look-at gestures, and holonomic navigation with the mobile base.
+    The wrist cameras are well-suited to imitation-learning capture.
+  safety: |
+    Hardware E-stop on the torso; software stop responds within 50 ms.
+    Each arm is rated for 3 kg payload and capped at 90 dps. Mobile-base
+    motion, bimanual coordination, and high-reach poses each route through
+    explicit HITL gates because mistakes in those modes can injure
+    bystanders or damage the robot. The Pollen docker image (amd64-only)
+    is the supported simulator surface — verify host architecture before
+    expecting interactive frame rates.

--- a/cli/src/robot_md/presets/stretch3.yaml
+++ b/cli/src/robot_md/presets/stretch3.yaml
@@ -1,0 +1,168 @@
+# robot-md preset — Stretch 3 (Hello Robot mobile manipulator).
+# Apply with: robot-md init --preset stretch3
+#
+# Stretch 3 is a single-arm mobile manipulator: a vertically-actuated
+# lift carrying a telescoping arm with 3-DoF wrist + parallel gripper,
+# mounted on a differential-drive base with a 2-DoF (pan/tilt) head.
+# Vision: head RealSense D435if (RGB-D), wrist RealSense D405 (RGB-D),
+# base D435if (navigation/cliff). Control via the `stretch_body` Python
+# SDK (USB) or ROS 2 (`stretch_ros2`).
+
+match:
+  drivers:
+    protocol: stretch_body
+  name_hints: ["stretch", "hello-robot"]
+  usb_hints: ["FTDI", "Stretch"]
+
+physics:
+  type: arm_manipulator
+  dof: 10                              # 1 lift + 1 arm-extension + 3 wrist + 1 gripper + 2 head + 2 base
+  solver:
+    convention: custom                 # mixed prismatic/revolute + diff-drive — not a clean DH chain
+    base_frame: { up: z, forward: x }
+    encoder:
+      steps_per_rev: 16384             # Hello Robot uses 14-bit encoders on the lift/arm
+    cameras:
+      - driver_id: head_d435i
+        primary_stream: rgb
+        mount: world
+        extrinsic: null
+      - driver_id: wrist_d405
+        primary_stream: rgb
+        mount: world
+        extrinsic: null
+      - driver_id: base_d435i
+        primary_stream: rgb
+        mount: world
+        extrinsic: null
+    gripper:
+      joint_id: gripper
+      tip_offset_mm: [0, 0, 0]
+      open_steps: 100
+      close_steps: 0
+  kinematics:
+    - id: lift
+      axis: z
+      limits_mm: [0, 1100]
+      length_mm: 0
+      a_mm: 0
+      d_mm: 0
+    - id: arm
+      axis: x
+      limits_mm: [0, 520]
+      length_mm: 0
+      a_mm: 0
+      d_mm: 0
+    - id: wrist_yaw
+      axis: z
+      limits_deg: [-75, 200]
+      length_mm: 0
+      a_mm: 0
+      d_mm: 0
+    - id: wrist_pitch
+      axis: y
+      limits_deg: [-90, 30]
+      length_mm: 0
+      a_mm: 0
+      d_mm: 0
+    - id: wrist_roll
+      axis: x
+      limits_deg: [-180, 180]
+      length_mm: 0
+      a_mm: 0
+      d_mm: 0
+    - id: gripper
+      axis: y
+      limits_deg: [0, 90]
+      length_mm: 0
+      a_mm: 0
+      d_mm: 0
+    - id: head_pan
+      axis: z
+      limits_deg: [-180, 90]
+      length_mm: 0
+      a_mm: 0
+      d_mm: 0
+    - id: head_tilt
+      axis: y
+      limits_deg: [-90, 30]
+      length_mm: 0
+      a_mm: 0
+      d_mm: 0
+    - id: base_left_wheel
+      axis: y
+      length_mm: 0
+      a_mm: 0
+      d_mm: 0
+    - id: base_right_wheel
+      axis: y
+      length_mm: 0
+      a_mm: 0
+      d_mm: 0
+
+drivers:
+  - id: stretch
+    protocol: stretch_body
+    port: /dev/hello-motor-arm        # Hello Robot udev-aliased ports
+    model: RE2V0
+  - id: head_d435i
+    protocol: realsense
+    model: D435if
+  - id: wrist_d405
+    protocol: realsense
+    model: D405
+  - id: base_d435i
+    protocol: realsense
+    model: D435if
+
+capabilities:
+  - arm.pick
+  - arm.place
+  - arm.reach
+  - arm.home
+  - nav.go_to
+  - nav.stop
+  - nav.rotate
+  - head.look_at
+  - vision.describe
+  - status.report
+
+safety:
+  p66_enabled: true
+  loa_enforcement: true
+  max_joint_velocity_dps: 90
+  max_linear_velocity_ms: 0.5          # Stretch's safe-cap for human-shared spaces
+  payload_kg: 1.5                      # Stretch 3 spec
+  workspace_bounds_m: [10, 10, 2]
+  estop:
+    hardware: true                     # runstop button on chassis
+    software: true
+    response_ms: 50
+  failsafe_behavior: stop
+  hitl_gates:
+    - scope: destructive
+      require_auth: true
+    - scope: mobile_base
+      require_auth: true
+    - scope: high_lift
+      require_auth: true               # full-extension lift can knock items off shelves
+
+body_hints:
+  identity: |
+    Stretch 3 — Hello Robot single-arm mobile manipulator with a
+    1100 mm-stroke vertical lift, a 520 mm-extension telescoping arm,
+    3-DoF wrist + gripper, 2-DoF pan/tilt head, and a differential-drive
+    base. Cameras: head + base RealSense D435if (RGB-D + nav), wrist
+    RealSense D405 (close-range RGB-D). Control via `stretch_body`
+    Python SDK or `stretch_ros2`.
+  capabilities: |
+    Pick/place from floor-to-shelf height (lift + arm-extension + wrist),
+    drive to a goal pose, look-at gestures with the pan/tilt head.
+    Telescoping arm + lift gives a tall reach envelope unusual for
+    consumer-priced mobile manipulators.
+  safety: |
+    Hardware runstop on chassis; software stop within 50 ms. Linear
+    base velocity capped at 0.5 m/s. The lift can extend through
+    eye-level — `high_lift` HITL gate exists because full-extension
+    motion near humans is non-obvious. Mobile-base motion always
+    routes through the `mobile_base` gate.

--- a/cli/src/robot_md/presets/turtlebot3_burger.yaml
+++ b/cli/src/robot_md/presets/turtlebot3_burger.yaml
@@ -1,0 +1,82 @@
+# robot-md preset — TurtleBot 3 Burger (ROBOTIS, ROS 2 educational robot).
+# Ported from OpenCastor's turtlebot3_burger.rcan.yaml. Complements the
+# existing TurtleBot 4 preset — TB3 is still ubiquitous in undergrad
+# robotics courses and labs that haven't upgraded.
+#
+# TB3 Burger = Raspberry Pi 4 + OpenCR MCU + 2 wheels + LDS-01 360° lidar
+# + IMU. Differential drive over ROS 2, default cmd_vel/odom/scan topics.
+
+match:
+  drivers:
+    protocol: ros2
+  name_hints: ["turtlebot3", "tb3", "burger"]
+  pci_hints: ["LDS-01"]
+
+physics:
+  type: wheeled
+  dof: 2
+  solver:
+    convention: custom                 # differential drive
+    base_frame: { up: z, forward: x }
+    encoder:
+      steps_per_rev: 4096              # OpenCR encoder
+  kinematics:
+    - id: left_wheel
+      axis: y
+      length_mm: 0
+      a_mm: 0
+      d_mm: 0
+    - id: right_wheel
+      axis: y
+      length_mm: 0
+      a_mm: 0
+      d_mm: 0
+
+drivers:
+  - id: base
+    protocol: ros2
+    topic: /cmd_vel
+  - id: lidar
+    protocol: ros2
+    model: LDS-01
+    topic: /scan
+  - id: imu
+    protocol: ros2
+    topic: /imu
+
+capabilities:
+  - nav.go_to
+  - nav.stop
+  - nav.rotate
+  - status.report
+
+safety:
+  p66_enabled: true
+  loa_enforcement: true
+  max_linear_velocity_ms: 0.22         # ROBOTIS stock cap on Burger
+  max_joint_velocity_dps: 162          # 2.84 rad/s converted from upstream rcan
+  workspace_bounds_m: [5, 5, 1]
+  estop:
+    hardware: false                    # no physical E-stop on Burger
+    software: true
+    response_ms: 100
+  failsafe_behavior: stop
+  hitl_gates:
+    - scope: destructive
+      require_auth: true
+
+body_hints:
+  identity: |
+    TurtleBot 3 Burger — ROBOTIS entry-level ROS 2 mobile robot. Pi 4 +
+    OpenCR MCU + 2-wheel differential drive + LDS-01 360° lidar + IMU.
+    Wheel base 160 mm, wheel radius 33 mm. The canonical educational
+    ROS 2 platform.
+  capabilities: |
+    Indoor navigation with 2D SLAM via the lidar, plus stop and rotate
+    primitives. No vision in the stock build — operator can mount a
+    Pi camera if needed. Workspace ~5×5 m typical for classroom labs.
+  safety: |
+    No hardware E-stop. Linear velocity capped at 0.22 m/s (ROBOTIS
+    stock limit). Software stop responds within 100 ms. Indoor-only
+    platform — wheels and motor torque are not rated for ramps or
+    outdoor surfaces.

--- a/cli/tests/test_init.py
+++ b/cli/tests/test_init.py
@@ -68,10 +68,19 @@ def test_preset_match_score_zero_on_empty_scan(presets):
 
 
 def test_pick_best_returns_highest(presets):
+    """A 6-servo Feetech bus should pick so_arm101 (not lekiwi/koch_arm/leader).
+
+    Both so_arm101 and lekiwi declare match.drivers.protocol=feetech (+10),
+    but they declare different servo counts (so_arm101=6, lekiwi=9). A real
+    autodetect scan embeds servo count in the label as "(N servos)"; the
+    test scan does the same so the count match (+5) breaks the tie in
+    favour of the preset whose count actually matches the rig.
+    """
+
     class Device:
         bus = "usb"
         protocol = "feetech"
-        label = ""
+        label = "Feetech servo bus (6 servos)"
         path = "/dev/ttyACM0"
 
     class Scan:
@@ -79,7 +88,28 @@ def test_pick_best_returns_highest(presets):
 
     r = pick_best(presets, Scan())
     assert r is not None
-    assert r.preset.name == "so_arm101"  # highest scorer on a Feetech bus
+    assert r.preset.name == "so_arm101"  # 6 servos → so_arm101 wins on count match
+
+
+def test_pick_best_lekiwi_on_nine_servo_feetech(presets):
+    """A 9-servo Feetech bus picks lekiwi (6 arm + 3 wheels = 9 servos).
+
+    Same protocol as so_arm101 but distinct count — pins that the
+    preset matcher discriminates between the two via match.drivers.count.
+    """
+
+    class Device:
+        bus = "usb"
+        protocol = "feetech"
+        label = "Feetech servo bus (9 servos)"
+        path = "/dev/ttyACM0"
+
+    class Scan:
+        devices = [Device()]
+
+    r = pick_best(presets, Scan())
+    assert r is not None
+    assert r.preset.name == "lekiwi"  # 9 servos = 6 arm + 3 omni-wheel base
 
 
 def test_pick_best_prefers_minimal_when_all_scores_zero(presets):


### PR DESCRIPTION
## Summary

Brings bundled `robot-md init --preset` count from 11 to 17. Six new presets covering form factors that weren't represented:

- **reachy2** — Pollen Robotics humanoid (`physics.type: humanoid`). Bimanual 7-DoF arms + 3-DoF Orbita neck + Zuuu holonomic mobile base + 4-camera head/wrist stack. First preset to drive the `reachy2_sdk` gRPC interface (port 50051); same surface for real robot and the `pollenrobotics/reachy2` Docker simulator.
- **stretch3** — Hello Robot Stretch 3 (`physics.type: arm_manipulator`). Vertical lift + telescoping arm + 3-DoF wrist + pan/tilt head + diff-drive base + tri-RealSense vision.
- **lekiwi** — HuggingFace LeRobot LeKiwi (`physics.type: arm_manipulator`). 6-DoF Feetech arm on a 3-omni-wheel holonomic base, single shared Feetech bus (9 servos = 6 arm + 3 wheels).
- **lego-spike-prime** — Differential-drive classroom build over SPIKE hub serial protocol.
- **lego-ev3** — Differential-drive via `ev3dev` over SSH/RNDIS.
- **turtlebot3-burger** — ROS 2 + LDS-01 lidar; complements existing `turtlebot4` preset.

The 3 classroom/mobile presets are ported from opencastor's preset library.

## Test fix

`test_pick_best_returns_highest` regressed when lekiwi was added — both lekiwi and so_arm101 declare `match.drivers.protocol=feetech`, so on a bare Feetech-bus scan they tie at +10 each and lekiwi wins the alphabetical tiebreak.

The real autodetect scan embeds servo count in the label as `(N servos)`. Updated the test scan to match that shape — `match.drivers.count` (+5) now discriminates correctly:

- **6-servo Feetech bus** → so_arm101 (15 vs lekiwi 10) ✓
- **9-servo Feetech bus** → lekiwi (15 vs so_arm101 10) ✓ (new test pins this)

## Test plan

- [x] `load_presets()` loads all 17 (10 existing + 6 new)
- [x] Every shipped preset has `physics` block with schema-accepted type
- [x] All 6 new presets round-trip via `robot-md init <name> --preset <p> | robot-md validate`
- [x] `tests/test_init.py` — 17/17 pass (was 16/17 with lekiwi present)
- [x] ruff check + format clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)