### PR TITLE
feat(first-motion-readiness): defaults + pre-flight + namespace warn + first-activation script

### DIFF
--- a/cli/src/robot_md/compliance_status.py
+++ b/cli/src/robot_md/compliance_status.py
@@ -214,6 +214,209 @@ def _check_registry(
     return out
 
 
+# Capability namespaces that imply *motion* (vs observation-only). Used by
+# the first-motion-readiness check to decide whether the manifest needs
+# hitl_gates and the other actuation pre-flights. Mirrors the matcher in
+# `mcp.tools.execute_capability._match_hitl_gate` (cap_scope = first dot
+# segment).
+MOTION_CAPABILITY_NAMESPACES: tuple[str, ...] = ("manipulate", "arm", "nav", "navigate", "move")
+
+# Backend capability namespaces in the bundled drivers — used to detect
+# "namespace mismatch" where the manifest declares e.g. `manipulate.pick`
+# but every available backend implements `arm.pick`. Updated when new
+# backends ship.
+BACKEND_NAMESPACES: dict[str, tuple[str, ...]] = {
+    "feetech_scs": ("arm", "status"),
+    "feetech_depthai": ("arm", "perceive", "status"),
+    "oak_d_lr": ("perceive",),
+    "dynamixel": ("arm", "status"),
+}
+
+
+def _check_first_motion_readiness(fm: dict, manifest_path: Path) -> dict[str, Any]:
+    """Pre-flight check covering the 5 things that block a first motion attempt
+    even when the EU AI Act submission stack is otherwise green.
+
+    Surfaces gaps that bob's manifest exposed in the first-pick attempt
+    (2026-04-25): empty hitl_gates with declared motion capabilities,
+    missing safety.max_joint_velocity_dps, missing vision.object_descriptors,
+    uncalibrated camera extrinsic, and capability-namespace mismatch with
+    declared drivers. Returns structured per-check results so an operator
+    can see exactly which step blocks first motion.
+    """
+    capabilities = fm.get("capabilities") or []
+    if not isinstance(capabilities, list):
+        capabilities = []
+    safety = fm.get("safety") or {}
+    drivers = fm.get("drivers") or []
+    vision = fm.get("vision") or {}
+    physics = fm.get("physics") or {}
+    solver = physics.get("solver") or {}
+    cameras = solver.get("cameras") or []
+
+    # Derive declared capability namespaces (e.g. "manipulate", "perceive").
+    declared_namespaces = sorted({c.split(".", 1)[0] for c in capabilities if isinstance(c, str)})
+    has_motion_caps = any(ns in MOTION_CAPABILITY_NAMESPACES for ns in declared_namespaces)
+    has_pick = any(c in ("manipulate.pick", "arm.pick", "nav.pick") for c in capabilities)
+    has_vision_driver = any(
+        d.get("protocol") in ("oak_d_lr", "depthai", "realsense", "luxonis")
+        for d in drivers
+        if isinstance(d, dict)
+    )
+
+    # 1. hitl_gates non-empty when motion capabilities declared
+    gates = safety.get("hitl_gates") or []
+    gates_ok = (not has_motion_caps) or bool(gates)
+
+    # 2. max_joint_velocity_dps required when any actuation driver present
+    has_actuation_driver = any(
+        d.get("protocol") in ("feetech_scs", "feetech", "dynamixel", "ros2_control")
+        for d in drivers
+        if isinstance(d, dict)
+    )
+    has_velocity_limit = "max_joint_velocity_dps" in safety
+    velocity_ok = (not has_actuation_driver) or has_velocity_limit
+
+    # 3. vision.object_descriptors non-empty when any *.pick capability
+    descriptors = vision.get("object_descriptors") or []
+    descriptors_ok = (not has_pick) or bool(descriptors)
+
+    # 4. cameras[].extrinsic non-null when vision driver declared
+    extrinsic_ok = (not has_vision_driver) or any(
+        c.get("extrinsic") not in (None, {}) for c in cameras if isinstance(c, dict)
+    )
+
+    # 5. Capability namespace alignment — every declared motion namespace
+    # appears in the union of namespaces supplied by some declared driver.
+    declared_driver_protocols = {
+        d.get("protocol") for d in drivers if isinstance(d, dict) and d.get("protocol")
+    }
+    backend_namespaces_supplied: set[str] = set()
+    for proto in declared_driver_protocols:
+        backend_namespaces_supplied.update(BACKEND_NAMESPACES.get(proto, ()))
+    motion_namespaces_in_caps = {
+        ns for ns in declared_namespaces if ns in MOTION_CAPABILITY_NAMESPACES
+    }
+    namespace_mismatch = (
+        bool(motion_namespaces_in_caps)
+        and bool(backend_namespaces_supplied)
+        and motion_namespaces_in_caps.isdisjoint(backend_namespaces_supplied)
+    )
+    namespace_ok = not namespace_mismatch
+
+    return {
+        "applies": has_motion_caps or has_actuation_driver or has_vision_driver,
+        "ready": gates_ok and velocity_ok and descriptors_ok and extrinsic_ok and namespace_ok,
+        "checks": {
+            "hitl_gates": {
+                "ok": gates_ok,
+                "detail": (
+                    f"{len(gates)} gate(s) declared"
+                    if gates_ok
+                    else (
+                        "motion capabilities declared but safety.hitl_gates[] is empty — "
+                        "any execute_capability call will run unauthorized"
+                    )
+                ),
+                "fix": (
+                    None
+                    if gates_ok
+                    else (
+                        "Add at least one gate per motion namespace, e.g. "
+                        "`safety.hitl_gates: [{scope: manipulate, require_auth: true}]`"
+                    )
+                ),
+            },
+            "max_joint_velocity_dps": {
+                "ok": velocity_ok,
+                "detail": (
+                    f"declared ({safety.get('max_joint_velocity_dps')} dps)"
+                    if velocity_ok and has_velocity_limit
+                    else (
+                        "no actuation driver — N/A"
+                        if not has_actuation_driver
+                        else (
+                            "actuation driver declared but safety.max_joint_velocity_dps "
+                            "is missing — load_context will refuse to open the backend"
+                        )
+                    )
+                ),
+                "fix": (
+                    None
+                    if velocity_ok
+                    else "Set safety.max_joint_velocity_dps (e.g. 30 for collaborative arms)"
+                ),
+            },
+            "object_descriptors": {
+                "ok": descriptors_ok,
+                "detail": (
+                    f"{len(descriptors)} descriptor(s) declared"
+                    if descriptors_ok and descriptors
+                    else (
+                        "no pick capability — N/A"
+                        if not has_pick
+                        else (
+                            "*.pick capability declared but vision.object_descriptors is "
+                            "empty — vision.find has no target shape to resolve"
+                        )
+                    )
+                ),
+                "fix": (
+                    None
+                    if descriptors_ok
+                    else (
+                        "Declare at least one object descriptor under vision.object_descriptors[] "
+                        "(e.g. red_lego with detector: hsv)"
+                    )
+                ),
+            },
+            "camera_extrinsic": {
+                "ok": extrinsic_ok,
+                "detail": (
+                    "extrinsic present"
+                    if extrinsic_ok and has_vision_driver
+                    else (
+                        "no vision driver — N/A"
+                        if not has_vision_driver
+                        else (
+                            "vision driver declared but no camera has a calibrated "
+                            "extrinsic — IK targets will be unreachable"
+                        )
+                    )
+                ),
+                "fix": (
+                    None
+                    if extrinsic_ok
+                    else (
+                        "Run `robot-md calibrate --hand-eye --marker-pos x,y,z ROBOT.md` "
+                        "to populate physics.solver.cameras[*].extrinsic"
+                    )
+                ),
+            },
+            "capability_namespace": {
+                "ok": namespace_ok,
+                "detail": (
+                    "namespace alignment OK"
+                    if namespace_ok
+                    else (
+                        f"capabilities declare {sorted(motion_namespaces_in_caps)} but the "
+                        f"declared driver(s) implement {sorted(backend_namespaces_supplied)} — "
+                        f"every dispatch will return not_implemented"
+                    )
+                ),
+                "fix": (
+                    None
+                    if namespace_ok
+                    else (
+                        "Either rename capabilities to match the backend namespace "
+                        "(e.g. `manipulate.pick` → `arm.pick`) or change the driver"
+                    )
+                ),
+            },
+        },
+    }
+
+
 def _check_submission_readiness(apikey_present: bool) -> dict[str, dict[str, Any]]:
     out: dict[str, dict[str, Any]] = {}
     for kind in SUBMISSION_KINDS:
@@ -265,6 +468,12 @@ def _aggregate_blockers(status: dict[str, Any]) -> list[str]:
             f"apikey is recovered"
         )
 
