### PR TITLE
fix(ci) + feat(scaffold): MCP discover timeout 10→30s + compliance status preamble

### DIFF
--- a/cli/src/robot_md/init_phases/compliance_scaffold.py
+++ b/cli/src/robot_md/init_phases/compliance_scaffold.py
@@ -75,6 +75,14 @@ if [ "$RESET_AUDIT" = "--reset-audit" ]; then
   rm -f ~/.robot-md/audit/"$RRN".jsonl ~/.robot-md/incidents/"$RRN".jsonl
 fi
 
+echo "[0/6] pre-flight: robot-md compliance status"
+# Surface keystore/audit/artifact/RRF blockers BEFORE the demo so the operator
+# sees what's about to fail (e.g. apikey-gated --submit paths) up front.
+# --no-probe in CI; remove for live RRF check. Exit 4 = blockers present;
+# we DON'T abort — the demo runs to completion to validate the flow shape.
+robot-md compliance status "$MANIFEST" || true
+echo
+
 echo "[1/6] emit FRIA (Art. 27)"
 robot-md emit-fria "$MANIFEST" \\
   --deployment-context "demo-$(date -u +%Y-%m-%d)" \\

--- a/cli/tests/integration/test_mcp_discover_streaming.py
+++ b/cli/tests/integration/test_mcp_discover_streaming.py
@@ -110,7 +110,10 @@ def test_discover_emits_per_step_progress(fixtures_dir, tmp_path):
                 },
             },
         )
-        reply, progress = _read_until_response(proc, 42, timeout_s=10.0)
+        # 30s budget is intentional — github-hosted CI runners can take 12-15s
+        # for the MCP stdio child + multi-step discover dispatch under load.
+        # 10s was too tight and flaked ~30% on the matrix (one Python at a time).
+        reply, progress = _read_until_response(proc, 42, timeout_s=30.0)
         assert "result" in reply, f"discover call failed: {reply}"
         # Every progress notification for this call must carry the token.
         for p in progress:

--- a/cli/tests/test_compliance_scaffold.py
+++ b/cli/tests/test_compliance_scaffold.py
@@ -93,3 +93,18 @@ def test_demo_template_has_no_bob_specific_paths(tmp_path: Path):
     should be portable."""
     assert "/home/craigm26/bob" not in DEMO_SCRIPT_TEMPLATE
     assert "bob/scripts" not in DEMO_SCRIPT_TEMPLATE
+
+
+def test_demo_template_includes_compliance_status_preamble(tmp_path: Path):
+    """The demo must run `robot-md compliance status` BEFORE the emit-* steps
+    so the operator sees blockers (apikey gap, audit chain, RRF drift) up
+    front. Without this preamble, --submit failures surface mid-flow with
+    no context. The preamble must NOT abort the demo (|| true) — running
+    to completion validates the flow shape even when blockers exist."""
+    cmd = 'robot-md compliance status "$MANIFEST"'
+    assert cmd in DEMO_SCRIPT_TEMPLATE, "demo must invoke `compliance status` on $MANIFEST"
+    cmd_idx = DEMO_SCRIPT_TEMPLATE.index(cmd)
+    emit_idx = DEMO_SCRIPT_TEMPLATE.index("emit-fria")
+    assert cmd_idx < emit_idx, "compliance status must run before emit-fria"
+    cmd_line = DEMO_SCRIPT_TEMPLATE[cmd_idx : DEMO_SCRIPT_TEMPLATE.index("\n", cmd_idx)]
+    assert "|| true" in cmd_line, "preamble must use `|| true` to not abort on blockers"


### PR DESCRIPTION
## Summary

Two small follow-ups to the EU AI Act compliance stack:

1. **MCP discover test budget bump (10s → 30s).** `tests/integration/test_mcp_discover_streaming.py::test_discover_emits_per_step_progress` was flaking ~30% on github-hosted runners. The 10s budget for the multi-step discover round-trip on a fresh MCP stdio child process is too tight when the runner is under load. Hit on PR #5 (test 3.12) and PR #6 (test 3.11) within the same day; both passed on retry. 30s is generous enough that genuine regressions still surface fast, tight enough that real hangs don't sit forever.

2. **`robot-md compliance status` preamble in the init-scaffolded demo.** The demo template that ships in `robot-md init` (per-robot `scripts/demo-eu-ai-act.sh`) now runs `robot-md compliance status` as a `[0/N]` pre-flight step before the emit-* chain. Surfaces keystore/audit/artifact/RRF blockers up front so an operator sees apikey-gap, version-drift, etc. ahead of any `--submit` failure mid-flow. Uses `|| true` — the preamble is informational, not blocking; the local emit + audit flow validates regardless of submit-side blockers.

## Test plan

- [x] 7/7 existing scaffold tests pass
- [x] New `test_demo_template_includes_compliance_status_preamble` pins: command targets `$MANIFEST`, runs before `emit-fria`, uses `|| true`
- [x] `test_discover_emits_per_step_progress` passes locally with 30s budget
- [x] ruff check + format clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)