### PR TITLE
feat(first-motion-readiness): backend_resolution + device_availability checks

### DIFF
--- a/cli/src/robot_md/compliance_status.py
+++ b/cli/src/robot_md/compliance_status.py
@@ -23,6 +23,8 @@ deterministic and offline.
 from __future__ import annotations
 
 import json
+import shutil
+import subprocess
 import urllib.error
 import urllib.request
 from pathlib import Path
@@ -227,10 +229,89 @@ MOTION_CAPABILITY_NAMESPACES: tuple[str, ...] = ("manipulate", "arm", "nav", "na
 # backends ship.
 BACKEND_NAMESPACES: dict[str, tuple[str, ...]] = {
     "feetech_scs": ("arm", "status"),
+    "feetech": ("arm", "status"),
     "feetech_depthai": ("arm", "perceive", "status"),
+    "depthai": ("perceive",),
     "oak_d_lr": ("perceive",),
     "dynamixel": ("arm", "status"),
 }
+
+# Driver protocols that name an actuator + the path field that holds the
+# device endpoint. Used by the device-availability probe to find what's
+# currently holding a serial port (or other actuator endpoint).
+ACTUATOR_PROTOCOLS_WITH_PORTS: tuple[str, ...] = (
+    "feetech",
+    "feetech_scs",
+    "dynamixel",
+    "ros2_control",
+)
+
+
+def _get_registered_protocols() -> set[str]:
+    """Union of `.protocols` across every registered backend in the entry-point
+    registry. Empty set if backends fail to load — caller treats empty as
+    "can't check, skip the gate". Lazy import to avoid pulling backend deps
+    on machines that only render manifests.
+    """
+    try:
+        from robot_md.backends.registry import BackendRegistry
+    except Exception:
+        return set()
+    try:
+        registry = BackendRegistry.from_entry_points()
+    except Exception:
+        return set()
+    out: set[str] = set()
+    for b in registry.backends:
+        out.update(getattr(b, "protocols", ()) or ())
+    return out
+
+
+_SERIAL_PORT_PATH_PREFIXES: tuple[str, ...] = ("/dev/tty", "/dev/serial/", "/dev/cu.")
+
+
+def _probe_serial_port_holder(port: str) -> dict[str, Any]:
+    """Best-effort: report whether `port` is currently held by another process.
+
+    Returns one of:
+      {"state": "free"}                              — port exists and is unheld
+      {"state": "held", "holders": [{pid, command}]} — held by N process(es)
+      {"state": "missing"}                           — port path does not exist
+      {"state": "skipped", "reason": "..."}          — not a serial-port-shaped
+                                                       path (e.g. /dev/null fixture)
+      {"state": "unknown", "reason": "..."}          — probe couldn't run
+    """
+    if not port:
+        return {"state": "unknown", "reason": "no port declared"}
+    if not any(port.startswith(prefix) for prefix in _SERIAL_PORT_PATH_PREFIXES):
+        return {"state": "skipped", "reason": "not a serial-port path"}
+    if not Path(port).exists():
+        return {"state": "missing"}
+    if shutil.which("lsof") is None:
+        return {"state": "unknown", "reason": "lsof not available"}
+    try:
+        result = subprocess.run(
+            ["lsof", "-Fpc", "--", port],
+            capture_output=True,
+            text=True,
+            timeout=3,
+            check=False,
+        )
+    except (subprocess.TimeoutExpired, OSError) as exc:
+        return {"state": "unknown", "reason": f"lsof failed: {exc!s}"}
+    if result.returncode == 1 and not result.stdout.strip():
+        return {"state": "free"}
+    holders: list[dict[str, str]] = []
+    pid: str | None = None
+    for line in result.stdout.splitlines():
+        if line.startswith("p"):
+            pid = line[1:]
+        elif line.startswith("c") and pid is not None:
+            holders.append({"pid": pid, "command": line[1:]})
+            pid = None
+    if not holders:
+        return {"state": "unknown", "reason": "no holders parsed"}
+    return {"state": "held", "holders": holders}
 
 
 def _check_first_motion_readiness(fm: dict, manifest_path: Path) -> dict[str, Any]:
@@ -304,9 +385,61 @@ def _check_first_motion_readiness(fm: dict, manifest_path: Path) -> dict[str, An
     )
     namespace_ok = not namespace_mismatch
 
+    # 6. Backend resolution — every declared driver protocol must be supplied
+    # by some registered backend. Catches the case where a manifest invents
+    # a friendly protocol name (e.g. "feetech_scs", "oak_d_lr") that no
+    # backend in the entry-point registry actually claims, so dispatch
+    # short-circuits at no_backend before any capability runs.
+    registered_protocols = _get_registered_protocols()
+    if registered_protocols and declared_driver_protocols:
+        unmatched_protocols = sorted(declared_driver_protocols - registered_protocols)
+        backend_resolution_ok = not unmatched_protocols
+    else:
+        # No registered backends loadable in this env, OR no drivers declared.
+        # Skip the gate rather than raise a false alarm.
+        unmatched_protocols = []
+        backend_resolution_ok = True
+
+    # 7. Device availability — at probe time, are the actuator serial ports
+    # already held by another process? Best-effort runtime probe; non-blocking
+    # if lsof is missing or the port doesn't exist yet (operator may calibrate
+    # before plugging in). Reported as a warning-flavored check: held device
+    # = blocker, but missing/unknown = informational.
+    device_probes: list[dict[str, Any]] = []
+    any_held = False
+    for d in drivers:
+        if not isinstance(d, dict):
+            continue
+        if d.get("protocol") not in ACTUATOR_PROTOCOLS_WITH_PORTS:
+            continue
+        port = d.get("port")
+        probe = (
+            _probe_serial_port_holder(port)
+            if isinstance(port, str)
+            else {
+                "state": "unknown",
+                "reason": "non-string port",
+            }
+        )
+        device_probes.append(
+            {"driver_id": d.get("id"), "protocol": d.get("protocol"), "port": port, **probe}
+        )
+        if probe.get("state") == "held":
+            any_held = True
+    device_availability_ok = not any_held
+    device_applies = any(p.get("state") in ("free", "held", "missing") for p in device_probes)
+
     return {
         "applies": has_motion_caps or has_actuation_driver or has_vision_driver,
-        "ready": gates_ok and velocity_ok and descriptors_ok and extrinsic_ok and namespace_ok,
+        "ready": (
+            gates_ok
+            and velocity_ok
+            and descriptors_ok
+            and extrinsic_ok
+            and namespace_ok
+            and backend_resolution_ok
+            and device_availability_ok
+        ),
         "checks": {
             "hitl_gates": {
                 "ok": gates_ok,
@@ -412,6 +545,71 @@ def _check_first_motion_readiness(fm: dict, manifest_path: Path) -> dict[str, An
                         "(e.g. `manipulate.pick` → `arm.pick`) or change the driver"
                     )
                 ),
+            },
+            "backend_resolution": {
+                "ok": backend_resolution_ok,
+                "detail": (
+                    f"all declared protocols match registered backends "
+                    f"({len(declared_driver_protocols)} driver(s))"
+                    if backend_resolution_ok and declared_driver_protocols
+                    else (
+                        "no drivers declared — N/A"
+                        if not declared_driver_protocols
+                        else (
+                            "no registered backends discoverable in this env — skipped"
+                            if not registered_protocols
+                            else (
+                                f"declared driver protocol(s) {unmatched_protocols} "
+                                f"have no registered backend — every execute_capability "
+                                f"call will return no_backend. Registered protocols: "
+                                f"{sorted(registered_protocols)}"
+                            )
+                        )
+                    )
+                ),
+                "fix": (
+                    None
+                    if backend_resolution_ok
+                    else (
+                        f"Rename driver protocol(s) to one of the registered set "
+                        f"{sorted(registered_protocols)} (e.g. `feetech_scs` → `feetech`, "
+                        f"`oak_d_lr` → `depthai`), or install a plugin backend that "
+                        f"registers the missing protocol(s) under the "
+                        f"`robot_md.backends` entry-point group"
+                    )
+                ),
+            },
+            "device_availability": {
+                "ok": device_availability_ok,
+                "detail": (
+                    "no probable serial actuator drivers — N/A"
+                    if not device_applies
+                    else (
+                        "all actuator ports free"
+                        if device_availability_ok
+                        else (
+                            "actuator port(s) currently held: "
+                            + "; ".join(
+                                f"{p['driver_id']}@{p['port']} held by "
+                                + ", ".join(
+                                    f"{h['command']}({h['pid']})" for h in p.get("holders", [])
+                                )
+                                for p in device_probes
+                                if p.get("state") == "held"
+                            )
+                        )
+                    )
+                ),
+                "fix": (
+                    None
+                    if device_availability_ok or not device_applies
+                    else (
+                        "Stop the holding process (e.g. "
+                        "`sudo systemctl stop castor-gateway` for OpenCastor) "
+                        "before invoking robot-md motion"
+                    )
+                ),
+                "probes": device_probes,
             },
         },
     }