+    fmr = status.get("first_motion_readiness") or {}
+    if fmr.get("applies") and not fmr.get("ready"):
+        for cid, c in (fmr.get("checks") or {}).items():
+            if not c.get("ok"):
+                blockers.append(f"first-motion: {cid} — {c.get('detail', '')}")
+
     return blockers
 
 
@@ -311,6 +520,7 @@ def gather_status(
     }
     apikey_present = status["keystore"]["apikey"]["present"]
     status["submission_readiness"] = _check_submission_readiness(apikey_present)
+    status["first_motion_readiness"] = _check_first_motion_readiness(fm, manifest_path)
     status["blockers"] = _aggregate_blockers(status)
     return status
 
@@ -408,6 +618,16 @@ def format_status_text(status: dict[str, Any]) -> str:
         else:
             lines.append(f"  ✗ emit-{kind:<18}  blocked — {r['reason']}")
     lines.append("")
+
+    # First-motion readiness — pre-flight for the actual hardware run
+    fmr = status.get("first_motion_readiness") or {}
+    if fmr.get("applies"):
+        lines.append("First-motion readiness")
+        for cid, c in (fmr.get("checks") or {}).items():
+            lines.append(f"  {_icon(c['ok'])} {cid:<24}  {c.get('detail', '')}")
+            if not c.get("ok") and c.get("fix"):
+                lines.append(f"      → {c['fix']}")
+        lines.append("")
 
     # Blockers summary
     if status["blockers"]:

--- a/cli/src/robot_md/init.py
+++ b/cli/src/robot_md/init.py
@@ -284,7 +284,87 @@ def merge_preset_into_draft(
                 }
             )
 
+    _ensure_first_motion_defaults(fm)
     return fm
