### PR TITLE
fix + feat(first-motion-readiness): 2 production bugs + 4 calibration-prereq checks + --yes

### DIFF
--- a/cli/src/robot_md/__main__.py
+++ b/cli/src/robot_md/__main__.py
@@ -1709,6 +1709,16 @@ def calibrate(
         "--extrinsic",
         help="Calibrate camera-to-arm extrinsic via gripper silhouette.",
     ),
+    yes: bool = typer.Option(
+        False,
+        "--yes",
+        "-y",
+        help=(
+            "Skip interactive prompts (assume yes). For --extrinsic this auto-"
+            "confirms both the initial 'arm will move' prompt and the high-"
+            "residual acceptance prompt. Required when invoking from a script."
+        ),
+    ),
     hand_eye: bool = typer.Option(
         False,
         "--hand-eye",
@@ -1784,7 +1794,9 @@ def calibrate(
                 cam = None
         except Exception as e:
             typer.echo(f"could not load manifest: {e}", err=True)
-        result = phase_calibrate_extrinsic(path, bus=bus, camera=cam, interactive=True)
+        result = phase_calibrate_extrinsic(
+            path, bus=bus, camera=cam, interactive=True, auto_yes=yes
+        )
         typer.echo(result.message)
         if bus is not None:
             with contextlib.suppress(Exception):

--- a/cli/src/robot_md/compliance_status.py
+++ b/cli/src/robot_md/compliance_status.py
@@ -429,6 +429,50 @@ def _check_first_motion_readiness(fm: dict, manifest_path: Path) -> dict[str, An
     device_availability_ok = not any_held
     device_applies = any(p.get("state") in ("free", "held", "missing") for p in device_probes)
 
+    # 8. Workspace bounds_mm required for IK envelope sampling. `calibrate
+    # --extrinsic`'s plan_sweep keys directly into
+    # `physics.workspace.bounds_mm` and KeyErrors when only `reach_mm` is
+    # declared. The IK target reachability check needs it too. Required
+    # whenever motion capabilities are declared.
+    workspace = physics.get("workspace") or {}
+    bounds_mm = workspace.get("bounds_mm") or {}
+    has_xyz_bounds = all(k in bounds_mm for k in ("x", "y", "z"))
+    workspace_bounds_ok = (not has_motion_caps) or has_xyz_bounds
+
+    # 9. Kinematics chain length must match dof. IK + FK + plan_sweep all
+    # iterate `physics.kinematics[]`; len < dof produces silent IK failures
+    # downstream. Manifests that copied a preset usually pass; hand-rolled
+    # ones often miss the kinematics block entirely.
+    declared_dof = int(physics.get("dof") or 0)
+    kinematics_entries = physics.get("kinematics") or []
+    kinematics_len = len(kinematics_entries) if isinstance(kinematics_entries, list) else 0
+    kinematics_ok = (not has_motion_caps) or (declared_dof == 0 or kinematics_len >= declared_dof)
+
+    # 10. Solver block required for IK when motion capabilities exist.
+    # Needs at minimum `ik_provider` and (for vision-aided motion) `cameras`.
+    solver_has_ik = bool(solver.get("ik_provider"))
+    solver_has_cameras = isinstance(solver.get("cameras"), list) and bool(solver.get("cameras"))
+    solver_ok = not has_motion_caps or (
+        solver_has_ik and (not has_vision_driver or solver_has_cameras)
+    )
+
+    # 11. Joint zero / sign calibration. SO-ARM101's preset ships
+    # `zero_pose_steps: 2048` (servo midpoint) and `encoder_sign: 1` for
+    # every joint as TODO defaults. With those, `calibrate --extrinsic`'s
+    # FK reference is systematically biased and the optimization can't
+    # converge below ~150-220mm residual regardless of detector quality.
+    # Warn before extrinsic calibration is even attempted.
+    needs_zero_sign = False
+    if has_motion_caps and isinstance(kinematics_entries, list):
+        for k in kinematics_entries:
+            if not isinstance(k, dict):
+                continue
+            # 2048 = exactly servo midpoint, the canonical preset stub.
+            if k.get("zero_pose_steps") == 2048:
+                needs_zero_sign = True
+                break
+    zero_sign_ok = not needs_zero_sign
+
     return {
         "applies": has_motion_caps or has_actuation_driver or has_vision_driver,
         "ready": (
@@ -439,6 +483,10 @@ def _check_first_motion_readiness(fm: dict, manifest_path: Path) -> dict[str, An
             and namespace_ok
             and backend_resolution_ok
             and device_availability_ok
+            and workspace_bounds_ok
+            and kinematics_ok
+            and solver_ok
+            and zero_sign_ok
         ),
         "checks": {
             "hitl_gates": {
@@ -610,6 +658,110 @@ def _check_first_motion_readiness(fm: dict, manifest_path: Path) -> dict[str, An
                     )
                 ),
                 "probes": device_probes,
+            },
+            "workspace_bounds_mm": {
+                "ok": workspace_bounds_ok,
+                "detail": (
+                    "no motion capabilities — N/A"
+                    if not has_motion_caps
+                    else (
+                        "bounds_mm declared on x/y/z"
+                        if workspace_bounds_ok
+                        else (
+                            "physics.workspace.bounds_mm missing or incomplete — "
+                            "calibrate --extrinsic and IK envelope sampling both "
+                            "need x/y/z ranges"
+                        )
+                    )
+                ),
+                "fix": (
+                    None
+                    if workspace_bounds_ok
+                    else (
+                        "Add physics.workspace.bounds_mm with x, y, z ranges "
+                        "(e.g. `bounds_mm: {x: [-200, 340], y: [-340, 340], z: [0, 250]}`)"
+                    )
+                ),
+            },
+            "kinematics_complete": {
+                "ok": kinematics_ok,
+                "detail": (
+                    "no motion capabilities — N/A"
+                    if not has_motion_caps
+                    else (
+                        f"{kinematics_len} joints declared (dof={declared_dof})"
+                        if kinematics_ok
+                        else (
+                            f"physics.kinematics has {kinematics_len} joints but "
+                            f"physics.dof = {declared_dof} — IK + FK iterate "
+                            f"kinematics[] and silently produce wrong answers when short"
+                        )
+                    )
+                ),
+                "fix": (
+                    None
+                    if kinematics_ok
+                    else (
+                        f"Declare {declared_dof} joints under physics.kinematics[] "
+                        f"with id/axis/limits_deg/a_mm/d_mm/servo_id/encoder_sign/"
+                        f"zero_pose_steps. Copy from a matching preset (e.g. so_arm101) "
+                        f"if available."
+                    )
+                ),
+            },
+            "solver_block": {
+                "ok": solver_ok,
+                "detail": (
+                    "no motion capabilities — N/A"
+                    if not has_motion_caps
+                    else (
+                        "solver block populated"
+                        if solver_ok
+                        else (
+                            "physics.solver missing ik_provider"
+                            if not solver_has_ik
+                            else (
+                                "vision driver declared but solver.cameras[] is empty — "
+                                "camera-to-base transform can't be applied"
+                            )
+                        )
+                    )
+                ),
+                "fix": (
+                    None
+                    if solver_ok
+                    else (
+                        "Add physics.solver with `ik_provider` and (when a vision "
+                        "driver is present) `cameras: [{driver_id, primary_stream, "
+                        "mount, extrinsic_source}]`. Copy from a matching preset."
+                    )
+                ),
+            },
+            "joint_zero_sign": {
+                "ok": zero_sign_ok,
+                "detail": (
+                    "no motion capabilities — N/A"
+                    if not has_motion_caps
+                    else (
+                        "zero_pose_steps and encoder_sign appear operator-calibrated"
+                        if zero_sign_ok
+                        else (
+                            "one or more joints still at preset-default "
+                            "zero_pose_steps=2048 — calibrate --extrinsic's FK "
+                            "reference will be biased and the optimization can't "
+                            "converge below ~150-220mm residual"
+                        )
+                    )
+                ),
+                "fix": (
+                    None
+                    if zero_sign_ok
+                    else (
+                        "Run `robot-md calibrate --zero ROBOT.md` (pose arm at zero "
+                        "config, press Enter) and `robot-md calibrate --sign ROBOT.md` "
+                        "(per-joint y/n) BEFORE `robot-md calibrate --extrinsic`"
+                    )
+                ),
             },
         },
     }

--- a/cli/src/robot_md/init.py
+++ b/cli/src/robot_md/init.py
@@ -351,17 +351,37 @@ def _ensure_first_motion_defaults(fm: dict[str, Any]) -> None:
         vision = fm.setdefault("vision", {})
         descriptors = vision.setdefault("object_descriptors", [])
         if not descriptors:
+            # Match the keys read by detectors/hsv.py: `h_ranges` (list of
+            # [lo, hi] pairs), `s_min`/`s_max`/`v_min`/`v_max`. Wrong keys
+            # silently fall back to "match every saturated pixel" — the
+            # centroid lands at image center and dispatch resolves to
+            # whatever pixel happens to sit behind that.
             descriptors.extend(
                 [
                     {
                         "id": "red_lego",
                         "detector": "hsv",
-                        "params": {"h": [0, 10], "s": [120, 255], "v": [80, 255]},
+                        # Red wraps both ends of the HSV hue circle.
+                        "params": {
+                            "h_ranges": [[0, 10], [170, 180]],
+                            "s_min": 120,
+                            "s_max": 255,
+                            "v_min": 80,
+                            "v_max": 255,
+                            "min_area": 200,
+                        },
                     },
                     {
                         "id": "white_bowl",
                         "detector": "hsv",
-                        "params": {"h": [0, 180], "s": [0, 60], "v": [180, 255]},
+                        "params": {
+                            "h_ranges": [[0, 180]],
+                            "s_min": 0,
+                            "s_max": 60,
+                            "v_min": 180,
+                            "v_max": 255,
+                            "min_area": 1000,
+                        },
                     },
                 ]
             )

--- a/cli/src/robot_md/init_phases/calibrate_extrinsic.py
+++ b/cli/src/robot_md/init_phases/calibrate_extrinsic.py
@@ -23,9 +23,14 @@ def phase_calibrate_extrinsic(
     camera: Any | None,
     interactive: bool = True,
     n_poses: int = 6,
+    auto_yes: bool = False,
 ) -> PhaseResult:
     """Opt-in init phase; writes `extrinsic_source: gripper_silhouette_calibrated`
     plus the computed 6-vec back into the manifest on success.
+
+    `auto_yes=True` (passed by the CLI when `--yes` is set) skips both
+    interactive prompts: the initial "arm will move through N poses"
+    confirmation AND the high-residual acceptance prompt at the end.
     """
     if not interactive:
         return PhaseResult(
@@ -73,17 +78,20 @@ def phase_calibrate_extrinsic(
             detail={"reason": "already_calibrated", "source": source},
         )
 
-    answer = (
-        (
-            input(
-                "Calibrate camera-to-arm alignment now? The arm will move through "
-                f"{n_poses} poses. [Y/n] "
+    if auto_yes:
+        answer = "y"
+    else:
+        answer = (
+            (
+                input(
+                    "Calibrate camera-to-arm alignment now? The arm will move through "
+                    f"{n_poses} poses. [Y/n] "
+                )
+                or "y"
             )
-            or "y"
+            .strip()
+            .lower()
         )
-        .strip()
-        .lower()
-    )
     if answer.startswith("n"):
         return PhaseResult(
             phase="calibrate_extrinsic",
@@ -172,11 +180,14 @@ def phase_calibrate_extrinsic(
 
         six_vec, residual = solve(samples)
         if residual > 15.0:
-            ans = (
-                (input(f"Calibration residual {residual:.1f}mm is high. Accept? [y/N] ") or "n")
-                .strip()
-                .lower()
-            )
+            if auto_yes:
+                ans = "y"
+            else:
+                ans = (
+                    (input(f"Calibration residual {residual:.1f}mm is high. Accept? [y/N] ") or "n")
+                    .strip()
+                    .lower()
+                )
             if not ans.startswith("y"):
                 return PhaseResult(
                     phase="calibrate_extrinsic",

--- a/cli/src/robot_md/mcp/tools/vision_find.py
+++ b/cli/src/robot_md/mcp/tools/vision_find.py
@@ -49,7 +49,10 @@ def vision_find_tool(ctx: Any, *, descriptor_id: str) -> dict:
     patch = depth[max(0, v - r) : min(h, v + r + 1), max(0, u - r) : min(w, u + r + 1)].astype(
         np.float32
     )
-    valid = patch[patch > 0]
+    # Filter out OAK-D's 65535 "no data" sentinel — without this, sparse
+    # valid pixels in a textureless patch are dwarfed by the saturated
+    # background and the median lands at ~15m even for objects at 40cm.
+    valid = patch[(patch > 0) & (patch < 10000)]
     depth_mm = float(np.median(valid)) if valid.size else float("nan")
     xyz = _pixel_to_3d(u, v, depth_mm, K)
     return {

--- a/cli/tests/test_compliance_status.py
+++ b/cli/tests/test_compliance_status.py
@@ -1,3 +1,6 @@
+# ruff: noqa: E501  -- YAML test fixtures (kinematics entries) are flow-style
+# one-liners; splitting them across multiple lines hurts readability for the
+# small diff this saves.
 """Tests for `robot-md compliance status` — the one-shot pre-flight check.
 
 Pulls together: manifest, keystore, audit chain, incidents log, on-disk
@@ -33,7 +36,16 @@ metadata:
   rrn: RRN-000000000099
 network:
   rrf_endpoint: https://robotregistryfoundation.org
-physics: { type: arm, dof: 6 }
+physics:
+  type: arm
+  dof: 2
+  workspace:
+    bounds_mm: { x: [0, 300], y: [-200, 200], z: [0, 250] }
+  solver:
+    ik_provider: stub
+  kinematics:
+    - { id: j1, axis: z, limits_deg: [-180, 180], a_mm: 0, d_mm: 60, servo_id: 1, encoder_sign: 1, zero_pose_steps: 1500 }
+    - { id: j2, axis: y, limits_deg: [-90, 90], a_mm: 100, d_mm: 0, servo_id: 2, encoder_sign: 1, zero_pose_steps: 2200 }
 drivers:
   - { id: arm, protocol: feetech, port: /dev/null }
 safety:
@@ -318,6 +330,10 @@ def test_first_motion_readiness_section_present(manifest, home):
         "capability_namespace",
         "backend_resolution",
         "device_availability",
+        "workspace_bounds_mm",
+        "kinematics_complete",
+        "solver_block",
+        "joint_zero_sign",
     ):
         assert cid in fmr["checks"], f"missing first-motion check: {cid}"
 
@@ -374,6 +390,9 @@ def test_first_motion_readiness_bubbles_to_blockers(bob_not_ready, home):
         "camera_extrinsic",
         "capability_namespace",
         "backend_resolution",
+        "workspace_bounds_mm",
+        "kinematics_complete",
+        "solver_block",
     ):
         assert cid in blocker_text, f"first-motion check {cid} not aggregated into blockers"
 
@@ -418,19 +437,25 @@ network:
   rrf_endpoint: https://robotregistryfoundation.org
 physics:
   type: arm
-  dof: 6
+  dof: 2
+  workspace:
+    bounds_mm: { x: [0, 300], y: [-200, 200], z: [0, 250] }
   solver:
+    ik_provider: stub
     cameras:
       - driver_id: cam
         primary_stream: rgb
         mount: world
         extrinsic: { R: [[1,0,0],[0,1,0],[0,0,1]], t: [0.0, 0.0, 0.5] }
+  kinematics:
+    - { id: j1, axis: z, limits_deg: [-180, 180], a_mm: 0, d_mm: 60, servo_id: 1, encoder_sign: 1, zero_pose_steps: 1500 }
+    - { id: j2, axis: y, limits_deg: [-90, 90], a_mm: 100, d_mm: 0, servo_id: 2, encoder_sign: 1, zero_pose_steps: 2200 }
 drivers:
   - { id: arm, protocol: feetech, port: /dev/null }
   - { id: vision, protocol: depthai, connection: usb }
 vision:
   object_descriptors:
-    - { id: red_lego, detector: hsv, params: { h: [0, 10] } }
+    - { id: red_lego, detector: hsv, params: { h_ranges: [[0, 10]], s_min: 120 } }
 capabilities:
   - arm.pick
   - arm.place
@@ -593,3 +618,118 @@ safety:
     assert "stop" in check["fix"].lower()
     # Bubbles into ranked blockers
     assert any("device_availability" in b for b in s["blockers"])
+
+
+# ---- workspace_bounds_mm / kinematics / solver / joint_zero_sign (PR follow-up-2, 2026-04-25) ---
+
+
+_MOTION_HEAD = """\
+---
+rcan_version: "3.2"
+metadata: { robot_name: t, manufacturer: A, model: m, firmware_version: 1.0.0 }
+"""
+_MOTION_TAIL = """\
+drivers:
+  - { id: arm, protocol: feetech, port: /dev/null }
+capabilities: [arm.home]
+safety:
+  estop: { software: true, response_ms: 50 }
+  max_joint_velocity_dps: 30
+  hitl_gates: [{ scope: arm, require_auth: true }]
+---
+"""
+
+
+def _write(path, physics_yaml: str) -> None:
+    path.write_text(_MOTION_HEAD + physics_yaml + _MOTION_TAIL)
+
+
+def test_workspace_bounds_mm_flags_missing_bounds(tmp_path, home):
+    """`calibrate --extrinsic` keys into physics.workspace.bounds_mm; missing
+    it KeyErrors at calibration time. The pre-flight should refuse first."""
+    p = tmp_path / "ROBOT.md"
+    _write(p, "physics: { type: arm, dof: 2, workspace: { reach_mm: 400 } }\n")
+    s = gather_status(p, network_probe=False)
+    check = s["first_motion_readiness"]["checks"]["workspace_bounds_mm"]
+    assert check["ok"] is False
+    assert "bounds_mm" in check["detail"] and "bounds_mm" in check["fix"]
+
+
+def test_kinematics_complete_flags_short_chain(tmp_path, home):
+    """dof=6 but only 2 kinematics entries → IK + FK silently produce wrong
+    answers. Pre-flight should refuse."""
+    p = tmp_path / "ROBOT.md"
+    _write(
+        p,
+        """physics:
+  type: arm
+  dof: 6
+  workspace: { bounds_mm: { x: [0, 300], y: [-200, 200], z: [0, 250] } }
+  solver: { ik_provider: stub }
+  kinematics:
+    - { id: j1, axis: z, limits_deg: [-180, 180], a_mm: 0, d_mm: 60, servo_id: 1, encoder_sign: 1, zero_pose_steps: 1500 }
+    - { id: j2, axis: y, limits_deg: [-90, 90], a_mm: 100, d_mm: 0, servo_id: 2, encoder_sign: 1, zero_pose_steps: 2200 }
+""",
+    )
+    s = gather_status(p, network_probe=False)
+    check = s["first_motion_readiness"]["checks"]["kinematics_complete"]
+    assert check["ok"] is False
+    assert "2" in check["detail"] and "6" in check["detail"]
+
+
+def test_solver_block_flags_missing_ik_provider(tmp_path, home):
+    p = tmp_path / "ROBOT.md"
+    _write(
+        p,
+        """physics:
+  type: arm
+  dof: 1
+  workspace: { bounds_mm: { x: [0, 300], y: [-200, 200], z: [0, 250] } }
+  kinematics:
+    - { id: j1, axis: z, limits_deg: [-180, 180], a_mm: 0, d_mm: 60, servo_id: 1, encoder_sign: 1, zero_pose_steps: 1500 }
+""",
+    )
+    s = gather_status(p, network_probe=False)
+    check = s["first_motion_readiness"]["checks"]["solver_block"]
+    assert check["ok"] is False
+    assert "ik_provider" in check["detail"]
+
+
+def test_joint_zero_sign_flags_default_zeros(tmp_path, home):
+    """zero_pose_steps still at servo midpoint 2048 → calibration won't
+    converge. Pre-flight should refuse to run --extrinsic."""
+    p = tmp_path / "ROBOT.md"
+    _write(
+        p,
+        """physics:
+  type: arm
+  dof: 1
+  workspace: { bounds_mm: { x: [0, 300], y: [-200, 200], z: [0, 250] } }
+  solver: { ik_provider: stub }
+  kinematics:
+    - { id: j1, axis: z, limits_deg: [-180, 180], a_mm: 0, d_mm: 60, servo_id: 1, encoder_sign: 1, zero_pose_steps: 2048 }
+""",
+    )
+    s = gather_status(p, network_probe=False)
+    check = s["first_motion_readiness"]["checks"]["joint_zero_sign"]
+    assert check["ok"] is False
+    assert "2048" in check["detail"] or "preset-default" in check["detail"]
+    assert "calibrate --zero" in check["fix"]
+
+
+def test_joint_zero_sign_clean_when_calibrated(tmp_path, home):
+    """Non-2048 zero_pose_steps → operator has run --zero. Check passes."""
+    p = tmp_path / "ROBOT.md"
+    _write(
+        p,
+        """physics:
+  type: arm
+  dof: 1
+  workspace: { bounds_mm: { x: [0, 300], y: [-200, 200], z: [0, 250] } }
+  solver: { ik_provider: stub }
+  kinematics:
+    - { id: j1, axis: z, limits_deg: [-180, 180], a_mm: 0, d_mm: 60, servo_id: 1, encoder_sign: 1, zero_pose_steps: 1837 }
+""",
+    )
+    s = gather_status(p, network_probe=False)
+    assert s["first_motion_readiness"]["checks"]["joint_zero_sign"]["ok"] is True

--- a/cli/tests/test_init.py
+++ b/cli/tests/test_init.py
@@ -349,6 +349,34 @@ def test_first_motion_defaults_descriptors_from_pick_capability():
     assert "white_bowl" in ids
 
 
+def test_first_motion_defaults_descriptors_use_correct_param_keys():
+    """The HSV detector reads `h_ranges` (list of [lo, hi] pairs), `s_min`,
+    `s_max`, `v_min`, `v_max` — NOT `h`/`s`/`v` with list values. Wrong keys
+    silently fall back to "match every saturated pixel" so the centroid
+    lands at image center and dispatch resolves to whatever happens to be
+    behind it (production bug observed during bob's first-pick attempt
+    2026-04-25)."""
+    preset = _bare_preset(
+        physics={"type": "arm", "dof": 6},
+        drivers=[{"id": "arm", "protocol": "feetech_scs"}],
+        capabilities=["arm.pick"],
+        safety={"estop": {"software": True, "response_ms": 50}},
+    )
+    fm = merge_preset_into_draft(preset, "bot", _Scan())
+    by_id = {d["id"]: d for d in fm["vision"]["object_descriptors"]}
+    for desc_id in ("red_lego", "white_bowl"):
+        params = by_id[desc_id]["params"]
+        # The shape the detector actually reads
+        assert "h_ranges" in params, f"{desc_id} missing h_ranges"
+        assert isinstance(params["h_ranges"], list)
+        assert all(isinstance(pair, list) and len(pair) == 2 for pair in params["h_ranges"])
+        assert "s_min" in params and "s_max" in params
+        assert "v_min" in params and "v_max" in params
+        # NOT the broken shape from the original PR #8 scaffold
+        assert "h" not in params, f"{desc_id} still has bare 'h' key"
+        assert "s" not in params, f"{desc_id} still has bare 's' key"
+
+
 def test_first_motion_defaults_does_not_override_preset_descriptors():
     """If preset already declares descriptors, init keeps them verbatim."""
     preset = _bare_preset(

--- a/cli/tests/unit/test_vision_find_tool.py
+++ b/cli/tests/unit/test_vision_find_tool.py
@@ -174,3 +174,48 @@ def test_vision_find_depth_patch_is_clamped():
     assert abs(r["depth_mm"] - 500) < 50, (
         f"depth_mm={r['depth_mm']} — radius clamp missing? patch may be sampling background."
     )
+
+
+def test_vision_find_filters_oak_d_no_data_sentinel():
+    """OAK-D's stereo depth fills textureless surfaces (lego, bowl) with the
+    65535mm 'no data' sentinel. Without filtering, the patch median around
+    the centroid is dominated by saturated values and depth lands at ~15m
+    even when valid neighboring pixels are at 40cm."""
+    rgb = np.zeros((200, 300, 3), dtype=np.uint8)
+    rgb[:] = (240, 240, 240)
+    cv2.rectangle(rgb, (120, 60), (180, 120), (40, 40, 220), -1)
+    # Depth: most of the patch around the red blob is saturated (65535).
+    # A few scattered valid pixels (within the patch) at 400mm — the
+    # legitimate depth of the textureless lego surface gleaned from edges.
+    depth = np.full((200, 300), 65535, dtype=np.uint16)
+    depth[80:85, 145:155] = 400  # small valid patch inside the blob
+    K = np.array([[500.0, 0, 150.0], [0, 500.0, 100.0], [0, 0, 1.0]])
+
+    per = MagicMock()
+    per.grab_frame.return_value = (rgb, depth, K)
+    backend = MagicMock()
+    backend._perception = per
+
+    spec = MagicMock()
+    spec.vision = VisionBlock(
+        object_descriptors=(
+            ObjectDescriptor(
+                id="red_lego",
+                detector="hsv",
+                params={"h_ranges": [[0, 10], [170, 180]], "s_min": 80, "v_min": 80},
+            ),
+        )
+    )
+    ctx = MagicMock()
+    ctx.backend = backend
+    ctx.spec = spec
+
+    r = vision_find_tool(ctx, descriptor_id="red_lego")
+    assert r["status"] == "ok"
+    # If the saturation filter is broken, depth_mm would be ~65535 (or its
+    # median with a few 400s mixed in: still >>10000). With the filter,
+    # depth_mm should be near 400.
+    assert r["depth_mm"] < 1000, (
+        f"depth filter broken — saturation values pulled median to {r['depth_mm']}mm"
+    )
+    assert 350 < r["depth_mm"] < 500


### PR DESCRIPTION
## Summary

Bob's first-pick attempt on 2026-04-25 surfaced **six more issues** after PRs #8 and #9 shipped, all blocking real-hardware first-motion. Two are production bugs; four are pre-flight gaps; one is a CLI ergonomics fix. This PR ships all seven.

### Production bugs

1. **`vision_find` depth patch doesn't filter OAK-D's 65535mm sentinel.** On textureless surfaces where stereo depth fails, valid neighboring pixels in the 15px patch are dwarfed by saturated values and depth lands at ~15m even when the object is at 40cm. One-line fix: `(patch > 0) & (patch < 10000)`.

2. **`init` HSV descriptor scaffold uses the wrong YAML keys.** Bob's manifest had `h: [0, 10]`, `s: [120, 255]` but the detector reads `h_ranges: [[0, 10]]`, `s_min: 120`, `s_max: 255`. Wrong keys silently fall back to "match every saturated pixel" — centroid lands at image center, dispatch resolves to whatever happens to sit behind the center pixel. PR #8 shipped this broken scaffold; this PR fixes both keys and adds the canonical second hue range for red `[170, 180]`.

### New pre-flight checks (extends `_check_first_motion_readiness`)

| Check ID | Catches |
|---|---|
| `workspace_bounds_mm` | `calibrate --extrinsic`'s plan_sweep KeyErrors when only `reach_mm` is declared |
| `kinematics_complete` | `len(physics.kinematics) < physics.dof` — IK + FK silently produce wrong answers |
| `solver_block` | `solver.ik_provider` missing, or vision driver declared but `solver.cameras[]` empty |
| `joint_zero_sign` | One or more joints still at preset-default `zero_pose_steps: 2048` — `--extrinsic`'s FK reference is biased and the optimization can't converge below ~150-220mm residual |

The `joint_zero_sign` check is the most consequential: it tells operators the truth that pure-camera-only extrinsic calibration cannot fix bias from miscalibrated joint zeros, no matter how many runs. Before this check, an operator could spin on `--extrinsic` indefinitely, accepting high-residual results that produce unreachable IK targets.

### CLI ergonomics

`robot-md calibrate --yes / -y` — bypasses `--extrinsic`'s two interactive prompts (initial confirmation + high-residual acceptance). Required when invoking from a script or non-interactive CI; the workaround `printf "y\ny\n" | robot-md calibrate --extrinsic` breaks when the residual prompt doesn't fire.

## End-to-end verification

Against bob's hand-rolled manifest 2026-04-25 (post-`--zero` + `--sign` calibration), with all six fixes applied:
- Pipeline reaches IK layer and returns specific joint-limit errors (no longer architecturally blocked)
- `vision.find` returns sane camera-frame coordinates (375mm depth instead of 15643mm)
- `compliance status` flags exactly the four prerequisites still missing in a fresh manifest
- The remaining gap is purely physical: SO-ARM101's ±90° joint limits vs object position

## Test plan

- [x] 39/39 in `test_compliance_status.py` + `test_vision_find_tool.py` pass locally
- [x] 3/3 descriptor-scaffold tests in `test_init.py` pass
- [x] `ruff check` clean, `ruff format --check` clean
- [x] BOB_MIN + BOB_NOT_READY + the "passes when 5 gaps filled" fixture all updated for the 4 new checks
- [ ] CI green

## Out of scope

- The phase function defaults to motion-delta detection; `capture_via_wrist_wiggle` shipped in the same module gives 30% lower residuals but isn't wired in. Separate PR.
- Joint limits ±90° are physical-servo-conservative; SO-ARM101 likely supports wider safely. Tracked for hardware-validation work.

🤖 Generated with [Claude Code](https://claude.com/claude-code)