--- a/cli/tests/test_compliance_status.py
+++ b/cli/tests/test_compliance_status.py
@@ -40,8 +40,8 @@ safety:
   estop: { software: true, hardware: false, response_ms: 50 }
   max_joint_velocity_dps: 30
   hitl_gates:
-    - { scope: navigate, require_auth: true }
-capabilities: [navigate]
+    - { scope: arm, require_auth: true }
+capabilities: [arm.home]
 ---
 # bob
 """
@@ -316,6 +316,8 @@ def test_first_motion_readiness_section_present(manifest, home):
         "object_descriptors",
         "camera_extrinsic",
         "capability_namespace",
+        "backend_resolution",
+        "device_availability",
     ):
         assert cid in fmr["checks"], f"missing first-motion check: {cid}"
 
@@ -353,6 +355,13 @@ def test_first_motion_readiness_flags_bobs_actual_gaps(bob_not_ready, home):
     # 5. manipulate.* capabilities but feetech_scs implements arm.*
     assert checks["capability_namespace"]["ok"] is False
     assert "manipulate" in checks["capability_namespace"]["detail"]
+    # 6. feetech_scs / oak_d_lr have no registered backend at all (the only
+    # built-in backend exposes feetech + depthai protocols)
+    assert checks["backend_resolution"]["ok"] is False
+    assert (
+        "feetech_scs" in checks["backend_resolution"]["detail"]
+        or "oak_d_lr" in checks["backend_resolution"]["detail"]
+    )
 
 
 def test_first_motion_readiness_bubbles_to_blockers(bob_not_ready, home):
@@ -364,6 +373,7 @@ def test_first_motion_readiness_bubbles_to_blockers(bob_not_ready, home):
         "object_descriptors",
         "camera_extrinsic",
         "capability_namespace",
+        "backend_resolution",
     ):
         assert cid in blocker_text, f"first-motion check {cid} not aggregated into blockers"
 
@@ -416,8 +426,8 @@ physics:
         mount: world
         extrinsic: { R: [[1,0,0],[0,1,0],[0,0,1]], t: [0.0, 0.0, 0.5] }
 drivers:
-  - { id: arm, protocol: feetech_scs, port: /dev/null }
-  - { id: vision, protocol: oak_d_lr, connection: usb }
+  - { id: arm, protocol: feetech, port: /dev/null }
+  - { id: vision, protocol: depthai, connection: usb }
 vision:
   object_descriptors:
     - { id: red_lego, detector: hsv, params: { h: [0, 10] } }
@@ -445,3 +455,141 @@ def test_format_text_includes_first_motion_section(bob_not_ready, home):
     # Each failed check shows its fix line
     assert "hitl_gates" in out
     assert "extrinsic" in out
+
+
+# ---- backend_resolution check (PR follow-up, 2026-04-25) -----------------
+
+
+def test_backend_resolution_passes_for_canonical_protocols(tmp_path, home):
+    """A manifest declaring `feetech` + `depthai` (the canonical protocols
+    the bundled backend registers under) should pass backend_resolution."""
+    p = tmp_path / "ROBOT.md"
+    p.write_text("""\
+---
+rcan_version: "3.2"
+metadata: { robot_name: bob, manufacturer: Acme, model: rx, firmware_version: 1.0.0 }
+physics: { type: arm, dof: 6 }
+drivers:
+  - { id: arm, protocol: feetech, port: /dev/null }
+  - { id: vision, protocol: depthai, connection: usb }
+capabilities: [arm.home]
+safety:
+  estop: { software: true, response_ms: 50 }
+  max_joint_velocity_dps: 30
+  hitl_gates: [{ scope: arm, require_auth: true }]
+---
+""")
+    s = gather_status(p, network_probe=False)
+    assert s["first_motion_readiness"]["checks"]["backend_resolution"]["ok"] is True
+
+
+def test_backend_resolution_flags_unregistered_protocols(tmp_path, home):
+    """`feetech_scs` and `oak_d_lr` look reasonable but aren't claimed by any
+    registered backend — the bundled `FeetechDepthaiBackend.protocols` is
+    `{feetech, depthai}`. Dispatch will fail at no_backend, so this is a
+    first-motion blocker."""
+    p = tmp_path / "ROBOT.md"
+    p.write_text("""\
+---
+rcan_version: "3.2"
+metadata: { robot_name: bob, manufacturer: Acme, model: rx, firmware_version: 1.0.0 }
+physics: { type: arm, dof: 6 }
+drivers:
+  - { id: arm, protocol: feetech_scs, port: /dev/null }
+  - { id: vision, protocol: oak_d_lr, connection: usb }
+capabilities: [arm.home]
+safety:
+  estop: { software: true, response_ms: 50 }
+  max_joint_velocity_dps: 30
+  hitl_gates: [{ scope: arm, require_auth: true }]
+---
+""")
+    s = gather_status(p, network_probe=False)
+    check = s["first_motion_readiness"]["checks"]["backend_resolution"]
+    assert check["ok"] is False
+    assert "feetech_scs" in check["detail"] and "oak_d_lr" in check["detail"]
+    # Fix-line names canonical replacements
+    assert "feetech" in check["fix"] and "depthai" in check["fix"]
+
+
+# ---- device_availability check (PR follow-up, 2026-04-25) ----------------
+
+
+def test_device_availability_skipped_for_dev_null(manifest, home):
+    """BOB_MIN uses `port: /dev/null` as a fixture sentinel — the probe
+    should skip non-serial-port-shaped paths so existing tests don't trip."""
+    s = gather_status(manifest, network_probe=False)
+    check = s["first_motion_readiness"]["checks"]["device_availability"]
+    assert check["ok"] is True
+    # Probe ran but skipped the non-tty path
+    probes = check.get("probes", [])
+    assert any(p.get("state") == "skipped" for p in probes), (
+        f"expected at least one skipped probe; got {probes}"
+    )
+
+
+def test_device_availability_reports_missing_for_nonexistent_tty(tmp_path, home):
+    """If the manifest names a /dev/tty* path that doesn't exist, the probe
+    reports 'missing' (operator may not have plugged in yet) — not a blocker."""
+    p = tmp_path / "ROBOT.md"
+    p.write_text("""\
+---
+rcan_version: "3.2"
+metadata: { robot_name: bob, manufacturer: Acme, model: rx, firmware_version: 1.0.0 }
+physics: { type: arm, dof: 6 }
+drivers:
+  - { id: arm, protocol: feetech, port: /dev/ttyDOES_NOT_EXIST_99 }
+capabilities: [arm.home]
+safety:
+  estop: { software: true, response_ms: 50 }
+  max_joint_velocity_dps: 30
+  hitl_gates: [{ scope: arm, require_auth: true }]
+---
+""")
+    s = gather_status(p, network_probe=False)
+    check = s["first_motion_readiness"]["checks"]["device_availability"]
+    # Missing port is informational, not a blocker
+    assert check["ok"] is True
+    probes = check.get("probes", [])
+    assert any(pr.get("state") == "missing" for pr in probes), probes
+
+
+def test_device_availability_detects_held_serial_port(tmp_path, home, monkeypatch):
+    """When a serial port is held, the probe surfaces the holder + fix line."""
+    p = tmp_path / "ROBOT.md"
+    p.write_text("""\
+---
+rcan_version: "3.2"
+metadata: { robot_name: bob, manufacturer: Acme, model: rx, firmware_version: 1.0.0 }
+physics: { type: arm, dof: 6 }
+drivers:
+  - { id: arm, protocol: feetech, port: /dev/ttyTEST_FAKE }
+capabilities: [arm.home]
+safety:
+  estop: { software: true, response_ms: 50 }
+  max_joint_velocity_dps: 30
+  hitl_gates: [{ scope: arm, require_auth: true }]
+---
+""")
+
+    # Stub the probe to simulate a held port — avoids needing a real holder
+    # and keeps the test deterministic across OS/lsof variants.
+    from robot_md import compliance_status as cs
+
+    def _fake_probe(port: str) -> dict:
+        if port == "/dev/ttyTEST_FAKE":
+            return {
+                "state": "held",
+                "holders": [{"pid": "12345", "command": "castor"}],
+            }
+        return {"state": "skipped", "reason": "not under test"}
+
+    monkeypatch.setattr(cs, "_probe_serial_port_holder", _fake_probe)
+
+    s = gather_status(p, network_probe=False)
+    check = s["first_motion_readiness"]["checks"]["device_availability"]
+    assert check["ok"] is False
+    assert "castor" in check["detail"] and "12345" in check["detail"]
+    assert "stop" in check["fix"].lower()
+    # Bubbles into ranked blockers
+    assert any("device_availability" in b for b in s["blockers"])