+
+
+# --- first-motion defaults --------------------------------------------------
+#
+# Scaffold the manifest fields that make a robot "first-motion ready" so an
+# operator running `robot-md init <preset>` doesn't discover blockers at first
+# motion. Mirrors the pre-flight checks in compliance_status.
+# _check_first_motion_readiness — what's checked there is what's defaulted here.
+#
+# Intentionally additive: if the preset declares a value, the default is NOT
+# applied. Operator-supplied values always win.
+
+_FIRST_MOTION_NAMESPACES_OBSERVATION = ("perceive", "perception", "status", "report", "observe")
+_FIRST_MOTION_ACTUATION_PROTOCOLS = ("feetech_scs", "feetech", "dynamixel", "ros2_control")
+_FIRST_MOTION_VISION_PROTOCOLS = ("oak_d_lr", "depthai", "realsense", "luxonis")
+_FIRST_MOTION_PICK_CAPABILITIES = ("manipulate.pick", "arm.pick", "nav.pick")
+_FIRST_MOTION_DEFAULT_VELOCITY_DPS = 30  # Conservative collaborative-arm budget
+
+
+def _ensure_first_motion_defaults(fm: dict[str, Any]) -> None:
+    """Fill in safety.hitl_gates, safety.max_joint_velocity_dps, and
+    vision.object_descriptors when the manifest's capabilities + drivers
+    imply they're needed and the operator/preset hasn't supplied them.
+    Mutates `fm` in place. Pure additive — never overrides existing values.
+    """
+    capabilities = fm.get("capabilities") or []
+    if not isinstance(capabilities, list):
+        return
+    drivers = fm.get("drivers") or []
+    if not isinstance(drivers, list):
+        drivers = []
+
+    safety = fm.setdefault("safety", {})
+
+    # 1. Default hitl_gates from declared motion namespaces.
+    motion_namespaces: list[str] = []
+    seen: set[str] = set()
+    for cap in capabilities:
+        if not isinstance(cap, str) or "." not in cap:
+            continue
+        ns = cap.split(".", 1)[0]
+        if ns in _FIRST_MOTION_NAMESPACES_OBSERVATION or ns in seen:
+            continue
+        motion_namespaces.append(ns)
+        seen.add(ns)
+    if motion_namespaces and not safety.get("hitl_gates"):
+        safety["hitl_gates"] = [{"scope": ns, "require_auth": True} for ns in motion_namespaces]
+
+    # 2. Default max_joint_velocity_dps when any actuation driver is declared.
+    has_actuation = any(
+        isinstance(d, dict) and d.get("protocol") in _FIRST_MOTION_ACTUATION_PROTOCOLS
+        for d in drivers
+    )
+    if has_actuation and "max_joint_velocity_dps" not in safety:
+        safety["max_joint_velocity_dps"] = _FIRST_MOTION_DEFAULT_VELOCITY_DPS
+
+    # 3. Default vision.object_descriptors placeholders when any *.pick
+    #    capability is declared. Two canonical placeholders (red_lego,
+    #    white_bowl) — enough that vision.find has SOME shape to resolve;
+    #    operator replaces with real targets.
+    has_pick = any(c in _FIRST_MOTION_PICK_CAPABILITIES for c in capabilities)
+    if has_pick:
+        vision = fm.setdefault("vision", {})
+        descriptors = vision.setdefault("object_descriptors", [])
+        if not descriptors:
+            descriptors.extend(
+                [
+                    {
+                        "id": "red_lego",
+                        "detector": "hsv",
+                        "params": {"h": [0, 10], "s": [120, 255], "v": [80, 255]},
+                    },
+                    {
+                        "id": "white_bowl",
+                        "detector": "hsv",
+                        "params": {"h": [0, 180], "s": [0, 60], "v": [180, 255]},
+                    },
+                ]
+            )
 
 
 def render_draft(

--- a/cli/src/robot_md/init_phases/compliance_scaffold.py
+++ b/cli/src/robot_md/init_phases/compliance_scaffold.py
@@ -162,6 +162,79 @@ sign + POST in one step. Submit attempts are recorded in the local
 hash-chained audit log (`robot-md audit verify`).
 """
 
+FIRST_ACTIVATION_TEMPLATE = """\
+#!/usr/bin/env bash
+# first-activation.sh — run once after `robot-md init` to confirm the
+# robot is ready for its first motion.
+#
+# This script is non-destructive but DOES touch hardware:
+#   1. Validates the manifest (schema + first-motion warnings)
+#   2. Runs `robot-md compliance status` to surface any blockers
+#   3. Probes RRF connectivity (`robot-md doctor`)
+#   4. (optional) Runs `robot-md calibrate --zero` to teach the ready pose
+#      — requires the operator to physically position the arm
+#   5. (optional) Runs `robot-md calibrate --hand-eye` if a vision driver
+#      is declared — requires a calibration marker at known coordinates
+#
+# After this script exits 0, the robot is ready for its first
+# `execute_capability` call. Re-run any time the manifest changes.
+
+set -euo pipefail
+
+MANIFEST="${MANIFEST:-$(dirname "$0")/../ROBOT.md}"
+SKIP_CALIBRATION="${SKIP_CALIBRATION:-}"
+
+if [ ! -f "$MANIFEST" ]; then
+  echo "error: $MANIFEST does not exist (set MANIFEST=...)" >&2
+  exit 2
+fi
+
+echo "=== first-activation: $MANIFEST ==="
+echo
+
+echo "[1/5] validate manifest"
+robot-md validate "$MANIFEST"
+echo
+
+echo "[2/5] compliance status (first-motion-readiness pre-flight)"
+# Don't abort on blockers — surface them, then keep going so calibration
+# can proceed and reduce the blocker count.
+robot-md compliance status "$MANIFEST" --no-probe || true
+echo
+
+echo "[3/5] RRF reachability (skip with: NO_RRF=1)"
+if [ "${NO_RRF:-}" != "1" ]; then
+  robot-md doctor --path "$MANIFEST" || echo "  (doctor reported issues; continuing)"
+else
+  echo "  (skipped per NO_RRF=1)"
+fi
+echo
+
+if [ "$SKIP_CALIBRATION" = "1" ]; then
+  echo "[4-5/5] calibration skipped per SKIP_CALIBRATION=1"
+else
+  echo "[4/5] calibrate --zero (teach the ready pose)"
+  echo "      Position the arm in the rest pose, then press ENTER..."
+  read -r _
+  robot-md calibrate --zero "$MANIFEST" || {
+    echo "  (calibrate --zero failed; continuing — re-run manually)"
+  }
+  echo
+
+  echo "[5/5] calibrate --hand-eye (if a vision driver is declared)"
+  echo "      Place the calibration marker at the known position, then"
+  echo "      pass --marker-pos <x>,<y>,<z>. Skipping for now — run manually:"
+  echo "        robot-md calibrate --hand-eye --marker-pos 200,0,0 $MANIFEST"
+  echo
+fi
+
+echo "=== final compliance status ==="
+robot-md compliance status "$MANIFEST" --no-probe || true
+
+echo
+echo "✓ first-activation complete. Manifest is staged for first motion."
+"""
+
 
 def phase_compliance_scaffold(
     manifest_path: Path,
@@ -177,6 +250,7 @@ def phase_compliance_scaffold(
     scripts_dir = base / "scripts"
     compliance_dir = base / "compliance"
     demo_path = scripts_dir / "demo-eu-ai-act.sh"
+    activation_path = scripts_dir / "first-activation.sh"
     readme_path = compliance_dir / "README.md"
     gitkeep_path = compliance_dir / ".gitkeep"
 
@@ -192,6 +266,13 @@ def phase_compliance_scaffold(
         demo_path.write_text(DEMO_SCRIPT_TEMPLATE)
         demo_path.chmod(0o755)
         created.append(str(demo_path.relative_to(base)))
+
+    if activation_path.exists() and not force_scripts:
+        skipped.append(str(activation_path.relative_to(base)))
+    else:
+        activation_path.write_text(FIRST_ACTIVATION_TEMPLATE)
+        activation_path.chmod(0o755)
+        created.append(str(activation_path.relative_to(base)))
 
     if readme_path.exists() and not force_scripts:
         skipped.append(str(readme_path.relative_to(base)))

--- a/cli/src/robot_md/validate.py
+++ b/cli/src/robot_md/validate.py
@@ -99,6 +99,41 @@ def validate(parsed: ParsedRobotMd) -> ValidationResult:
                 f"run `robot-md calibrate-intrinsic --driver {did} --stream {primary}`"
             )
 
+    # 1d. Capability namespace alignment with declared drivers. Warn when
+    # capabilities[] contains motion namespaces that none of the declared
+    # drivers implement — every dispatch through that namespace would
+    # return not_implemented at runtime. See compliance_status.
+    # MOTION_CAPABILITY_NAMESPACES + BACKEND_NAMESPACES for the canonical
+    # set; mirrored here to avoid a circular import.
+    motion_namespaces = {"manipulate", "arm", "nav", "navigate", "move"}
+    driver_namespace_map = {
+        "feetech_scs": ("arm", "status"),
+        "feetech": ("arm", "status"),
+        "feetech_depthai": ("arm", "perceive", "status"),
+        "oak_d_lr": ("perceive",),
+        "depthai": ("perceive",),
+        "dynamixel": ("arm", "status"),
+        "ros2_control": ("arm", "nav", "navigate", "status"),
+    }
+    capabilities = fm.get("capabilities") or []
+    if isinstance(capabilities, list):
+        declared_motion_ns = {
+            c.split(".", 1)[0]
+            for c in capabilities
+            if isinstance(c, str) and "." in c and c.split(".", 1)[0] in motion_namespaces
+        }
+        supplied_ns: set[str] = set()
+        for d in fm.get("drivers") or []:
+            if isinstance(d, dict):
+                for ns in driver_namespace_map.get(d.get("protocol"), ()):
+                    supplied_ns.add(ns)
+        if declared_motion_ns and supplied_ns and declared_motion_ns.isdisjoint(supplied_ns):
+            warnings.append(
+                f"capability namespace mismatch: capabilities declare "
+                f"{sorted(declared_motion_ns)} but declared driver(s) implement "
+                f"{sorted(supplied_ns)} — execute_capability will return not_implemented"
+            )
+
     # 2. Body-section checks
     robot_name = fm.get("metadata", {}).get("robot_name", "")
     if not _has_matching_h1(body, robot_name):

--- a/cli/tests/test_compliance_scaffold.py
+++ b/cli/tests/test_compliance_scaffold.py
@@ -8,6 +8,7 @@ from pathlib import Path
 from robot_md.init_phases.compliance_scaffold import (
     COMPLIANCE_README,
     DEMO_SCRIPT_TEMPLATE,
+    FIRST_ACTIVATION_TEMPLATE,
     phase_compliance_scaffold,
 )
 
@@ -20,8 +21,40 @@ def test_phase_creates_scripts_and_compliance_dirs(tmp_path: Path):
 
     assert result.status == "ok"
     assert (tmp_path / "scripts" / "demo-eu-ai-act.sh").exists()
+    assert (tmp_path / "scripts" / "first-activation.sh").exists()
     assert (tmp_path / "compliance" / "README.md").exists()
     assert (tmp_path / "compliance" / ".gitkeep").exists()
+
+
+def test_first_activation_script_is_executable(tmp_path: Path):
+    manifest = tmp_path / "ROBOT.md"
+    manifest.write_text("---\n---\n# x\n")
+    phase_compliance_scaffold(manifest)
+    p = tmp_path / "scripts" / "first-activation.sh"
+    mode = p.stat().st_mode
+    assert mode & stat.S_IXUSR, f"first-activation.sh not executable: {oct(mode)}"
+
+
+def test_first_activation_template_runs_compliance_status_and_calibration(tmp_path: Path):
+    """Template wires the four key pre-first-motion steps: validate,
+    compliance status, doctor, and calibrate-zero. Pinning the structure
+    so future edits can't silently drop steps the operator depends on."""
+    for step in (
+        "robot-md validate",
+        "robot-md compliance status",
+        "robot-md doctor",
+        "robot-md calibrate --zero",
+        "calibrate --hand-eye",
+    ):
+        assert step in FIRST_ACTIVATION_TEMPLATE, f"first-activation must run `{step}`"
+
+
+def test_first_activation_template_uses_relative_manifest(tmp_path: Path):
+    """Same portability requirement as demo: $MANIFEST derives from $0,
+    not a hardcoded path."""
+    assert "MANIFEST=" in FIRST_ACTIVATION_TEMPLATE
+    assert '$(dirname "$0")' in FIRST_ACTIVATION_TEMPLATE
+    assert "/home/craigm26" not in FIRST_ACTIVATION_TEMPLATE
 
 
 def test_demo_script_is_executable(tmp_path: Path):

--- a/cli/tests/test_compliance_status.py
+++ b/cli/tests/test_compliance_status.py
@@ -38,6 +38,9 @@ drivers:
   - { id: arm, protocol: feetech, port: /dev/null }
 safety:
   estop: { software: true, hardware: false, response_ms: 50 }
+  max_joint_velocity_dps: 30
+  hitl_gates:
+    - { scope: navigate, require_auth: true }
 capabilities: [navigate]
 ---
 # bob
@@ -90,6 +93,7 @@ def test_status_has_all_top_level_sections(manifest, home):
         "artifacts",
         "registry",
         "submission_readiness",
+        "first_motion_readiness",
         "blockers",
     ):
         assert k in s, f"missing section: {k}"
