### PR TITLE
fix(test): handle Click 8.2 dropping mix_stderr from CliRunner

### DIFF
--- a/cli/tests/test_apikey_request.py
+++ b/cli/tests/test_apikey_request.py
@@ -297,7 +297,12 @@ def test_cli_request_apikey_submit_prints_body_and_saves_key(home, tmp_path: Pat
             },
         )
 
-    runner = CliRunner(mix_stderr=False)
+    # Click 8.2 removed the `mix_stderr` kwarg (stderr is always separate now);
+    # Click 8.1.x still requires it to access result.stderr without ValueError.
+    try:
+        runner = CliRunner(mix_stderr=False)
+    except TypeError:
+        runner = CliRunner()
     with patch("urllib.request.urlopen", side_effect=fake_urlopen):
         result = runner.invoke(app, ["request-apikey", str(manifest), "--submit"])
 


### PR DESCRIPTION
## Summary

- One-line robustness fix in \`cli/tests/test_apikey_request.py:300\` — try \`CliRunner(mix_stderr=False)\` (Click 8.1.x), fall back to \`CliRunner()\` (Click 8.2+) on TypeError.
- Resolves the only failing test on the main CI matrix (Python 3.11/3.12/3.13). The other 16 tests in this module already use \`CliRunner()\` without the kwarg.

## Why

Click 8.2 (released ~Jan 2026) removed the \`mix_stderr\` kwarg — \`CliRunner(mix_stderr=False)\` raises \`TypeError\`. Click 8.1.x still requires it, otherwise \`result.stderr\` raises \`ValueError\` (stdout/stderr mixed). CI installs the latest Click via \`pip install -e ".[dev,...]"\` and hits the new behavior; the test was added in 40adf18 (v1.2.3 release today) using the old API.

## Test plan

- [x] \`pytest cli/tests/test_apikey_request.py\` — 17/17 pass on Click 8.1.8 locally
- [x] CI green on this PR

🤖 Generated with [Claude Code](https://claude.com/claude-code)