### PR DESCRIPTION
## Summary

PR #8 shipped a 5-check first-motion-readiness pre-flight. Bob's first-pick attempt on 2026-04-25 then surfaced two more gaps the static checks missed:

1. **`backend_resolution`** — bob's manifest declared driver protocols `feetech_scs` + `oak_d_lr`. The static `BACKEND_NAMESPACES` lookup said "namespace alignment OK" because it knows those protocol names map to arm/perceive namespaces. But the actual `BackendRegistry` only registers `{feetech, depthai}` — so `execute_capability` returned `no_backend` long before reaching IK. The new check compares declared driver protocols against `BackendRegistry.protocols` union and flags any that have no registered backend.
2. **`device_availability`** — best-effort lsof probe of actuator serial ports. Surfaces the holder (e.g. `castor` PID 1593 holding `/dev/ttyACM0`) plus a fix line. Non-tty paths (`/dev/null` fixtures) are skipped so unit tests don't false-positive. Probes return `state ∈ {free, held, missing, skipped, unknown}` and only `held` flips the gate.

Both wire into `_check_first_motion_readiness` return + format text + `_aggregate_blockers` (the existing blocker iteration is generic, so new check IDs bubble automatically). Adds canonical `feetech` + `depthai` to `BACKEND_NAMESPACES` so the namespace-alignment check agrees with the registry.

## Detection at a glance

| Operator says | Pre-`#8` | Post-`#8` | Post-this-PR |
|---|---|---|---|
| `manipulate.pick` with empty `hitl_gates` | runtime | ✓ caught | ✓ caught |
| `feetech_scs` driver (no registered backend) | runtime | ✗ missed | ✓ caught (`backend_resolution`) |
| `/dev/ttyACM0` held by another process | runtime | ✗ missed | ✓ caught (`device_availability`) |

## Test plan

- [x] 25/25 in `cli/tests/test_compliance_status.py` pass locally
- [x] `ruff check` clean, `ruff format --check` clean
- [x] 7 new tests cover: canonical-protocols pass, unregistered-protocols flagged, BOB_NOT_READY's exact 6th gap surfaces, `/dev/null` fixture skipped, missing-ttypath reported informational, monkeypatched-held probe bubbles to blockers
- [ ] CI green

## Out of scope

- DepthAI runtime probe (`Device.getAllAvailableDevices()`) for vision drivers — separate PR; needs more care around side-effects.
- Updating `validate.py`'s separate `driver_namespace_map` to delegate to the registry — same problem in two places, but bigger refactor.

🤖 Generated with [Claude Code](https://claude.com/claude-code)