@@ -261,3 +265,183 @@ def test_format_text_no_blockers_when_clean(manifest, home, tmp_path):
 
     s = gather_status(manifest, artifacts_dir=artifacts_dir, network_probe=False)
     assert s["blockers"] == []
+
+
+# ---- first-motion readiness ---------------------------------------------
+
+
+BOB_NOT_READY = """\
+---
+rcan_version: "3.2"
+metadata:
+  robot_name: bob
+  manufacturer: Acme
+  model: SO-ARM101
+  firmware_version: 1.0.0
+  rrn: RRN-000000000077
+network:
+  rrf_endpoint: https://robotregistryfoundation.org
+physics:
+  type: arm
+  dof: 6
+drivers:
+  - { id: arm, protocol: feetech_scs, port: /dev/null }
+  - { id: vision, protocol: oak_d_lr, connection: usb }
+capabilities:
+  - manipulate.pick
+  - manipulate.place
+safety:
+  estop: { software: true, response_ms: 50 }
+---
+# bob (not first-motion-ready)
+"""
+
+
+@pytest.fixture
+def bob_not_ready(tmp_path: Path) -> Path:
+    p = tmp_path / "ROBOT_NOT_READY.md"
+    p.write_text(BOB_NOT_READY)
+    return p
+
+
+def test_first_motion_readiness_section_present(manifest, home):
+    s = gather_status(manifest, network_probe=False)
+    fmr = s["first_motion_readiness"]
+    assert "applies" in fmr
+    assert "ready" in fmr
+    assert "checks" in fmr
+    for cid in (
+        "hitl_gates",
+        "max_joint_velocity_dps",
+        "object_descriptors",
+        "camera_extrinsic",
+        "capability_namespace",
+    ):
+        assert cid in fmr["checks"], f"missing first-motion check: {cid}"
+
+
+def test_first_motion_readiness_clean_for_well_formed_manifest(manifest, home):
+    """BOB_MIN has gates + velocity-limit + only `navigate` cap (no .pick) +
+    no vision driver → all 5 checks pass."""
+    s = gather_status(manifest, network_probe=False)
+    fmr = s["first_motion_readiness"]
+    assert fmr["ready"] is True
+    for cid, c in fmr["checks"].items():
+        assert c["ok"] is True, f"{cid} unexpectedly not ok: {c}"
+
+
+def test_first_motion_readiness_flags_bobs_actual_gaps(bob_not_ready, home):
+    """The exact 5 gaps bob's hand-rolled manifest exposed on 2026-04-25."""
+    s = gather_status(bob_not_ready, network_probe=False)
+    fmr = s["first_motion_readiness"]
+    assert fmr["applies"] is True
+    assert fmr["ready"] is False
+
+    checks = fmr["checks"]
+    # 1. No hitl_gates declared with motion capabilities
+    assert checks["hitl_gates"]["ok"] is False
+    assert "hitl_gates" in checks["hitl_gates"]["detail"].lower()
+    # 2. Actuation driver but no max_joint_velocity_dps
+    assert checks["max_joint_velocity_dps"]["ok"] is False
+    assert "max_joint_velocity_dps" in checks["max_joint_velocity_dps"]["detail"]
+    # 3. *.pick declared but no descriptors
+    assert checks["object_descriptors"]["ok"] is False
+    assert "descriptor" in checks["object_descriptors"]["detail"].lower()
+    # 4. Vision driver but no extrinsic
+    assert checks["camera_extrinsic"]["ok"] is False
+    assert "extrinsic" in checks["camera_extrinsic"]["detail"].lower()
+    # 5. manipulate.* capabilities but feetech_scs implements arm.*
+    assert checks["capability_namespace"]["ok"] is False
+    assert "manipulate" in checks["capability_namespace"]["detail"]
+
+
+def test_first_motion_readiness_bubbles_to_blockers(bob_not_ready, home):
+    s = gather_status(bob_not_ready, network_probe=False)
+    blocker_text = "\n".join(s["blockers"])
+    for cid in (
+        "hitl_gates",
+        "max_joint_velocity_dps",
+        "object_descriptors",
+        "camera_extrinsic",
+        "capability_namespace",
+    ):
+        assert cid in blocker_text, f"first-motion check {cid} not aggregated into blockers"
+
+
+def test_first_motion_readiness_does_not_apply_for_pure_sensor_manifest(tmp_path, home):
+    """A manifest with no actuation driver, no motion capabilities, no
+    vision driver should not surface first-motion blockers — fmr.applies=False."""
+    sensor_only = tmp_path / "ROBOT_sensor.md"
+    sensor_only.write_text("""\
+---
+rcan_version: "3.2"
+metadata:
+  robot_name: lonely-thermometer
+  manufacturer: Acme
+  model: probe
+  firmware_version: 1.0.0
+physics: { type: sensor, dof: 0 }
+drivers:
+  - { id: temp, protocol: i2c, port: /dev/null }
+safety:
+  estop: { software: true, response_ms: 50 }
+capabilities: [perceive.temperature]
+---
+""")
+    s = gather_status(sensor_only, network_probe=False)
+    fmr = s["first_motion_readiness"]
+    assert fmr["applies"] is False, "pure-sensor manifest should not trigger first-motion checks"
+
+
+def test_first_motion_readiness_passes_when_all_5_gaps_filled(tmp_path, home):
+    ready = tmp_path / "ROBOT_ready.md"
+    ready.write_text("""\
+---
+rcan_version: "3.2"
+metadata:
+  robot_name: ready-bob
+  manufacturer: Acme
+  model: SO-ARM101
+  firmware_version: 1.0.0
+  rrn: RRN-000000000088
+network:
+  rrf_endpoint: https://robotregistryfoundation.org
+physics:
+  type: arm
+  dof: 6
+  solver:
+    cameras:
+      - driver_id: cam
+        primary_stream: rgb
+        mount: world
+        extrinsic: { R: [[1,0,0],[0,1,0],[0,0,1]], t: [0.0, 0.0, 0.5] }
+drivers:
+  - { id: arm, protocol: feetech_scs, port: /dev/null }
+  - { id: vision, protocol: oak_d_lr, connection: usb }
+vision:
+  object_descriptors:
+    - { id: red_lego, detector: hsv, params: { h: [0, 10] } }
+capabilities:
+  - arm.pick
+  - arm.place
+  - perceive.rgb
+safety:
+  estop: { software: true, response_ms: 50 }
+  max_joint_velocity_dps: 30
+  hitl_gates:
+    - { scope: arm, require_auth: true }
+---
+""")
+    s = gather_status(ready, network_probe=False)
+    fmr = s["first_motion_readiness"]
+    assert fmr["applies"] is True
+    assert fmr["ready"] is True, f"expected ready=True; checks: {fmr['checks']}"
+
+
+def test_format_text_includes_first_motion_section(bob_not_ready, home):
+    s = gather_status(bob_not_ready, network_probe=False)
+    out = format_status_text(s)
+    assert "First-motion readiness" in out
+    # Each failed check shows its fix line
+    assert "hitl_gates" in out
+    assert "extrinsic" in out

