### PR TITLE
chore(voice-setup): replace deprecated datetime.utcnow

### DIFF
--- a/cli/src/robot_md/init_phases/voice_setup.py
+++ b/cli/src/robot_md/init_phases/voice_setup.py
@@ -198,10 +198,8 @@ def run_voice_setup(
             sys.stdout.write("(deferred to runtime — re-run with `pendantd voice test-wake`)\n")
 
     cfg_path.parent.mkdir(parents=True, exist_ok=True)
-    provenance = (
-        f"# Provenance: autodetected {_dt.datetime.utcnow().isoformat(timespec='seconds')}Z; "
-        f"first input that matched USB class.\n"
-    )
+    _now = _dt.datetime.now(tz=_dt.timezone.utc).isoformat(timespec="seconds")
+    provenance = f"# Provenance: autodetected {_now}; first input that matched USB class.\n"
     cfg_path.write_text(yaml.safe_dump(cfg) + provenance)
     sys.stdout.write(f"Wrote {cfg_path}.\n")
     return 0


### PR DESCRIPTION
## Summary

- Replaces `datetime.utcnow()` with `datetime.now(tz=datetime.timezone.utc)` in `voice_setup.py` to eliminate the Python 3.12+ deprecation warning.
- The UTC timestamp in the provenance comment now includes timezone offset (`+00:00`) instead of a bare `Z` suffix — semantically equivalent and more stdlib-idiomatic.

## Test plan

- [ ] `cd cli && pytest tests/test_voice_setup.py -q` — 4 passed, 0 warnings
- [ ] `ruff check src/robot_md/init_phases/voice_setup.py` — clean
- [ ] `ruff format --check src/robot_md/init_phases/voice_setup.py` — clean

Closes part of #2.