### PR TITLE
feat(init): voice_setup phase (audio detection + voice.yaml)

### DIFF
--- a/cli/src/robot_md/init.py
+++ b/cli/src/robot_md/init.py
@@ -712,6 +712,12 @@ def default_flow(
     if do_teach_poses:
         results.append(phase_teach_poses(manifest_path=out_path, interactive=sys.stdin.isatty()))
 
+    # Phase 8: voice/audio onboarding — host-dependent (USB audio devices),
+    # so placed last alongside other hardware-detection phases.
+    from robot_md.init_phases import phase_voice_setup
+
+    results.append(phase_voice_setup(out_path, non_interactive=not sys.stdin.isatty()))
+
     _print_tally(results, out_path)
     return 0
 

--- a/cli/src/robot_md/init_phases/__init__.py
+++ b/cli/src/robot_md/init_phases/__init__.py
@@ -30,6 +30,7 @@ from robot_md.init_phases.install_mcp import phase_install_mcp  # noqa: E402
 from robot_md.init_phases.install_skill import phase_install_skill  # noqa: E402
 from robot_md.init_phases.register import phase_register  # noqa: E402
 from robot_md.init_phases.teach_poses import phase_teach_poses  # noqa: E402
+from robot_md.init_phases.voice_setup import phase_voice_setup  # noqa: E402
 from robot_md.init_phases.write_manifest import phase_write_manifest  # noqa: E402
 
 __all__ = [
@@ -44,5 +45,6 @@ __all__ = [
     "phase_install_skill",
     "phase_register",
     "phase_teach_poses",
+    "phase_voice_setup",
     "phase_write_manifest",
 ]

--- a/cli/src/robot_md/init_phases/voice_setup.py
+++ b/cli/src/robot_md/init_phases/voice_setup.py
@@ -8,10 +8,8 @@ from __future__ import annotations
 import datetime as _dt
 import sys
 from pathlib import Path
-from typing import Any
 
 import yaml
-
 
 _HEADER = (
     "═══ Voice setup ═══════════════════════════════════════════"
@@ -31,7 +29,7 @@ def _prompt_choice(prompt: str, options: list, default_idx: int = 0) -> int:
     for i, o in enumerate(options, 1):
         marker = "  ←  auto-pick" if i - 1 == default_idx else ""
         sys.stdout.write(f"  [{i}] {o.name}{marker}\n")
-    sys.stdout.write(f"  [ ] Press Enter to accept auto-pick, or type a number: ")
+    sys.stdout.write("  [ ] Press Enter to accept auto-pick, or type a number: ")
     sys.stdout.flush()
     line = sys.stdin.readline().strip()
     if not line:
@@ -55,9 +53,10 @@ def _confirm(prompt: str) -> bool:
 def _speaker_test(output_device_name: str) -> bool:
     """Play a 1s 880Hz tone via the chosen output. Returns True if user confirmed."""
     try:
+        import asyncio
         import math
         import struct
-        import asyncio
+
         from pendantd.audio.devices import list_devices, match_substring  # type: ignore
         from pendantd.audio.streams import OutputStream  # type: ignore
 
@@ -73,7 +72,10 @@ def _speaker_test(output_device_name: str) -> bool:
         sr = device.sample_rate
         n = int(1.0 * sr)
         amp = 8000  # ~25% of int16 max — comfortable
-        tone = struct.pack(f"<{n}h", *[int(amp * math.sin(2 * math.pi * 880 * t / sr)) for t in range(n)])
+        tone = struct.pack(
+            f"<{n}h",
+            *[int(amp * math.sin(2 * math.pi * 880 * t / sr)) for t in range(n)],
+        )
 
         async def _play() -> None:
             stream = OutputStream(device_index=device.index, samplerate=sr)
@@ -95,9 +97,10 @@ def _mic_loopback_test(input_name: str, output_name: str) -> bool:
     """Record 2s, play it back. Returns True if user confirmed."""
     try:
         import asyncio
+
         from pendantd.audio.devices import list_devices, match_substring  # type: ignore
-        from pendantd.audio.streams import InputStream, OutputStream  # type: ignore
         from pendantd.audio.loopback import record_and_play  # type: ignore
+        from pendantd.audio.streams import InputStream, OutputStream  # type: ignore
 
         devs = list_devices()
         in_dev = match_substring(devs.inputs, input_name)
@@ -115,7 +118,10 @@ def _mic_loopback_test(input_name: str, output_name: str) -> bool:
             f"Mic loopback test… recording 2s via {in_dev.name}, playing back via {out_dev.name}\n"
         )
         result = asyncio.run(_loopback())
-        sys.stdout.write(f"  recorded {result.recorded_bytes} bytes (peak {result.peak_dbfs:.1f} dBFS)\n")
+        sys.stdout.write(
+            f"  recorded {result.recorded_bytes} bytes "
+            f"(peak {result.peak_dbfs:.1f} dBFS)\n"
+        )
     except Exception as e:
         sys.stdout.write(f"  (loopback failed: {e}; falling back to manual confirmation)\n")
     return _confirm("Sound right?")
@@ -153,31 +159,41 @@ def run_voice_setup(
             "# TODO(voice): no audio devices detected at init time\n"
             + yaml.safe_dump(cfg)
         )
-        sys.stdout.write("No audio devices detected. Wrote a TODO marker; re-run when devices attach.\n")
+        sys.stdout.write(
+            "No audio devices detected. Wrote a TODO marker; re-run when devices attach.\n"
+        )
         return 0
 
     in_default = devs_mod.pick_default(devs.inputs, kind="input") if devs.inputs else None
-    out_default = devs_mod.pick_default(devs.outputs, kind="output", all_devices=devs) if devs.outputs else None
+    out_default = (
+        devs_mod.pick_default(devs.outputs, kind="output", all_devices=devs)
+        if devs.outputs
+        else None
+    )
 
     if non_interactive:
         cfg["input_device"] = in_default.name if in_default else ""
         cfg["output_device"] = out_default.name if out_default else ""
     else:
         if devs.inputs:
-            idx = _prompt_choice("Inputs:", devs.inputs, default_idx=devs.inputs.index(in_default) if in_default else 0)
+            default_idx = devs.inputs.index(in_default) if in_default else 0
+            idx = _prompt_choice("Inputs:", devs.inputs, default_idx=default_idx)
             cfg["input_device"] = devs.inputs[idx].name
         if devs.outputs:
-            idx = _prompt_choice("Outputs:", devs.outputs, default_idx=devs.outputs.index(out_default) if out_default else 0)
+            default_idx = devs.outputs.index(out_default) if out_default else 0
+            idx = _prompt_choice("Outputs:", devs.outputs, default_idx=default_idx)
             cfg["output_device"] = devs.outputs[idx].name
 
         # Speaker test
-        if cfg["output_device"]:
-            if not _speaker_test(cfg["output_device"]):
-                sys.stdout.write("Output may need attention. Continuing.\n")
+        if cfg["output_device"] and not _speaker_test(cfg["output_device"]):
+            sys.stdout.write("Output may need attention. Continuing.\n")
         # Mic loopback test
-        if cfg["input_device"] and cfg["output_device"]:
-            if not _mic_loopback_test(cfg["input_device"], cfg["output_device"]):
-                sys.stdout.write("Input may need attention. Continuing.\n")
+        if (
+            cfg["input_device"]
+            and cfg["output_device"]
+            and not _mic_loopback_test(cfg["input_device"], cfg["output_device"])
+        ):
+            sys.stdout.write("Input may need attention. Continuing.\n")
         # Wake-word check
         if not _skip_wake_check and cfg["robot_name"]:
             sys.stdout.write(f'Wake-word check… say "{cfg["robot_name"]}" or "claude" within 10s\n')

--- a/cli/src/robot_md/init_phases/voice_setup.py
+++ b/cli/src/robot_md/init_phases/voice_setup.py
@@ -3,6 +3,7 @@
 Imports pendantd.audio.devices as a soft dependency. If pendantd isn't
 importable, the phase prints a notice and exits rc=0.
 """
+
 from __future__ import annotations
 
 import datetime as _dt
@@ -11,14 +12,13 @@ from pathlib import Path
 
 import yaml
 
-_HEADER = (
-    "═══ Voice setup ═══════════════════════════════════════════"
-)
+_HEADER = "═══ Voice setup ═══════════════════════════════════════════"
 
 
 def _try_import_pendantd():
     try:
         from pendantd.audio import devices as devs_mod  # type: ignore
+
         return devs_mod
     except Exception:
         return None
@@ -119,8 +119,7 @@ def _mic_loopback_test(input_name: str, output_name: str) -> bool:
         )
         result = asyncio.run(_loopback())
         sys.stdout.write(
-            f"  recorded {result.recorded_bytes} bytes "
-            f"(peak {result.peak_dbfs:.1f} dBFS)\n"
+            f"  recorded {result.recorded_bytes} bytes (peak {result.peak_dbfs:.1f} dBFS)\n"
         )
     except Exception as e:
         sys.stdout.write(f"  (loopback failed: {e}; falling back to manual confirmation)\n")
@@ -156,8 +155,7 @@ def run_voice_setup(
     if not devs.inputs and not devs.outputs:
         cfg_path.parent.mkdir(parents=True, exist_ok=True)
         cfg_path.write_text(
-            "# TODO(voice): no audio devices detected at init time\n"
-            + yaml.safe_dump(cfg)
+            "# TODO(voice): no audio devices detected at init time\n" + yaml.safe_dump(cfg)
         )
         sys.stdout.write(
             "No audio devices detected. Wrote a TODO marker; re-run when devices attach.\n"

--- a/cli/src/robot_md/init_phases/voice_setup.py
+++ b/cli/src/robot_md/init_phases/voice_setup.py
@@ -52,6 +52,75 @@ def _confirm(prompt: str) -> bool:
     return line in ("", "y", "yes")
 
 
+def _speaker_test(output_device_name: str) -> bool:
+    """Play a 1s 880Hz tone via the chosen output. Returns True if user confirmed."""
+    try:
+        import math
+        import struct
+        import asyncio
+        from pendantd.audio.devices import list_devices, match_substring  # type: ignore
+        from pendantd.audio.streams import OutputStream  # type: ignore
+
+        devs = list_devices()
+        device = match_substring(devs.outputs, output_device_name)
+        if device is None:
+            sys.stdout.write(
+                f"  (couldn't find output device matching {output_device_name!r}; skipping tone)\n"
+            )
+            return _confirm("Hear it?")
+
+        # Generate 1s of 880Hz tone, mono int16 at the device's preferred rate
+        sr = device.sample_rate
+        n = int(1.0 * sr)
+        amp = 8000  # ~25% of int16 max — comfortable
+        tone = struct.pack(f"<{n}h", *[int(amp * math.sin(2 * math.pi * 880 * t / sr)) for t in range(n)])
+
+        async def _play() -> None:
+            stream = OutputStream(device_index=device.index, samplerate=sr)
+            await stream.start()
+            try:
+                await stream.write(tone)
+                await asyncio.sleep(1.1)  # let the tone finish
+            finally:
+                await stream.stop()
+
+        sys.stdout.write(f"Speaker test… playing 880 Hz via {device.name}\n")
+        asyncio.run(_play())
+    except Exception as e:
+        sys.stdout.write(f"  (speaker test failed: {e}; falling back to manual confirmation)\n")
+    return _confirm("Hear it?")
+
+
+def _mic_loopback_test(input_name: str, output_name: str) -> bool:
+    """Record 2s, play it back. Returns True if user confirmed."""
+    try:
+        import asyncio
+        from pendantd.audio.devices import list_devices, match_substring  # type: ignore
+        from pendantd.audio.streams import InputStream, OutputStream  # type: ignore
+        from pendantd.audio.loopback import record_and_play  # type: ignore
+
+        devs = list_devices()
+        in_dev = match_substring(devs.inputs, input_name)
+        out_dev = match_substring(devs.outputs, output_name)
+        if in_dev is None or out_dev is None:
+            sys.stdout.write("  (couldn't find devices for loopback; skipping)\n")
+            return _confirm("Sound right?")
+
+        async def _loopback():
+            inp = InputStream(device_index=in_dev.index, samplerate=in_dev.sample_rate)
+            out = OutputStream(device_index=out_dev.index, samplerate=in_dev.sample_rate)
+            return await record_and_play(inp, out, seconds=2.0)
+
+        sys.stdout.write(
+            f"Mic loopback test… recording 2s via {in_dev.name}, playing back via {out_dev.name}\n"
+        )
+        result = asyncio.run(_loopback())
+        sys.stdout.write(f"  recorded {result.recorded_bytes} bytes (peak {result.peak_dbfs:.1f} dBFS)\n")
+    except Exception as e:
+        sys.stdout.write(f"  (loopback failed: {e}; falling back to manual confirmation)\n")
+    return _confirm("Sound right?")
+
+
 def run_voice_setup(
     robot_name: str,
     cfg_path: Path,
@@ -103,14 +172,11 @@ def run_voice_setup(
 
         # Speaker test
         if cfg["output_device"]:
-            sys.stdout.write(f"Speaker test… (you should hear a 1s tone via {cfg['output_device']})\n")
-            sys.stdout.write("(skipped in this build — confirm interactively after pendantd starts)\n")
-            if not _confirm("Hear it?"):
+            if not _speaker_test(cfg["output_device"]):
                 sys.stdout.write("Output may need attention. Continuing.\n")
-        # Mic loopback test placeholder
-        if cfg["input_device"]:
-            sys.stdout.write("Mic loopback test… (deferred to runtime; pendantd reports peak dBFS)\n")
-            if not _confirm("Sound right?"):
+        # Mic loopback test
+        if cfg["input_device"] and cfg["output_device"]:
+            if not _mic_loopback_test(cfg["input_device"], cfg["output_device"]):
                 sys.stdout.write("Input may need attention. Continuing.\n")
         # Wake-word check
         if not _skip_wake_check and cfg["robot_name"]:

--- a/cli/src/robot_md/init_phases/voice_setup.py
+++ b/cli/src/robot_md/init_phases/voice_setup.py
@@ -125,3 +125,51 @@ def run_voice_setup(
     cfg_path.write_text(yaml.safe_dump(cfg) + provenance)
     sys.stdout.write(f"Wrote {cfg_path}.\n")
     return 0
+
+
+# ---------------------------------------------------------------------------
+# Phase adapter — converts run_voice_setup's int rc to PhaseResult so this
+# phase can be wired into default_flow alongside the other init phases.
+# ---------------------------------------------------------------------------
+
+from pathlib import Path as _Path  # noqa: E402 (below module-level code)
+
+from robot_md.init_phases import PhaseResult as _PhaseResult  # noqa: E402
+
+
+def phase_voice_setup(
+    manifest_path: _Path,
+    *,
+    non_interactive: bool = False,
+) -> _PhaseResult:
+    """Adapter: run voice/audio onboarding and return a PhaseResult.
+
+    Derives the robot_name from the manifest's frontmatter.
+    The voice config is written to ``<manifest_dir>/.robot-md/voice.yaml``.
+    Always returns status="ok" when pendantd is missing (soft dependency).
+    """
+    robot_name = ""
+    try:
+        from robot_md.parser import parse_file
+
+        parsed = parse_file(manifest_path)
+        robot_name = (parsed.frontmatter.get("metadata") or {}).get("robot_name", "") or ""
+    except Exception:
+        pass  # robot_name stays ""; run_voice_setup handles empty gracefully
+
+    cfg_path = manifest_path.parent / ".robot-md" / "voice.yaml"
+    rc = run_voice_setup(robot_name, cfg_path=cfg_path, non_interactive=non_interactive)
+
+    if rc == 0:
+        return _PhaseResult(
+            phase="voice_setup",
+            status="ok",
+            message=f"voice config written to {cfg_path}",
+            detail={"cfg_path": str(cfg_path), "robot_name": robot_name},
+        )
+    return _PhaseResult(
+        phase="voice_setup",
+        status="failed",
+        message=f"run_voice_setup exited with rc={rc}",
+        detail={"rc": rc, "cfg_path": str(cfg_path)},
+    )

--- a/cli/src/robot_md/init_phases/voice_setup.py
+++ b/cli/src/robot_md/init_phases/voice_setup.py
@@ -1,0 +1,127 @@
+"""robot-md init phase — voice + audio onboarding.
+
+Imports pendantd.audio.devices as a soft dependency. If pendantd isn't
+importable, the phase prints a notice and exits rc=0.
+"""
+from __future__ import annotations
+
+import datetime as _dt
+import sys
+from pathlib import Path
+from typing import Any
+
+import yaml
+
+
+_HEADER = (
+    "═══ Voice setup ═══════════════════════════════════════════"
+)
+
+
+def _try_import_pendantd():
+    try:
+        from pendantd.audio import devices as devs_mod  # type: ignore
+        return devs_mod
+    except Exception:
+        return None
+
+
+def _prompt_choice(prompt: str, options: list, default_idx: int = 0) -> int:
+    sys.stdout.write(prompt + "\n")
+    for i, o in enumerate(options, 1):
+        marker = "  ←  auto-pick" if i - 1 == default_idx else ""
+        sys.stdout.write(f"  [{i}] {o.name}{marker}\n")
+    sys.stdout.write(f"  [ ] Press Enter to accept auto-pick, or type a number: ")
+    sys.stdout.flush()
+    line = sys.stdin.readline().strip()
+    if not line:
+        return default_idx
+    try:
+        n = int(line)
+        if 1 <= n <= len(options):
+            return n - 1
+    except ValueError:
+        pass
+    return default_idx
+
+
+def _confirm(prompt: str) -> bool:
+    sys.stdout.write(prompt + " [Y/n] ")
+    sys.stdout.flush()
+    line = sys.stdin.readline().strip().lower()
+    return line in ("", "y", "yes")
+
+
+def run_voice_setup(
+    robot_name: str,
+    cfg_path: Path,
+    non_interactive: bool = False,
+    _skip_wake_check: bool = False,
+) -> int:
+    """Returns rc (0 on success, even when no audio devices were found)."""
+    devs_mod = _try_import_pendantd()
+    if devs_mod is None:
+        sys.stdout.write("pendantd not detected; skipping voice setup\n")
+        return 0
+
+    sys.stdout.write(_HEADER + "\n")
+    sys.stdout.write("Detecting audio devices…\n")
+    devs = devs_mod.list_devices()
+
+    cfg = {
+        "wake_word": "claude",
+        "robot_name": robot_name or "",
+        "wake_aliases": [],
+        "input_device": "",
+        "output_device": "",
+        "sample_rate": 16000,
+        "tts_voice": "en_US-amy-medium",
+    }
+
+    if not devs.inputs and not devs.outputs:
+        cfg_path.parent.mkdir(parents=True, exist_ok=True)
+        cfg_path.write_text(
+            "# TODO(voice): no audio devices detected at init time\n"
+            + yaml.safe_dump(cfg)
+        )
+        sys.stdout.write("No audio devices detected. Wrote a TODO marker; re-run when devices attach.\n")
+        return 0
+
+    in_default = devs_mod.pick_default(devs.inputs, kind="input") if devs.inputs else None
+    out_default = devs_mod.pick_default(devs.outputs, kind="output", all_devices=devs) if devs.outputs else None
+
+    if non_interactive:
+        cfg["input_device"] = in_default.name if in_default else ""
+        cfg["output_device"] = out_default.name if out_default else ""
+    else:
+        if devs.inputs:
+            idx = _prompt_choice("Inputs:", devs.inputs, default_idx=devs.inputs.index(in_default) if in_default else 0)
+            cfg["input_device"] = devs.inputs[idx].name
+        if devs.outputs:
+            idx = _prompt_choice("Outputs:", devs.outputs, default_idx=devs.outputs.index(out_default) if out_default else 0)
+            cfg["output_device"] = devs.outputs[idx].name
+
+        # Speaker test
+        if cfg["output_device"]:
+            sys.stdout.write(f"Speaker test… (you should hear a 1s tone via {cfg['output_device']})\n")
+            sys.stdout.write("(skipped in this build — confirm interactively after pendantd starts)\n")
+            if not _confirm("Hear it?"):
+                sys.stdout.write("Output may need attention. Continuing.\n")
+        # Mic loopback test placeholder
+        if cfg["input_device"]:
+            sys.stdout.write("Mic loopback test… (deferred to runtime; pendantd reports peak dBFS)\n")
+            if not _confirm("Sound right?"):
+                sys.stdout.write("Input may need attention. Continuing.\n")
+        # Wake-word check
+        if not _skip_wake_check and cfg["robot_name"]:
+            sys.stdout.write(f'Wake-word check… say "{cfg["robot_name"]}" or "claude" within 10s\n')
+            sys.stdout.write("(deferred to runtime — re-run with `pendantd voice test-wake`)\n")
+
+    cfg_path.parent.mkdir(parents=True, exist_ok=True)
+    provenance = (
+        f"# Provenance: autodetected {_dt.datetime.utcnow().isoformat(timespec='seconds')}Z; "
+        f"first input that matched USB class.\n"
+    )
+    cfg_path.write_text(yaml.safe_dump(cfg) + provenance)
+    sys.stdout.write(f"Wrote {cfg_path}.\n")
+    return 0

--- a/cli/tests/test_voice_setup.py
+++ b/cli/tests/test_voice_setup.py
@@ -1,0 +1,62 @@
+import io
+from pathlib import Path
+import pytest
+import yaml
+
+from robot_md.init_phases.voice_setup import run_voice_setup
+
+
+def _stub_pendantd(monkeypatch, devices=None):
+    """Inject a stub pendantd.audio.devices module."""
+    devices = devices or {"inputs": [], "outputs": []}
+    class FakeDevice:
+        def __init__(self, name): self.name = name; self.index = 0; self.kind = "input"
+        def __repr__(self): return f"<Dev {self.name}>"
+    class FakeList:
+        def __init__(self, d): self.inputs = [FakeDevice(n) for n in d["inputs"]]; self.outputs = [FakeDevice(n) for n in d["outputs"]]
+    fake_devs_mod = type("M", (), {})()
+    fake_devs_mod.list_devices = lambda: FakeList(devices)
+    fake_devs_mod.pick_default = lambda lst, kind, all_devices=None: lst[0] if lst else None
+    fake_audio_mod = type("M", (), {"devices": fake_devs_mod})()
+    monkeypatch.setitem(__import__("sys").modules, "pendantd", type("M", (), {})())
+    monkeypatch.setitem(__import__("sys").modules, "pendantd.audio", fake_audio_mod)
+    monkeypatch.setitem(__import__("sys").modules, "pendantd.audio.devices", fake_devs_mod)
+
+
+def test_voice_setup_skips_when_pendantd_missing(monkeypatch, tmp_path, capsys):
+    monkeypatch.setitem(__import__("sys").modules, "pendantd.audio.devices", None)
+    cfg_path = tmp_path / ".robot-md" / "voice.yaml"
+    rc = run_voice_setup(robot_name="bob", cfg_path=cfg_path, non_interactive=True)
+    assert rc == 0
+    assert "pendantd not detected" in capsys.readouterr().out
+    assert not cfg_path.exists()
+
+
+def test_voice_setup_writes_yaml_in_non_interactive(monkeypatch, tmp_path):
+    _stub_pendantd(monkeypatch, devices={"inputs": ["USB PnP Sound Device"], "outputs": ["Jabra SPEAK 410"]})
+    cfg_path = tmp_path / ".robot-md" / "voice.yaml"
+    rc = run_voice_setup(robot_name="bob", cfg_path=cfg_path, non_interactive=True)
+    assert rc == 0
+    data = yaml.safe_load(cfg_path.read_text())
+    assert data["robot_name"] == "bob"
+    assert data["wake_word"] == "claude"
+    assert data["input_device"] == "USB PnP Sound Device"
+    assert data["output_device"] == "Jabra SPEAK 410"
+
+
+def test_voice_setup_emits_todo_when_no_devices(monkeypatch, tmp_path):
+    _stub_pendantd(monkeypatch, devices={"inputs": [], "outputs": []})
+    cfg_path = tmp_path / ".robot-md" / "voice.yaml"
+    rc = run_voice_setup(robot_name="bob", cfg_path=cfg_path, non_interactive=True)
+    assert rc == 0
+    text = cfg_path.read_text()
+    assert "TODO(voice): no audio devices detected at init time" in text
+
+
+def test_voice_setup_interactive_accepts_default(monkeypatch, tmp_path):
+    _stub_pendantd(monkeypatch, devices={"inputs": ["USB PnP"], "outputs": ["Jabra"]})
+    monkeypatch.setattr("sys.stdin", io.StringIO("\n\nn\nn\n"))  # accept defaults; skip tests
+    cfg_path = tmp_path / ".robot-md" / "voice.yaml"
+    rc = run_voice_setup(robot_name="bob", cfg_path=cfg_path, non_interactive=False, _skip_wake_check=True)
+    assert rc == 0
+    assert yaml.safe_load(cfg_path.read_text())["input_device"] == "USB PnP"

--- a/cli/tests/test_voice_setup.py
+++ b/cli/tests/test_voice_setup.py
@@ -1,6 +1,6 @@
 import io
-from pathlib import Path
-import pytest
+import sys
+
 import yaml
 
 from robot_md.init_phases.voice_setup import run_voice_setup
@@ -9,22 +9,32 @@ from robot_md.init_phases.voice_setup import run_voice_setup
 def _stub_pendantd(monkeypatch, devices=None):
     """Inject a stub pendantd.audio.devices module."""
     devices = devices or {"inputs": [], "outputs": []}
+
     class FakeDevice:
-        def __init__(self, name): self.name = name; self.index = 0; self.kind = "input"
-        def __repr__(self): return f"<Dev {self.name}>"
+        def __init__(self, name):
+            self.name = name
+            self.index = 0
+            self.kind = "input"
+
+        def __repr__(self):
+            return f"<Dev {self.name}>"
+
     class FakeList:
-        def __init__(self, d): self.inputs = [FakeDevice(n) for n in d["inputs"]]; self.outputs = [FakeDevice(n) for n in d["outputs"]]
+        def __init__(self, d):
+            self.inputs = [FakeDevice(n) for n in d["inputs"]]
+            self.outputs = [FakeDevice(n) for n in d["outputs"]]
+
     fake_devs_mod = type("M", (), {})()
     fake_devs_mod.list_devices = lambda: FakeList(devices)
     fake_devs_mod.pick_default = lambda lst, kind, all_devices=None: lst[0] if lst else None
     fake_audio_mod = type("M", (), {"devices": fake_devs_mod})()
-    monkeypatch.setitem(__import__("sys").modules, "pendantd", type("M", (), {})())
-    monkeypatch.setitem(__import__("sys").modules, "pendantd.audio", fake_audio_mod)
-    monkeypatch.setitem(__import__("sys").modules, "pendantd.audio.devices", fake_devs_mod)
+    monkeypatch.setitem(sys.modules, "pendantd", type("M", (), {})())
+    monkeypatch.setitem(sys.modules, "pendantd.audio", fake_audio_mod)
+    monkeypatch.setitem(sys.modules, "pendantd.audio.devices", fake_devs_mod)
 
 
 def test_voice_setup_skips_when_pendantd_missing(monkeypatch, tmp_path, capsys):
-    monkeypatch.setitem(__import__("sys").modules, "pendantd.audio.devices", None)
+    monkeypatch.setitem(sys.modules, "pendantd.audio.devices", None)
     cfg_path = tmp_path / ".robot-md" / "voice.yaml"
     rc = run_voice_setup(robot_name="bob", cfg_path=cfg_path, non_interactive=True)
     assert rc == 0
@@ -33,7 +43,10 @@ def test_voice_setup_skips_when_pendantd_missing(monkeypatch, tmp_path, capsys):
 
 
 def test_voice_setup_writes_yaml_in_non_interactive(monkeypatch, tmp_path):
-    _stub_pendantd(monkeypatch, devices={"inputs": ["USB PnP Sound Device"], "outputs": ["Jabra SPEAK 410"]})
+    _stub_pendantd(
+        monkeypatch,
+        devices={"inputs": ["USB PnP Sound Device"], "outputs": ["Jabra SPEAK 410"]},
+    )
     cfg_path = tmp_path / ".robot-md" / "voice.yaml"
     rc = run_voice_setup(robot_name="bob", cfg_path=cfg_path, non_interactive=True)
     assert rc == 0
@@ -57,6 +70,11 @@ def test_voice_setup_interactive_accepts_default(monkeypatch, tmp_path):
     _stub_pendantd(monkeypatch, devices={"inputs": ["USB PnP"], "outputs": ["Jabra"]})
     monkeypatch.setattr("sys.stdin", io.StringIO("\n\nn\nn\n"))  # accept defaults; skip tests
     cfg_path = tmp_path / ".robot-md" / "voice.yaml"
-    rc = run_voice_setup(robot_name="bob", cfg_path=cfg_path, non_interactive=False, _skip_wake_check=True)
+    rc = run_voice_setup(
+        robot_name="bob",
+        cfg_path=cfg_path,
+        non_interactive=False,
+        _skip_wake_check=True,
+    )
     assert rc == 0
     assert yaml.safe_load(cfg_path.read_text())["input_device"] == "USB PnP"


### PR DESCRIPTION
## Summary

Adds a new `voice_setup` init phase to `robot-md init`, slotted into `default_flow` as Phase 8. Detects host audio devices via the soft `pendantd.audio.devices` dependency, lets the user pick (or accepts auto-pick), and writes `.robot-md/voice.yaml`. No-ops cleanly when `pendantd` isn't installed.

Companion to [`RobotRegistryFoundation/robot-md-pendant#3`](https://github.com/RobotRegistryFoundation/robot-md-pendant/pull/3) which ships the host-audio voice path.

## What's added

- `cli/src/robot_md/init_phases/voice_setup.py`
  - `run_voice_setup(robot_name, cfg_path, non_interactive=False)` returns `int` (rc)
  - `phase_voice_setup(out_path, non_interactive)` returns `PhaseResult` (the existing init contract)
  - Honors `--non-interactive` / `--yes`: silent auto-pick, no prompts
  - Emits `# TODO(voice): no audio devices detected at init time` when zero devices
- `cli/tests/test_voice_setup.py` — 4 tests covering: skip-when-pendantd-missing, write-yaml-non-interactive, todo-when-no-devices, interactive-accepts-default
- `cli/src/robot_md/init.py` — wires `phase_voice_setup` into `default_flow`
- `cli/src/robot_md/init_phases/__init__.py` — exports `phase_voice_setup`

## Tests

- 4 new voice_setup tests pass
- Existing init test suite (`test_init.py`) continues to pass — 30 passed combined
- Full `cli/` suite: pre-existing unrelated failures untouched

## Known follow-ups (tracked in companion repo)

- I7 in [robot-md-pendant#1](https://github.com/RobotRegistryFoundation/robot-md-pendant/issues/1): verify `manifest.metadata.robot_name` is the right key on the project's actual ROBOT.md frontmatter
- M1 in [robot-md-pendant#2](https://github.com/RobotRegistryFoundation/robot-md-pendant/issues/2): replace deprecated `datetime.utcnow()` with `datetime.now(tz=...)`

## Test plan

- [ ] `robot-md init --non-interactive` writes `.robot-md/voice.yaml` with auto-picked devices when `pendantd` is installed
- [ ] `robot-md init --non-interactive` skips voice_setup with a notice when `pendantd` isn't installed
- [ ] `robot-md init` interactively prompts and writes config matching user choices
- [ ] Zero-audio-device case writes the TODO marker and continues

🤖 Generated with [Claude Code](https://claude.com/claude-code)