--- a/cli/tests/test_init.py
+++ b/cli/tests/test_init.py
@@ -256,3 +256,128 @@ def test_so_arm101_preset_ships_object_descriptors(presets):
     bowl = next(d for d in descs if d["id"] == "white_bowl")
     assert bowl["detector"] == "hsv_roi"
     assert "roi" in bowl["params"]
+
+
+# ---- first-motion defaults (PR D, 2026-04-25) ----------------------------
+
+
+class _Scan:
+    devices: list = []
+    cameras: list = []
+
+
+def _bare_preset(**data) -> Preset:
+    """Tiny synthetic preset for unit-testing first-motion defaults without
+    touching the bundled presets."""
+    return Preset(name="bare", match={}, data=data)
+
+
+def test_first_motion_defaults_scaffold_hitl_gates_from_motion_capabilities():
+    """capabilities=[manipulate.pick] with no preset gates → init scaffolds
+    one gate per motion namespace with require_auth=true."""
+    preset = _bare_preset(
+        physics={"type": "arm", "dof": 6},
+        drivers=[{"id": "arm", "protocol": "feetech_scs"}],
+        capabilities=["manipulate.pick", "manipulate.place", "perceive.rgb"],
+        safety={"estop": {"software": True, "response_ms": 50}},
+    )
+    fm = merge_preset_into_draft(preset, "bot", _Scan())
+    gates = fm["safety"]["hitl_gates"]
+    scopes = [g["scope"] for g in gates]
+    assert "manipulate" in scopes
+    # observation namespace excluded
+    assert "perceive" not in scopes
+    assert all(g["require_auth"] is True for g in gates)
+
+
+def test_first_motion_defaults_does_not_override_preset_hitl_gates():
+    """Operator/preset gates win — defaults are additive only."""
+    preset = _bare_preset(
+        physics={"type": "arm", "dof": 6},
+        drivers=[{"id": "arm", "protocol": "feetech_scs"}],
+        capabilities=["manipulate.pick"],
+        safety={
+            "estop": {"software": True, "response_ms": 50},
+            "hitl_gates": [{"scope": "destructive", "require_auth": True}],
+        },
+    )
+    fm = merge_preset_into_draft(preset, "bot", _Scan())
+    gates = fm["safety"]["hitl_gates"]
+    # Original preset gate is preserved verbatim
+    assert gates == [{"scope": "destructive", "require_auth": True}]
+
+
+def test_first_motion_defaults_velocity_limit_from_actuation_driver():
+    """Any feetech_scs / dynamixel / ros2_control driver triggers a default
+    safety.max_joint_velocity_dps when none is declared."""
+    preset = _bare_preset(
+        physics={"type": "arm", "dof": 6},
+        drivers=[{"id": "arm", "protocol": "feetech_scs"}],
+        capabilities=["arm.home"],
+        safety={"estop": {"software": True, "response_ms": 50}},
+    )
+    fm = merge_preset_into_draft(preset, "bot", _Scan())
+    assert fm["safety"]["max_joint_velocity_dps"] == 30
+
+
+def test_first_motion_defaults_does_not_override_preset_velocity_limit():
+    preset = _bare_preset(
+        physics={"type": "arm", "dof": 6},
+        drivers=[{"id": "arm", "protocol": "feetech_scs"}],
+        capabilities=["arm.home"],
+        safety={
+            "estop": {"software": True, "response_ms": 50},
+            "max_joint_velocity_dps": 180,
+        },
+    )
+    fm = merge_preset_into_draft(preset, "bot", _Scan())
+    assert fm["safety"]["max_joint_velocity_dps"] == 180
+
+
+def test_first_motion_defaults_descriptors_from_pick_capability():
+    """capabilities include arm.pick or manipulate.pick → object_descriptors
+    placeholder seeded if none declared."""
+    preset = _bare_preset(
+        physics={"type": "arm", "dof": 6},
+        drivers=[{"id": "arm", "protocol": "feetech_scs"}],
+        capabilities=["manipulate.pick", "manipulate.place"],
+        safety={"estop": {"software": True, "response_ms": 50}},
+    )
+    fm = merge_preset_into_draft(preset, "bot", _Scan())
+    ids = {d["id"] for d in fm["vision"]["object_descriptors"]}
+    assert "red_lego" in ids
+    assert "white_bowl" in ids
+
+
+def test_first_motion_defaults_does_not_override_preset_descriptors():
+    """If preset already declares descriptors, init keeps them verbatim."""
+    preset = _bare_preset(
+        physics={"type": "arm", "dof": 6},
+        drivers=[{"id": "arm", "protocol": "feetech_scs"}],
+        capabilities=["arm.pick"],
+        vision={
+            "object_descriptors": [
+                {"id": "blue_block", "detector": "hsv", "params": {"h": [200, 240]}}
+            ]
+        },
+        safety={"estop": {"software": True, "response_ms": 50}},
+    )
+    fm = merge_preset_into_draft(preset, "bot", _Scan())
+    ids = {d["id"] for d in fm["vision"]["object_descriptors"]}
+    assert ids == {"blue_block"}
+
+
+def test_first_motion_defaults_inert_for_sensor_only_preset():
+    """Pure observation preset (no motion namespaces, no actuation driver,
+    no .pick capability) → defaults add nothing."""
+    preset = _bare_preset(
+        physics={"type": "sensor", "dof": 0},
+        drivers=[{"id": "temp", "protocol": "i2c"}],
+        capabilities=["perceive.temperature"],
+        safety={"estop": {"software": True, "response_ms": 50}},
+    )
+    fm = merge_preset_into_draft(preset, "thermo", _Scan())
+    safety = fm["safety"]
+    assert "hitl_gates" not in safety, "no motion namespaces — should not add gates"
+    assert "max_joint_velocity_dps" not in safety, "no actuator — should not add velocity limit"
+    assert "vision" not in fm, "no .pick — should not add descriptors"

--- a/cli/tests/test_validate.py
+++ b/cli/tests/test_validate.py
@@ -75,3 +75,90 @@ def test_valid_minimal_has_summary(fixtures_dir):
     result = validate(parsed)
     assert result.summary
     assert "test-bot" in result.summary
+
+
+# ---- capability namespace alignment warning (PR D, 2026-04-25) ----------
+
+
+def test_namespace_mismatch_warning_on_manipulate_with_feetech(tmp_path):
+    """Bob's actual hand-rolled gap: capabilities declare manipulate.* but
+    feetech_scs driver implements arm.*. Validation should warn — not fail
+    the schema (it's a runtime-time issue, not a schema violation)."""
+    p = tmp_path / "ROBOT.md"
+    p.write_text("""\
+---
+rcan_version: "3.2"
+metadata:
+  robot_name: bob
+  manufacturer: Acme
+  model: SO-ARM101
+  firmware_version: 1.0.0
+physics: { type: arm, dof: 6 }
+drivers:
+  - { id: arm, protocol: feetech_scs, port: /dev/null }
+capabilities: [manipulate.pick]
+safety:
+  estop: { software: true, response_ms: 50 }
+  max_joint_velocity_dps: 30
+  hitl_gates: [{ scope: manipulate, require_auth: true }]
+---
+# bob
+
+## Identity
+
+bob.
+
+## What bob Can Do
+
+stuff.
+
+## Safety Gates
+
+manipulate.
+""")
+    result = validate(parse_file(p))
+    assert result.code == VALID, (
+        f"expected VALID + warning; got code={result.code} errors={result.errors}"
+    )
+    assert any("namespace mismatch" in w.lower() for w in result.warnings), (
+        f"expected namespace-mismatch warning; got {result.warnings}"
+    )
+
+
+def test_no_namespace_mismatch_warning_when_aligned(tmp_path):
+    """capabilities = arm.* with feetech_scs driver → no warning."""
+    p = tmp_path / "ROBOT.md"
+    p.write_text("""\
+---
+rcan_version: "3.2"
+metadata:
+  robot_name: bob
+  manufacturer: Acme
+  model: SO-ARM101
+  firmware_version: 1.0.0
+physics: { type: arm, dof: 6 }
+drivers:
+  - { id: arm, protocol: feetech_scs, port: /dev/null }
+capabilities: [arm.pick, arm.home]
+safety:
+  estop: { software: true, response_ms: 50 }
+  max_joint_velocity_dps: 30
+  hitl_gates: [{ scope: arm, require_auth: true }]
+---
+# bob
+
+## Identity
+
+bob.
+
+## What bob Can Do
+
+pick + home.
+
+## Safety Gates
+
+arm.
+""")
+    result = validate(parse_file(p))
+    assert result.code == VALID
+    assert not any("namespace mismatch" in w.lower() for w in result.warnings)


### PR DESCRIPTION
## Why

The "can bob pick up a red lego" attempt on 2026-04-25 surfaced **5 separate blockers**, none of which the existing init flow or validate step caught. Operator only discovered them at first motion attempt:

1. `safety.hitl_gates[]` empty — every dispatch runs unauthorized
2. `safety.max_joint_velocity_dps` missing — `load_context` refuses to open the backend
3. `vision.object_descriptors` empty — `vision.find` has nothing to resolve
4. `cameras[].extrinsic` uncalibrated — IK targets unreachable
5. Capability namespace mismatch — manifest declares `manipulate.*` but driver implements `arm.*` → `not_implemented`

This PR closes each gap with BOTH a default-supplier (init scaffolds it) and a detector (validate or compliance status flags it loudly).

## What's new

### 1. `compliance status` first-motion-readiness section

New top-level output section with 5 checks, each with a per-check fix line. Bubbles into the ranked-blockers aggregate as `first-motion: <check>`. Inert (`applies=False`) for pure-sensor manifests.

End-to-end on bob's actual ROBOT.md (the manifest that motivated this work):

```
First-motion readiness
  ✗ hitl_gates                motion capabilities declared but safety.hitl_gates[] is empty
      → Add at least one gate per motion namespace, e.g. `safety.hitl_gates: [{scope: manipulate, require_auth: true}]`
  ✗ max_joint_velocity_dps    actuation driver declared but safety.max_joint_velocity_dps is missing
      → Set safety.max_joint_velocity_dps (e.g. 30 for collaborative arms)
  ✗ object_descriptors        *.pick capability declared but vision.object_descriptors is empty
      → Declare at least one object descriptor under vision.object_descriptors[]
  ✗ camera_extrinsic          vision driver declared but no camera has a calibrated extrinsic
      → Run `robot-md calibrate --hand-eye --marker-pos x,y,z ROBOT.md`
  ✗ capability_namespace      capabilities declare ['manipulate'] but the declared driver(s) implement ['arm', 'perceive', 'status']
      → Either rename capabilities to match the backend namespace or change the driver
```

### 2. Init defaults via `_ensure_first_motion_defaults`

Pure-additive scaffolding in `merge_preset_into_draft`. Never overrides preset/operator-supplied values:

- `safety.hitl_gates` — one default `{scope: <ns>, require_auth: true}` per declared motion namespace (excludes observation-only: `perceive`, `perception`, `status`, `report`, `observe`)
- `safety.max_joint_velocity_dps = 30` (conservative collaborative-arm budget) when any `feetech_scs`/`dynamixel`/`ros2_control` driver
- `vision.object_descriptors` — placeholder pair (red_lego HSV + white_bowl HSV) when any `*.pick` capability

### 3. Validate-time namespace mismatch warning

When `capabilities[]` motion namespaces and declared driver protocol(s) namespaces are disjoint, `robot-md validate` emits a warning explaining `execute_capability` would return `not_implemented` at runtime. Catches bob's gap at init time, not first-motion time.

### 4. `scripts/first-activation.sh` in scaffold

Operator-facing entry point that ties the post-init steps together: validate → compliance status → doctor → calibrate-zero → calibrate hand-eye → final compliance status. Non-destructive; calibration prompts operator. Skip with `SKIP_CALIBRATION=1`.

## Test plan

- [x] 19 new tests across 4 test files
  - `test_compliance_status` +7: section presence, clean, bob's 5 gaps, bubble-up, sensor-inert, fully-ready, text format
  - `test_init` +7: gate scaffold + no-override, velocity-limit default + no-override, descriptor scaffold + no-override, sensor-only inert
  - `test_validate` +2: namespace mismatch warning, no-warn when aligned
  - `test_compliance_scaffold` +3: first-activation executable, template wires 5 steps, relative manifest
- [x] 70/70 pass on the impacted surface (compliance_status, init, validate, compliance_scaffold, examples)
- [x] ruff check + format clean
- [x] End-to-end on bob's actual ROBOT.md surfaces all 5 gaps with fix lines

🤖 Generated with [Claude Code](https://claude.com/claude-code)