### PR TITLE
feat(sp3): SDK adapter pattern Slice 0 — capabilities schema + tier validator + plans

### DIFF
--- a/cli/src/robot_md/backends/registry.py
+++ b/cli/src/robot_md/backends/registry.py
@@ -2,10 +2,47 @@
 
 from __future__ import annotations
 
+import re
 from dataclasses import dataclass, field
 
 from robot_md.backends.base import CapabilityBackend
 from robot_md.robot_spec import RobotSpec
+
+CORE_CAPABILITY_PREFIXES = frozenset({"arm.", "nav.", "perceive.", "gripper.", "safety."})
+_VENDOR_CAPABILITY_PATTERN = re.compile(r"^[a-z][a-z0-9_]*\.[a-z][a-z0-9_.]*$")
+
+
+class BackendRegistrationError(Exception):
+    """Raised when a backend declares a malformed capability name."""
+
+
+def _validate_capability_namespace(backend_name: str, caps: frozenset[str]) -> None:
+    """Reject backend registration if any capability is malformed.
+
+    Every capability name must match `<vendor>.<name>` shape:
+    `^[a-z][a-z0-9_]*\\.[a-z][a-z0-9_.]*$`. Core capabilities
+    (`arm.pick`, `nav.go_to`, etc.) match the same regex by design.
+
+    `CORE_CAPABILITY_PREFIXES` identifies which prefixes are RRF-canonical
+    "core"; downstream consumers (Task 5's `describe_default()`, Task 7's
+    `enumerate_capabilities()`) use it for tier classification. A
+    well-formed capability whose prefix is not in that set is treated as
+    vendor-shaped.
+
+    Raises BackendRegistrationError on first violation.
+
+    Note: the existing feetech_depthai backend declares `vision.describe`
+    and `status.report`. Both match the regex (they look like
+    <vendor>.<name>) so the registry accepts them as vendor-shaped, even
+    though they're shipped in a first-party backend. Do NOT expand
+    CORE_CAPABILITY_PREFIXES here — that list is RRF-canonical core only.
+    """
+    for cap in caps:
+        if not _VENDOR_CAPABILITY_PATTERN.match(cap):
+            raise BackendRegistrationError(
+                f"Backend '{backend_name}' declared capability '{cap}': "
+                f"not in <vendor>.<name> form."
+            )
 
 
 def discover_backends() -> list[CapabilityBackend]:

--- a/cli/src/robot_md/backends/registry.py
+++ b/cli/src/robot_md/backends/registry.py
@@ -9,7 +9,7 @@ from robot_md.backends.base import CapabilityBackend
 from robot_md.robot_spec import RobotSpec
 
 CORE_CAPABILITY_PREFIXES = frozenset({"arm.", "nav.", "perceive.", "gripper.", "safety."})
-_VENDOR_CAPABILITY_PATTERN = re.compile(r"^[a-z][a-z0-9_]*\.[a-z][a-z0-9_.]*$")
+_VENDOR_CAPABILITY_PATTERN = re.compile(r"^[a-z][a-z0-9_]*\.[a-z]([a-z0-9_.]*[a-z0-9_])?$")
 
 
 class BackendRegistrationError(Exception):
@@ -20,8 +20,14 @@ def _validate_capability_namespace(backend_name: str, caps: frozenset[str]) -> N
     """Reject backend registration if any capability is malformed.
 
     Every capability name must match `<vendor>.<name>` shape:
-    `^[a-z][a-z0-9_]*\\.[a-z][a-z0-9_.]*$`. Core capabilities
+    `^[a-z][a-z0-9_]*\\.[a-z]([a-z0-9_.]*[a-z0-9_])?$`. Core capabilities
     (`arm.pick`, `nav.go_to`, etc.) match the same regex by design.
+
+    Allowed characters are ASCII lowercase letters, digits, and underscore.
+    Multi-dot hierarchies are valid (`acme.robotics.servo`,
+    `lerobot.motion.cartesian`) — the vendor is the first component, the
+    name is everything after the first dot. The name segment must not
+    start or end with a dot.
 
     `CORE_CAPABILITY_PREFIXES` identifies which prefixes are RRF-canonical
     "core"; downstream consumers (Task 5's `describe_default()`, Task 7's
@@ -29,7 +35,13 @@ def _validate_capability_namespace(backend_name: str, caps: frozenset[str]) -> N
     well-formed capability whose prefix is not in that set is treated as
     vendor-shaped.
 
-    Raises BackendRegistrationError on first violation.
+    Args:
+        backend_name: entry-point name of the backend being registered;
+            used in the error message to identify the offender.
+        caps: the set returned from `backend.capabilities()`.
+
+    Raises:
+        BackendRegistrationError on first violation.
 
     Note: the existing feetech_depthai backend declares `vision.describe`
     and `status.report`. Both match the regex (they look like
@@ -41,7 +53,8 @@ def _validate_capability_namespace(backend_name: str, caps: frozenset[str]) -> N
         if not _VENDOR_CAPABILITY_PATTERN.match(cap):
             raise BackendRegistrationError(
                 f"Backend '{backend_name}' declared capability '{cap}': "
-                f"not in <vendor>.<name> form."
+                f"not in <vendor>.<name> form "
+                f"(e.g. 'arm.pick', 'lerobot.teleop')."
             )
 
 

--- a/cli/src/robot_md/schemas/capabilities.json
+++ b/cli/src/robot_md/schemas/capabilities.json
@@ -1,0 +1,37 @@
+{
+  "$id": "https://robotmd.dev/schemas/capabilities.json",
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "title": "robot-md core capability arg shapes",
+  "definitions": {
+    "arm.pick": {
+      "type": "object",
+      "required": ["target"],
+      "properties": {
+        "target": {
+          "type": "string",
+          "description": "Object descriptor id from manifest.vision.object_descriptors"
+        },
+        "approach_height_mm": {"type": "number", "minimum": 0, "default": 50}
+      }
+    },
+    "arm.place": {
+      "type": "object",
+      "required": ["destination"],
+      "properties": {
+        "destination": {"type": "string"},
+        "release_height_mm": {"type": "number", "minimum": 0, "default": 30}
+      }
+    },
+    "arm.home": {"type": "object", "additionalProperties": false},
+    "perceive.rgb": {"type": "object", "additionalProperties": false},
+    "perceive.depth": {"type": "object", "additionalProperties": false},
+    "gripper.open": {"type": "object", "additionalProperties": false},
+    "gripper.close": {"type": "object", "additionalProperties": false},
+    "nav.go_to": {
+      "type": "object",
+      "required": ["pose"],
+      "properties": {"pose": {"type": "object"}}
+    },
+    "safety.estop": {"type": "object", "additionalProperties": false}
+  }
+}

--- a/cli/src/robot_md/schemas/capabilities.json
+++ b/cli/src/robot_md/schemas/capabilities.json
@@ -6,6 +6,7 @@
     "arm.pick": {
       "type": "object",
       "required": ["target"],
+      "additionalProperties": false,
       "properties": {
         "target": {
           "type": "string",
@@ -17,6 +18,7 @@
     "arm.place": {
       "type": "object",
       "required": ["destination"],
+      "additionalProperties": false,
       "properties": {
         "destination": {"type": "string"},
         "release_height_mm": {"type": "number", "minimum": 0, "default": 30}
@@ -30,6 +32,7 @@
     "nav.go_to": {
       "type": "object",
       "required": ["pose"],
+      "additionalProperties": false,
       "properties": {"pose": {"type": "object"}}
     },
     "safety.estop": {"type": "object", "additionalProperties": false}

--- a/cli/tests/backends/test_capabilities_schema_all_core_caps_present.py
+++ b/cli/tests/backends/test_capabilities_schema_all_core_caps_present.py
@@ -1,0 +1,19 @@
+from __future__ import annotations
+
+import json
+from pathlib import Path
+
+
+_SCHEMA_PATH = Path(__file__).parents[2] / "src" / "robot_md" / "schemas" / "capabilities.json"
+
+# Mirrors backends/registry.py CORE_CAPABILITY_PREFIXES (introduced in Task 2).
+_CORE_PREFIXES = ("arm.", "nav.", "perceive.", "gripper.", "safety.")
+
+
+def test_every_core_prefix_has_at_least_one_capability_defined() -> None:
+    schema = json.loads(_SCHEMA_PATH.read_text())
+    defined = set(schema["definitions"].keys())
+    for prefix in _CORE_PREFIXES:
+        assert any(name.startswith(prefix) for name in defined), (
+            f"capabilities.json has no capability for core prefix {prefix!r}"
+        )

--- a/cli/tests/backends/test_capabilities_schema_all_core_caps_present.py
+++ b/cli/tests/backends/test_capabilities_schema_all_core_caps_present.py
@@ -3,7 +3,6 @@ from __future__ import annotations
 import json
 from pathlib import Path
 
-
 _SCHEMA_PATH = Path(__file__).parents[2] / "src" / "robot_md" / "schemas" / "capabilities.json"
 
 # Mirrors backends/registry.py CORE_CAPABILITY_PREFIXES (introduced in Task 2).

--- a/cli/tests/backends/test_capabilities_schema_arg_validation.py
+++ b/cli/tests/backends/test_capabilities_schema_arg_validation.py
@@ -1,0 +1,34 @@
+from __future__ import annotations
+
+import json
+from pathlib import Path
+
+import jsonschema
+import pytest
+
+
+_SCHEMA_PATH = Path(__file__).parents[2] / "src" / "robot_md" / "schemas" / "capabilities.json"
+
+
+def _load_def(name: str) -> dict:
+    schema = json.loads(_SCHEMA_PATH.read_text())
+    return schema["definitions"][name]
+
+
+def test_arm_pick_accepts_minimal_valid_args() -> None:
+    jsonschema.validate({"target": "red_lego"}, _load_def("arm.pick"))
+
+
+def test_arm_pick_rejects_missing_target() -> None:
+    with pytest.raises(jsonschema.ValidationError):
+        jsonschema.validate({}, _load_def("arm.pick"))
+
+
+def test_arm_pick_rejects_wrong_target_type() -> None:
+    with pytest.raises(jsonschema.ValidationError):
+        jsonschema.validate({"target": 42}, _load_def("arm.pick"))
+
+
+def test_arm_home_rejects_extra_properties() -> None:
+    with pytest.raises(jsonschema.ValidationError):
+        jsonschema.validate({"surprise": True}, _load_def("arm.home"))

--- a/cli/tests/backends/test_capabilities_schema_arg_validation.py
+++ b/cli/tests/backends/test_capabilities_schema_arg_validation.py
@@ -6,7 +6,6 @@ from pathlib import Path
 import jsonschema
 import pytest
 
-
 _SCHEMA_PATH = Path(__file__).parents[2] / "src" / "robot_md" / "schemas" / "capabilities.json"
 
 

--- a/cli/tests/backends/test_capabilities_schema_arg_validation.py
+++ b/cli/tests/backends/test_capabilities_schema_arg_validation.py
@@ -32,3 +32,27 @@ def test_arm_pick_rejects_wrong_target_type() -> None:
 def test_arm_home_rejects_extra_properties() -> None:
     with pytest.raises(jsonschema.ValidationError):
         jsonschema.validate({"surprise": True}, _load_def("arm.home"))
+
+
+def test_arm_pick_rejects_extra_properties() -> None:
+    with pytest.raises(jsonschema.ValidationError):
+        jsonschema.validate(
+            {"target": "red_lego", "apporoach_height_mm": 100},
+            _load_def("arm.pick"),
+        )
+
+
+def test_arm_place_rejects_extra_properties() -> None:
+    with pytest.raises(jsonschema.ValidationError):
+        jsonschema.validate(
+            {"destination": "bin", "release_hieght_mm": 30},
+            _load_def("arm.place"),
+        )
+
+
+def test_nav_go_to_rejects_extra_properties() -> None:
+    with pytest.raises(jsonschema.ValidationError):
+        jsonschema.validate(
+            {"pose": {}, "speed": 0.5},
+            _load_def("nav.go_to"),
+        )

--- a/cli/tests/backends/test_capabilities_schema_loads.py
+++ b/cli/tests/backends/test_capabilities_schema_loads.py
@@ -1,0 +1,11 @@
+from __future__ import annotations
+
+import json
+from pathlib import Path
+
+
+def test_capabilities_schema_parses_as_json() -> None:
+    path = Path(__file__).parents[2] / "src" / "robot_md" / "schemas" / "capabilities.json"
+    data = json.loads(path.read_text())
+    assert data["$schema"] == "https://json-schema.org/draft/2020-12/schema"
+    assert "definitions" in data

--- a/cli/tests/backends/test_capability_namespace_core_accepted.py
+++ b/cli/tests/backends/test_capability_namespace_core_accepted.py
@@ -1,0 +1,11 @@
+from __future__ import annotations
+
+from robot_md.backends.registry import _validate_capability_namespace
+
+
+def test_core_prefixes_accepted() -> None:
+    # Should not raise — these are all core-prefixed.
+    _validate_capability_namespace(
+        "test_backend",
+        frozenset({"arm.pick", "nav.go_to", "perceive.rgb", "gripper.open", "safety.estop"}),
+    )

--- a/cli/tests/backends/test_capability_namespace_malformed_rejected.py
+++ b/cli/tests/backends/test_capability_namespace_malformed_rejected.py
@@ -1,0 +1,27 @@
+from __future__ import annotations
+
+import pytest
+
+from robot_md.backends.registry import (
+    BackendRegistrationError,
+    _validate_capability_namespace,
+)
+
+
+@pytest.mark.parametrize(
+    "bad_capability",
+    [
+        "pick",        # no namespace
+        "Arm.pick",    # uppercase
+        "arm-pick",    # hyphen
+        ".arm.pick",   # leading dot
+        "arm.",        # trailing dot
+        "1arm.pick",   # leading digit
+        "arm. pick",   # whitespace
+    ],
+)
+def test_malformed_capability_rejected(bad_capability: str) -> None:
+    with pytest.raises(BackendRegistrationError) as excinfo:
+        _validate_capability_namespace("bad_backend", frozenset({bad_capability}))
+    assert "bad_backend" in str(excinfo.value)
+    assert bad_capability in str(excinfo.value)

--- a/cli/tests/backends/test_capability_namespace_malformed_rejected.py
+++ b/cli/tests/backends/test_capability_namespace_malformed_rejected.py
@@ -11,15 +11,15 @@ from robot_md.backends.registry import (
 @pytest.mark.parametrize(
     "bad_capability",
     [
-        "pick",        # no namespace
-        "Arm.pick",    # uppercase
-        "arm-pick",    # hyphen
-        ".arm.pick",   # leading dot
-        "arm.",        # trailing dot in vendor segment (empty name)
-        "1arm.pick",   # leading digit
-        "arm. pick",   # whitespace
-        "arm.pick.",   # trailing dot in name segment
-        "",            # empty
+        "pick",  # no namespace
+        "Arm.pick",  # uppercase
+        "arm-pick",  # hyphen
+        ".arm.pick",  # leading dot
+        "arm.",  # trailing dot in vendor segment (empty name)
+        "1arm.pick",  # leading digit
+        "arm. pick",  # whitespace
+        "arm.pick.",  # trailing dot in name segment
+        "",  # empty
     ],
 )
 def test_malformed_capability_rejected(bad_capability: str) -> None:

--- a/cli/tests/backends/test_capability_namespace_malformed_rejected.py
+++ b/cli/tests/backends/test_capability_namespace_malformed_rejected.py
@@ -15,9 +15,11 @@ from robot_md.backends.registry import (
         "Arm.pick",    # uppercase
         "arm-pick",    # hyphen
         ".arm.pick",   # leading dot
-        "arm.",        # trailing dot
+        "arm.",        # trailing dot in vendor segment (empty name)
         "1arm.pick",   # leading digit
         "arm. pick",   # whitespace
+        "arm.pick.",   # trailing dot in name segment
+        "",            # empty
     ],
 )
 def test_malformed_capability_rejected(bad_capability: str) -> None:

--- a/cli/tests/backends/test_capability_namespace_vendor_accepted.py
+++ b/cli/tests/backends/test_capability_namespace_vendor_accepted.py
@@ -1,0 +1,15 @@
+from __future__ import annotations
+
+from robot_md.backends.registry import _validate_capability_namespace
+
+
+def test_vendor_namespaced_accepted() -> None:
+    _validate_capability_namespace(
+        "test_backend",
+        frozenset({
+            "lerobot.teleop",
+            "realsense.aligned_depth",
+            "franka.cartesian_impedance",
+            "my_corp.skill_x",
+        }),
+    )

--- a/cli/tests/backends/test_capability_namespace_vendor_accepted.py
+++ b/cli/tests/backends/test_capability_namespace_vendor_accepted.py
@@ -6,10 +6,12 @@ from robot_md.backends.registry import _validate_capability_namespace
 def test_vendor_namespaced_accepted() -> None:
     _validate_capability_namespace(
         "test_backend",
-        frozenset({
-            "lerobot.teleop",
-            "realsense.aligned_depth",
-            "franka.cartesian_impedance",
-            "my_corp.skill_x",
-        }),
+        frozenset(
+            {
+                "lerobot.teleop",
+                "realsense.aligned_depth",
+                "franka.cartesian_impedance",
+                "my_corp.skill_x",
+            }
+        ),
     )

--- a/docs/superpowers/plans/2026-04-27-sp-an-announce-confirm.md
+++ b/docs/superpowers/plans/2026-04-27-sp-an-announce-confirm.md
@@ -1,0 +1,1040 @@
+# SP-AN — Hot-Plug Announce + Confirm Surfaces Implementation Plan (v1)
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Ship SP-AN v1 — the operator-facing announce + confirm layer over SP-HP's queue. v1 has two surfaces only: (a) Claude chat, driven by `notifications/resources/updated` for the new `robot-md://hotplug/pending` MCP resource + skill-text in `using-robot-md.SKILL.md` that turns those updates into announce / review / confirm flows, and (b) audio onboarding via Claude's existing voice mode (no new TTS code). **Pendant integration is deferred to SP-AN v2** — v1's queue contract (resolution race semantics: pending → resolved (bind|reject|expired), single writer = daemon, first-acting channel wins) is shape-correct so v2 plugs in without queue-shape changes.
+
+**Architecture:** SP-AN ships as additions to existing components — no new long-running processes. The MCP server gains one resource (`robot-md://hotplug/pending`) emitting `notifications/resources/updated` whenever SP-HP's daemon nudges the socket or the file-poll detects a queue change. Skill-text additions to the canonical `using-robot-md.SKILL.md` (per SP1 simplification-revisions Revision 7: edited only in `~/robot-md-mcp/skills/using-robot-md/SKILL.md`; sync script propagates to `cli/src/robot_md/skills/using-robot-md.SKILL.md`) instruct Claude on the announce-on-HIGH, surface-on-MEDIUM, undo-within-30s, and resolved-elsewhere flows. A sandboxed Claude harness exercises the skill-text contracts without a live model.
+
+**Tech Stack:** Python 3.10+, FastMCP (`mcp.server.fastmcp`), the existing `using-robot-md` skill text infrastructure + sync script (Revision 7), `pytest`, no new dependencies.
+
+**Spec:** `docs/superpowers/specs/2026-04-27-sp-an-announce-confirm-design.md`
+
+**Depends on:** SP-HP — the queue + daemon socket + manifest merge live there. SP-AN consumes them read-only via the resource + writes resolution records via `hotplug_confirm` (defined in SP-HP).
+
+---
+
+## File Structure
+
+**MCP-server-side resource:**
+- `cli/src/robot_md/mcp/resources/__init__.py` — NEW (only if the directory doesn't already exist).
+- `cli/src/robot_md/mcp/resources/hotplug_pending.py` — NEW. Reads pending records from `EventQueue`; surfaces them as a single resource document. Emits `notifications/resources/updated` on subscribed clients when the daemon's socket nudge fires (Linux) or when the periodic file-poll detects a queue change (macOS / Windows).
+- `cli/src/robot_md/mcp/server.py` — MODIFY. Register the resource + wire the socket subscriber + start the file-poll fallback timer.
+- `cli/src/robot_md/mcp/resource_subscribers.py` — NEW. Tracks subscribed clients, emits `notifications/resources/updated`.
+
+**Skill text:**
+- `~/robot-md-mcp/skills/using-robot-md/SKILL.md` (canonical, lives in the npm-published mcp-server repo) — MODIFY. Add three new sections: "Reacting to hot-plug events", "Modality hierarchy", "Resolved-elsewhere handling".
+- `cli/src/robot_md/skills/using-robot-md.SKILL.md` (CLI-shipped mirror) — REGENERATED via the sync script.
+- `cli/scripts/sync-skill.sh` (or wherever the existing Revision 7 sync script lives) — VERIFY it still copies cleanly after the additions.
+
+**Sandboxed harness tests:**
+- `cli/tests/hotplug_an/__init__.py` — NEW.
+- `cli/tests/hotplug_an/conftest.py` — NEW. Skill-text fixture loader.
+- `cli/tests/hotplug_an/test_skill_announce_high_tier_in_voice_mode.py` — NEW.
+- `cli/tests/hotplug_an/test_skill_undo_within_window_calls_reject.py` — NEW.
+- `cli/tests/hotplug_an/test_skill_undo_after_window_warns_manifest_bound.py` — NEW.
+- `cli/tests/hotplug_an/test_skill_medium_tier_surfaces_alternatives.py` — NEW.
+- `cli/tests/hotplug_an/test_skill_resolved_elsewhere_acknowledges.py` — NEW.
+
+**Resource subscription tests:**
+- `cli/tests/hotplug_an/test_hotplug_pending_resource_lists_pending.py` — NEW.
+- `cli/tests/hotplug_an/test_hotplug_pending_resource_emits_updated_on_nudge.py` — NEW.
+- `cli/tests/hotplug_an/test_hotplug_pending_resource_emits_updated_on_file_poll.py` — NEW.
+- `cli/tests/hotplug_an/test_hotplug_pending_resource_subscribers_only_get_changes.py` — NEW.
+
+**Manual smoke checklist:**
+- `cli/tests/manual/span_smoke.md` — NEW.
+
+**Documentation (called out as v1 limitation):**
+- `cli/docs/hotplug-roadmap.md` — NEW. Single page listing v2 follow-ups (pendant surface, web UI, manifest unbind tool, persistent operator preferences).
+
+---
+
+## Phase A — `robot-md://hotplug/pending` resource
+
+### Task 1: Resource read returns pending events from `EventQueue`
+
+**Files:**
+- Create: `cli/src/robot_md/mcp/resources/__init__.py`, `cli/src/robot_md/mcp/resources/hotplug_pending.py`
+- Test: `cli/tests/hotplug_an/test_hotplug_pending_resource_lists_pending.py`
+
+- [ ] **Step 1: Inspect existing resource patterns**
+
+```bash
+grep -rn "@server.resource\|server.resource(" cli/src/robot_md/mcp/ 2>/dev/null | head -10
+```
+
+Note the existing FastMCP resource registration pattern. Match it.
+
+- [ ] **Step 2: Write the resource-read test**
+
+```python
+# cli/tests/hotplug_an/test_hotplug_pending_resource_lists_pending.py
+from __future__ import annotations
+
+import json
+from pathlib import Path
+
+from robot_md.hotplug.event import DeviceEvent
+from robot_md.hotplug.matcher import Decision
+from robot_md.hotplug.queue import EventQueue
+from robot_md.mcp.resources.hotplug_pending import build_pending_payload
+
+
+def _evt() -> DeviceEvent:
+    return DeviceEvent(
+        kind="tty_added", vid="1a86", pid="7523", serial="AB12",
+        path="/dev/ttyACM0", transport="feetech",
+        raw_metadata={}, detected_at="2026-04-27T19:30:11Z",
+    )
+
+
+def test_payload_lists_only_pending_events(tmp_path: Path) -> None:
+    q = EventQueue(path=tmp_path / "q.jsonl")
+    p1 = q.append_pending(_evt(), Decision(tier="MEDIUM", unambiguous=False, bind_proposal=None))
+    p2 = q.append_pending(_evt(), Decision(tier="LOW", unambiguous=False, bind_proposal=None))
+    q.append_resolution(ref_id=p1.id, resolution="bind", by="cli", outcome={})
+
+    payload = build_pending_payload(_queue=q)
+    pending_ids = {p["event_id"] for p in payload["pending"]}
+    assert p2.id in pending_ids
+    assert p1.id not in pending_ids
+
+
+def test_payload_is_json_serializable(tmp_path: Path) -> None:
+    q = EventQueue(path=tmp_path / "q.jsonl")
+    q.append_pending(_evt(), Decision(tier="MEDIUM", unambiguous=False, bind_proposal=None))
+    payload = build_pending_payload(_queue=q)
+    json.dumps(payload)  # must not raise
+```
+
+- [ ] **Step 3: Run test (expect FAIL — module missing)**
+
+```bash
+cd cli && PYTHONPATH=src python -m pytest tests/hotplug_an/test_hotplug_pending_resource_lists_pending.py -v
+```
+
+- [ ] **Step 4: Implement `hotplug_pending.py`**
+
+Create `cli/src/robot_md/mcp/resources/__init__.py`:
+
+```python
+"""MCP resources — readable URIs that emit notifications/resources/updated."""
+```
+
+Create `cli/src/robot_md/mcp/resources/hotplug_pending.py`:
+
+```python
+"""robot-md://hotplug/pending — read-only view over SP-HP's pending events.
+
+Subscribers receive notifications/resources/updated on socket-nudge (Linux)
+or file-poll-detected change (macOS / Windows).
+"""
+
+from __future__ import annotations
+
+import json
+
+from robot_md.hotplug.queue import EventQueue
+
+
+URI = "robot-md://hotplug/pending"
+
+
+def build_pending_payload(*, _queue: EventQueue | None = None) -> dict:
+    q = _queue or EventQueue()
+    if not q.path.exists():
+        return {"pending": []}
+    records: list[dict] = []
+    for line in q.path.read_text().splitlines():
+        line = line.strip()
+        if not line:
+            continue
+        try:
+            records.append(json.loads(line))
+        except Exception:
+            continue
+    pending_ids = {r["id"] for r in records if r.get("kind") == "pending"}
+    resolved_refs = {r["ref"] for r in records if r.get("kind") == "resolved" and r.get("ref")}
+
+    out = []
+    for r in records:
+        if r.get("kind") == "pending" and r["id"] in (pending_ids - resolved_refs):
+            out.append({
+                "event_id": r["id"],
+                "tier": r["decision"]["tier"],
+                "device": r["event"],
+                "decision": r["decision"],
+            })
+    return {"pending": out}
+```
+
+- [ ] **Step 5: Run test (expect PASS 2/2)**
+
+- [ ] **Step 6: Commit (Task 1)**
+
+```bash
+cd /home/craigm26/robot-md/.worktrees/sp3-sdk-adapter
+git add cli/src/robot_md/mcp/resources/__init__.py cli/src/robot_md/mcp/resources/hotplug_pending.py cli/tests/hotplug_an/test_hotplug_pending_resource_lists_pending.py
+git commit -m "$(cat <<'EOF'
+feat(span): build_pending_payload — read-only view over SP-HP queue
+
+Filters resolved events out, surfaces only currently-pending records
+with tier + device metadata + decision blob. JSON-serializable for the
+MCP resource at robot-md://hotplug/pending. Resource registration +
+notifications wiring follow in Tasks 2-4.
+
+Co-Authored-By: Claude Opus 4.7 (1M context) <noreply@anthropic.com>
+EOF
+)"
+```
+
+---
+
+### Task 2: Register the resource on the MCP server + emit on subscribe
+
+**Files:**
+- Modify: `cli/src/robot_md/mcp/server.py` (register `@server.resource(URI)`)
+- Test: extend `cli/tests/hotplug_an/test_hotplug_pending_resource_lists_pending.py` with a server-roundtrip test, OR add a new `test_hotplug_pending_resource_registered.py`
+
+- [ ] **Step 1: Write the resource-registration test**
+
+```python
+# cli/tests/hotplug_an/test_hotplug_pending_resource_registered.py
+from __future__ import annotations
+
+
+def test_resource_uri_appears_in_server_list_resources() -> None:
+    from robot_md.mcp.server import server  # adjust to actual symbol
+    from robot_md.mcp.resources.hotplug_pending import URI
+    resources = list(server.list_resources())
+    uris = {r.uri for r in resources}
+    assert URI in uris, f"{URI} not registered; got {uris!r}"
+```
+
+(If `server.list_resources()` returns differently in this project's FastMCP version, adapt — the goal is to confirm the URI is registered.)
+
+- [ ] **Step 2: Run test (expect FAIL — not registered)**
+
+- [ ] **Step 3: Register in `server.py`**
+
+In `cli/src/robot_md/mcp/server.py`, alongside existing `@server.tool()` registrations, add:
+
+```python
+    from robot_md.mcp.resources.hotplug_pending import URI as _HOTPLUG_URI
+
+    @server.resource(_HOTPLUG_URI)
+    def hotplug_pending_resource() -> dict:
+        """Currently-pending hot-plug events awaiting operator confirmation."""
+        from robot_md.mcp.resources.hotplug_pending import build_pending_payload
+        return build_pending_payload()
+```
+
+- [ ] **Step 4: Run test (expect PASS)**
+
+- [ ] **Step 5: Commit (Task 2)**
+
+```bash
+git add cli/src/robot_md/mcp/server.py cli/tests/hotplug_an/test_hotplug_pending_resource_registered.py
+git commit -m "feat(span): register robot-md://hotplug/pending MCP resource"
+```
+
+---
+
+### Task 3: Emit `notifications/resources/updated` on socket-nudge (Linux)
+
+**Files:**
+- Create: `cli/src/robot_md/mcp/resource_subscribers.py`
+- Modify: `cli/src/robot_md/mcp/server.py` (start a socket subscriber on connect)
+- Test: `cli/tests/hotplug_an/test_hotplug_pending_resource_emits_updated_on_nudge.py`
+
+- [ ] **Step 1: Write the on-nudge test**
+
+```python
+# cli/tests/hotplug_an/test_hotplug_pending_resource_emits_updated_on_nudge.py
+from __future__ import annotations
+
+import asyncio
+import socket
+import sys
+from pathlib import Path
+
+import pytest
+
+from robot_md.mcp.resource_subscribers import HotplugResourceSubscriber
+
+
+pytestmark = pytest.mark.skipif(sys.platform != "linux", reason="Unix socket — Linux primary")
+
+
+def test_subscriber_emits_updated_on_socket_nudge(tmp_path: Path) -> None:
+    received: list = []
+    sock_path = tmp_path / "nudge.sock"
+
+    # Pre-bind a fake daemon socket.
+    server_sock = socket.socket(socket.AF_UNIX, socket.SOCK_STREAM)
+    server_sock.bind(str(sock_path))
+    server_sock.listen(1)
+
+    subscriber = HotplugResourceSubscriber(
+        socket_path=sock_path,
+        on_change=lambda: received.append(1),
+    )
+
+    async def main():
+        await subscriber.start()
+        # Connect + send 1-byte nudge.
+        client = socket.socket(socket.AF_UNIX, socket.SOCK_STREAM)
+        client.connect(str(sock_path))
+        client.sendall(b"\x01")
+        client.close()
+        await asyncio.sleep(0.1)
+        await subscriber.stop()
+
+    try:
+        asyncio.run(main())
+    finally:
+        server_sock.close()
+        sock_path.unlink(missing_ok=True)
+
+    assert received == [1]
+```
+
+(Note: this test as written wires the subscriber as a CLIENT of the daemon's socket. Adjust the implementation accordingly — the subscriber connects to the daemon's pre-bound socket and reads incoming nudge bytes.)
+
+- [ ] **Step 2: Implement `resource_subscribers.py`**
+
+```python
+# cli/src/robot_md/mcp/resource_subscribers.py
+"""Linux-only Unix-socket subscriber for SP-HP daemon nudges.
+
+Connects to /run/user/$UID/robot-md-hotplug.sock and reads nudge bytes;
+each byte received triggers on_change().
+"""
+
+from __future__ import annotations
+
+import asyncio
+import os
+from pathlib import Path
+from typing import Callable
+
+_DEFAULT_PATH = Path(f"/run/user/{os.getuid()}/robot-md-hotplug.sock") if hasattr(os, "getuid") else None
+
+
+class HotplugResourceSubscriber:
+    def __init__(self, *, socket_path: Path | None = None, on_change: Callable[[], None]) -> None:
+        self.socket_path = socket_path or _DEFAULT_PATH
+        self._task: asyncio.Task | None = None
+        self._stop = asyncio.Event()
+        self._on_change = on_change
+
+    async def start(self) -> None:
+        self._task = asyncio.create_task(self._run())
+
+    async def stop(self) -> None:
+        self._stop.set()
+        if self._task is not None:
+            self._task.cancel()
+            try:
+                await self._task
+            except asyncio.CancelledError:
+                pass
+            self._task = None
+
+    async def _run(self) -> None:
+        if self.socket_path is None or not self.socket_path.exists():
+            return
+        try:
+            reader, writer = await asyncio.open_unix_connection(str(self.socket_path))
+        except (FileNotFoundError, ConnectionRefusedError, OSError):
+            return
+        try:
+            while not self._stop.is_set():
+                data = await reader.read(1)
+                if not data:
+                    break
+                self._on_change()
+        finally:
+            writer.close()
+            try:
+                await writer.wait_closed()
+            except Exception:
+                pass
+```
+
+- [ ] **Step 3: Wire into `server.py`**
+
+In `cli/src/robot_md/mcp/server.py`, add startup hook (typical FastMCP shape — adapt to project convention):
+
+```python
+    # On connect: start the hotplug subscriber. on_change emits
+    # notifications/resources/updated for the pending resource.
+    @server.on_connect
+    async def _start_hotplug_subscriber():
+        from robot_md.mcp.resource_subscribers import HotplugResourceSubscriber
+        from robot_md.mcp.resources.hotplug_pending import URI as _HOTPLUG_URI
+
+        async def _emit():
+            await server.send_resource_updated(_HOTPLUG_URI)
+
+        sub = HotplugResourceSubscriber(on_change=lambda: asyncio.create_task(_emit()))
+        await sub.start()
+        # Stash on the server context so disconnect can stop it.
+        server.state["_hotplug_subscriber"] = sub
+
+    @server.on_disconnect
+    async def _stop_hotplug_subscriber():
+        sub = server.state.pop("_hotplug_subscriber", None)
+        if sub is not None:
+            await sub.stop()
+```
+
+(`@server.on_connect` / `@server.on_disconnect` / `server.send_resource_updated` are illustrative names matching MCP-spec semantics. Adapt to the actual FastMCP API shipped with this project — if those hooks aren't named that way, look at how the existing `tools/list_changed` notification is emitted on backend reload (Task 17 of SP-HP plan) and follow that pattern.)
+
+- [ ] **Step 4: Run test (expect PASS)**
+
+- [ ] **Step 5: Commit (Task 3)**
+
+```bash
+git add cli/src/robot_md/mcp/resource_subscribers.py cli/src/robot_md/mcp/server.py cli/tests/hotplug_an/test_hotplug_pending_resource_emits_updated_on_nudge.py
+git commit -m "feat(span): Linux socket subscriber emits notifications/resources/updated"
+```
+
+---
+
+### Task 4: File-poll fallback for macOS / Windows + subscriber-only-changes guard
+
+**Files:**
+- Modify: `cli/src/robot_md/mcp/resource_subscribers.py` (add `FilePollFallback`)
+- Modify: `cli/src/robot_md/mcp/server.py` (start poll on platforms without working socket)
+- Test: `cli/tests/hotplug_an/test_hotplug_pending_resource_emits_updated_on_file_poll.py`, `test_hotplug_pending_resource_subscribers_only_get_changes.py`
+
+- [ ] **Step 1: Write the file-poll test**
+
+```python
+# cli/tests/hotplug_an/test_hotplug_pending_resource_emits_updated_on_file_poll.py
+from __future__ import annotations
+
+import asyncio
+from pathlib import Path
+
+from robot_md.mcp.resource_subscribers import FilePollFallback
+
+
+def test_poll_fires_on_file_mtime_change(tmp_path: Path) -> None:
+    queue_path = tmp_path / "q.jsonl"
+    queue_path.write_text("")
+    received: list = []
+
+    poller = FilePollFallback(queue_path=queue_path, on_change=lambda: received.append(1), interval=0.05)
+
+    async def main():
+        await poller.start()
+        await asyncio.sleep(0.1)
+        # Simulate a daemon write.
+        queue_path.write_text('{"id":"evt_1","kind":"pending"}\n')
+        await asyncio.sleep(0.2)
+        await poller.stop()
+
+    asyncio.run(main())
+    assert received, "FilePollFallback did not fire on mtime change"
+```
+
+- [ ] **Step 2: Write the no-self-loop test**
+
+```python
+# cli/tests/hotplug_an/test_hotplug_pending_resource_subscribers_only_get_changes.py
+from __future__ import annotations
+
+import asyncio
+from pathlib import Path
+
+from robot_md.mcp.resource_subscribers import FilePollFallback
+
+
+def test_no_change_no_event(tmp_path: Path) -> None:
+    queue_path = tmp_path / "q.jsonl"
+    queue_path.write_text("seed\n")
+    received: list = []
+    poller = FilePollFallback(queue_path=queue_path, on_change=lambda: received.append(1), interval=0.02)
+
+    async def main():
+        await poller.start()
+        # No writes — poller should NOT fire.
+        await asyncio.sleep(0.15)
+        await poller.stop()
+
+    asyncio.run(main())
+    assert received == []
+```
+
+- [ ] **Step 3: Implement `FilePollFallback`**
+
+Append to `cli/src/robot_md/mcp/resource_subscribers.py`:
+
+```python
+class FilePollFallback:
+    def __init__(self, *, queue_path: Path, on_change: Callable[[], None], interval: float = 2.0) -> None:
+        self.queue_path = queue_path
+        self._on_change = on_change
+        self._interval = interval
+        self._task: asyncio.Task | None = None
+        self._stop = asyncio.Event()
+
+    async def start(self) -> None:
+        self._task = asyncio.create_task(self._run())
+
+    async def stop(self) -> None:
+        self._stop.set()
+        if self._task is not None:
+            self._task.cancel()
+            try:
+                await self._task
+            except asyncio.CancelledError:
+                pass
+            self._task = None
+
+    async def _run(self) -> None:
+        last_mtime = self._mtime()
+        while not self._stop.is_set():
+            try:
+                await asyncio.wait_for(self._stop.wait(), timeout=self._interval)
+                return
+            except asyncio.TimeoutError:
+                pass
+            current = self._mtime()
+            if current is not None and current != last_mtime:
+                last_mtime = current
+                self._on_change()
+
+    def _mtime(self) -> float | None:
+        try:
+            return self.queue_path.stat().st_mtime
+        except FileNotFoundError:
+            return None
+```
+
+Wire into `server.py`'s on-connect handler — start `FilePollFallback` on macOS / Windows (or any platform where the socket subscriber's `_run` returned without binding). Easiest: always start the poller; the socket subscriber is a low-latency optimization on top of it. If both fire on the same change, MCP clients gracefully ignore duplicate `notifications/resources/updated` (the resource is read on demand; the notification is just a hint).
+
+- [ ] **Step 4: Run tests (expect PASS 2/2)**
+
+- [ ] **Step 5: Commit (Task 4)**
+
+```bash
+git add cli/src/robot_md/mcp/resource_subscribers.py cli/src/robot_md/mcp/server.py cli/tests/hotplug_an/test_hotplug_pending_resource_emits_updated_on_file_poll.py cli/tests/hotplug_an/test_hotplug_pending_resource_subscribers_only_get_changes.py
+git commit -m "feat(span): file-poll fallback for non-Linux + no-spurious-event guard"
+```
+
+---
+
+## Phase B — Skill text additions
+
+### Task 5: Add three new sections to `using-robot-md.SKILL.md`
+
+**Files:**
+- Modify: `~/robot-md-mcp/skills/using-robot-md/SKILL.md` (canonical) — assume worktree contains a checkout or has the path mounted; if not, write to a draft path here and the implementer copies into the npm repo.
+- Modify: `cli/src/robot_md/skills/using-robot-md.SKILL.md` (regenerated mirror).
+- Run: existing Revision 7 sync script.
+- Test: drift check + content presence.
+
+- [ ] **Step 1: Locate the canonical skill file**
+
+```bash
+ls ~/robot-md-mcp/skills/using-robot-md/SKILL.md 2>/dev/null && echo "canonical found"
+ls cli/src/robot_md/skills/using-robot-md.SKILL.md 2>/dev/null && echo "mirror found"
+```
+
+If the canonical npm-side repo isn't checked out alongside this worktree, the implementer either (a) clones it adjacent and proceeds, or (b) edits the CLI-mirror directly and files a follow-up PR against the npm repo to sync. Either path: the new sections eventually live in the canonical file per Revision 7.
+
+- [ ] **Step 2: Write the content-presence test**
+
+```python
+# cli/tests/hotplug_an/test_skill_text_has_hotplug_sections.py
+from __future__ import annotations
+
+from pathlib import Path
+
+
+_MIRROR = Path(__file__).parents[2] / "src" / "robot_md" / "skills" / "using-robot-md.SKILL.md"
+
+
+def test_mirror_contains_three_new_sections() -> None:
+    text = _MIRROR.read_text()
+    assert "## Reacting to hot-plug events" in text
+    assert "## Modality hierarchy" in text
+    assert "## Resolved-elsewhere handling" in text
+
+
+def test_mirror_announces_30s_undo_window() -> None:
+    text = _MIRROR.read_text()
+    assert "30 s" in text or "30 seconds" in text
+
+
+def test_mirror_describes_hotplug_review_and_confirm_calls() -> None:
+    text = _MIRROR.read_text()
+    assert "hotplug_review" in text
+    assert "hotplug_confirm" in text
+```
+
+- [ ] **Step 3: Run test (expect FAIL — sections missing)**
+
+- [ ] **Step 4: Add the three sections**
+
+Edit the canonical `using-robot-md.SKILL.md` (or, in the fallback path, the mirror). Append:
+
+```markdown
+## Reacting to hot-plug events
+
+The MCP server emits `notifications/resources/updated` for
+`robot-md://hotplug/pending` whenever new hardware is detected.
+
+When you receive that notification:
+
+1. Call `hotplug_review`.
+2. For HIGH-tier events that already resolved (`bind`):
+   - **Announce to the operator** — say or write:
+     "Found a {preset_name} on {port}. I bound it as the {driver_id} driver
+      using the {backend_name} backend. Say 'undo' to reject."
+   - If the operator says undo / reject within 30 s of the announce,
+     call `hotplug_confirm({event_id}, "reject")`. The daemon will append
+     a rejection record; the manifest stays bound but the audit trail
+     captures the operator's intent. (Manifest unbinding is out of scope
+     for v1 — call this out and offer to help edit ROBOT.md by hand.)
+3. For MEDIUM/LOW-tier pending events:
+   - Surface the event with its alternatives.
+   - Ask the operator: "Want me to bind this as {top_candidate}, pick
+     a different option, or reject?"
+   - Call `hotplug_confirm` with their answer.
+
+## Modality hierarchy
+
+If the operator is in voice mode, **announce by voice first**, then mirror
+the same text to the chat. If the operator is in text mode, write to the
+chat only.
+
+## Resolved-elsewhere handling
+
+If you call `hotplug_confirm` and get back `already_resolved`, the
+operator confirmed it via another path (e.g., `robot-md hotplug confirm`
+from a terminal, or — in the future — a pendant). Tell them you saw it
+("Got it — I see {decision} happened from the terminal.") and move on.
+```
+
+- [ ] **Step 5: Run the existing Revision 7 sync script**
+
+```bash
+# Whatever the existing invocation is — examples:
+~/robot-md/scripts/sync-skill.sh
+# OR
+bash cli/scripts/sync-skill.sh
+```
+
+If the script doesn't exist (drift since SP1): file a follow-up to add it, but for v1 hand-copy the canonical content into the mirror.
+
+- [ ] **Step 6: Run tests (expect PASS 3/3)**
+
+```bash
+cd cli && PYTHONPATH=src python -m pytest tests/hotplug_an/test_skill_text_has_hotplug_sections.py -v
+```
+
+- [ ] **Step 7: Commit (Task 5)**
+
+```bash
+git add cli/src/robot_md/skills/using-robot-md.SKILL.md cli/tests/hotplug_an/test_skill_text_has_hotplug_sections.py
+# If editing the npm-side repo, that commit lands separately.
+git commit -m "$(cat <<'EOF'
+docs(span): skill-text additions for hot-plug announce + confirm
+
+Three new sections in using-robot-md.SKILL.md:
+  1. Reacting to hot-plug events — review on resource update; announce
+     HIGH-tier auto-binds; surface MEDIUM/LOW alternatives; pass operator
+     answers to hotplug_confirm.
+  2. Modality hierarchy — voice-first when operator is in voice mode;
+     text-only otherwise.
+  3. Resolved-elsewhere handling — acknowledge already_resolved cleanly.
+
+Per simplification-revisions Rev 7, the canonical file is
+~/robot-md-mcp/skills/using-robot-md/SKILL.md; the CLI mirror in
+cli/src/robot_md/skills/ is regenerated by the existing sync script.
+
+Co-Authored-By: Claude Opus 4.7 (1M context) <noreply@anthropic.com>
+EOF
+)"
+```
+
+---
+
+## Phase C — Sandboxed Claude harness tests
+
+These tests don't call a live model. They simulate the MCP-side message flow that a Claude session experiences (resource update, tool calls, tool responses) and assert the skill-text contract — i.e., that "given resource X arrives in state Y, the next operator-visible action is Z." The harness is a small Python helper that loads the skill text + scripts the conversation deterministically.
+
+### Task 6: Skill-text harness fixture
+
+**Files:**
+- Create: `cli/tests/hotplug_an/conftest.py`
+
+- [ ] **Step 1: Create the harness fixture**
+
+```python
+# cli/tests/hotplug_an/conftest.py
+"""Sandboxed harness for skill-text contract tests.
+
+Provides a SkillTextHarness that loads the canonical SKILL.md, exposes
+helpers to assert the operator-visible behavior given a fixed sequence
+of MCP messages, and simulates 'voice mode' / 'text mode' rendering.
+"""
+
+from __future__ import annotations
+
+from dataclasses import dataclass, field
+from pathlib import Path
+from typing import Any
+
+import pytest
+
+_SKILL_PATH = Path(__file__).parents[2] / "src" / "robot_md" / "skills" / "using-robot-md.SKILL.md"
+
+
+@dataclass
+class HarnessTranscript:
+    voice_lines: list[str] = field(default_factory=list)
+    text_lines: list[str] = field(default_factory=list)
+    tool_calls: list[tuple[str, dict]] = field(default_factory=list)
+
+
+@dataclass
+class SkillTextHarness:
+    """Minimal contract-checker. Tests inspect the skill text + assert that
+    rules described in it are present (regex-level checks). For full
+    end-to-end behavior a live model is required; that is the manual
+    smoke step in Task 12."""
+    skill_text: str
+
+    def has_rule(self, *substrings: str) -> bool:
+        return all(s in self.skill_text for s in substrings)
+
+
+@pytest.fixture
+def harness() -> SkillTextHarness:
+    return SkillTextHarness(skill_text=_SKILL_PATH.read_text())
+```
+
+- [ ] **Step 2: Commit (Task 6)**
+
+```bash
+git add cli/tests/hotplug_an/__init__.py cli/tests/hotplug_an/conftest.py
+git commit -m "feat(span): skill-text harness fixture"
+```
+
+---
+
+### Task 7: Announce-HIGH-in-voice-mode contract
+
+**Files:**
+- Test: `cli/tests/hotplug_an/test_skill_announce_high_tier_in_voice_mode.py`
+
+- [ ] **Step 1: Write the test**
+
+```python
+# cli/tests/hotplug_an/test_skill_announce_high_tier_in_voice_mode.py
+from __future__ import annotations
+
+
+def test_skill_text_describes_high_tier_announce(harness) -> None:
+    assert harness.has_rule(
+        "HIGH-tier events that already resolved",
+        'I bound it as the {driver_id} driver',
+        "Say 'undo' to reject",
+    )
+
+
+def test_skill_text_announces_voice_first(harness) -> None:
+    assert harness.has_rule(
+        "voice mode",
+        "announce by voice first",
+        "mirror the same text to the chat",
+    )
+```
+
+- [ ] **Step 2: Run test (expect PASS — Task 5 already added the content)**
+
+- [ ] **Step 3: Commit (Task 7)**
+
+```bash
+git add cli/tests/hotplug_an/test_skill_announce_high_tier_in_voice_mode.py
+git commit -m "test(span): lock skill-text HIGH-tier voice-announce contract"
+```
+
+---
+
+### Task 8: Undo-within-30s contract
+
+**Files:**
+- Test: `cli/tests/hotplug_an/test_skill_undo_within_window_calls_reject.py`, `test_skill_undo_after_window_warns_manifest_bound.py`
+
+- [ ] **Step 1: Write both undo tests**
+
+```python
+# cli/tests/hotplug_an/test_skill_undo_within_window_calls_reject.py
+from __future__ import annotations
+
+
+def test_skill_text_pulls_undo_through_to_hotplug_confirm_reject(harness) -> None:
+    assert harness.has_rule(
+        "operator says undo",
+        'hotplug_confirm({event_id}, "reject")',
+    )
+
+
+def test_skill_text_mentions_30s_window(harness) -> None:
+    assert harness.has_rule("within 30 s")
+```
+
+```python
+# cli/tests/hotplug_an/test_skill_undo_after_window_warns_manifest_bound.py
+from __future__ import annotations
+
+
+def test_skill_text_warns_that_manifest_stays_bound(harness) -> None:
+    assert harness.has_rule(
+        "manifest stays bound",
+        "Manifest unbinding is out of scope",
+        "help edit ROBOT.md by hand",
+    )
+```
+
+- [ ] **Step 2: Run tests (expect PASS — Task 5 added content)**
+
+- [ ] **Step 3: Commit (Task 8)**
+
+```bash
+git add cli/tests/hotplug_an/test_skill_undo_*.py
+git commit -m "test(span): lock skill-text undo / manifest-stays-bound contracts"
+```
+
+---
+
+### Task 9: MEDIUM-tier alternatives surfacing
+
+**Files:**
+- Test: `cli/tests/hotplug_an/test_skill_medium_tier_surfaces_alternatives.py`
+
+- [ ] **Step 1: Write the test**
+
+```python
+# cli/tests/hotplug_an/test_skill_medium_tier_surfaces_alternatives.py
+from __future__ import annotations
+
+
+def test_skill_text_describes_medium_tier_alternatives(harness) -> None:
+    assert harness.has_rule(
+        "MEDIUM/LOW-tier pending events",
+        "Surface the event with its alternatives",
+        "pick a different option, or reject",
+        "Call `hotplug_confirm` with their answer",
+    )
+```
+
+- [ ] **Step 2: Run test (expect PASS)**
+
+- [ ] **Step 3: Commit (Task 9)**
+
+```bash
+git add cli/tests/hotplug_an/test_skill_medium_tier_surfaces_alternatives.py
+git commit -m "test(span): lock skill-text MEDIUM-tier alternatives contract"
+```
+
+---
+
+### Task 10: Resolved-elsewhere acknowledgement
+
+**Files:**
+- Test: `cli/tests/hotplug_an/test_skill_resolved_elsewhere_acknowledges.py`
+
+- [ ] **Step 1: Write the test**
+
+```python
+# cli/tests/hotplug_an/test_skill_resolved_elsewhere_acknowledges.py
+from __future__ import annotations
+
+
+def test_skill_text_handles_already_resolved(harness) -> None:
+    assert harness.has_rule(
+        "already_resolved",
+        "operator confirmed it via another path",
+        "happened from the terminal",
+    )
+```
+
+- [ ] **Step 2: Run test (expect PASS)**
+
+- [ ] **Step 3: Commit (Task 10)**
+
+```bash
+git add cli/tests/hotplug_an/test_skill_resolved_elsewhere_acknowledges.py
+git commit -m "test(span): lock skill-text resolved-elsewhere acknowledgement contract"
+```
+
+---
+
+## Phase D — Documentation + manual smoke
+
+### Task 11: `cli/docs/hotplug-roadmap.md` — v2 follow-ups
+
+**Files:**
+- Create: `cli/docs/hotplug-roadmap.md`
+
+- [ ] **Step 1: Write the roadmap page**
+
+```markdown
+# Hot-plug roadmap (v2 and beyond)
+
+SP-AN v1 ships Claude chat + voice-mode audio. The following items are
+explicitly deferred and tracked here so v2 work has a starting point:
+
+## v2 — pendant screen surface
+
+- pendant-mcp gains `pendant_set_pending_panel(events)` tool. Skill text
+  calls it whenever new pending events appear; pendantd's existing
+  status renderer shows a "NEW HARDWARE" panel + Confirm/Reject/Skip
+  button bindings.
+- pendant-mcp depends on the separate
+  `2026-04-25-voice-host-audio-design.md` spec landing first.
+- Pendant hardware bring-up must unblock (BOOT button issue).
+
+## v2 — pendant independent subscriber
+
+- pendantd hosts its own Linux Unix-socket subscriber (mirroring the
+  MCP server's path). Removes the v1 limitation that pendant requires
+  an active Claude session to see real-time events.
+
+## v2 — manifest unbind tool (`hotplug_unbind`)
+
+- Complement to `hotplug_confirm`. Takes an existing driver_id; removes
+  it from `drivers[]` after safety checks (no kinematics referencing,
+  no in-flight execution).
+- Driver-dependency + safety semantics designed during the v2 plan.
+
+## v3+ — web UI surface
+
+- Out of scope for v2; tracked here so the queue contract design choices
+  (pending → resolved single-writer, hash-chained) hold the line on what
+  surfaces are addable without queue-shape changes.
+
+## v3+ — operator preferences
+
+- Per-RRN `~/.robot-md/hotplug-preferences.toml`: "always confirm even on
+  HIGH" / "never bind backend X" / etc. v1 uses SP-HP's tier policy as-is.
+```
+
+- [ ] **Step 2: Commit (Task 11)**
+
+```bash
+git add cli/docs/hotplug-roadmap.md
+git commit -m "docs(span): hotplug v2 roadmap (pendant + unbind tool + web UI + prefs)"
+```
+
+---
+
+### Task 12: Manual smoke checklist
+
+**Files:**
+- Create: `cli/tests/manual/span_smoke.md`
+
+- [ ] **Step 1: Write the manual smoke**
+
+```markdown
+# SP-AN v1 smoke — manual checks on bob
+
+Pre-requisites: SP-HP daemon running. Claude session open in either
+voice or text mode. Worktree `pip install -e cli[hardware]` complete.
+
+1. **Voice-mode HIGH-tier auto-bind.** With operator in Claude voice
+   mode, replug the SO-ARM101 USB cable on bob. Within 5 s of the plug
+   click, Claude announces by voice: "Found an SO-ARM101 on
+   /dev/ttyACM0. I bound it as arm_servos using lerobot. Say 'undo' to
+   reject." Confirm the announce text appears in chat too.
+
+2. **Voice-mode undo within window.** Same as #1 but the operator says
+   "undo" within 30 s. Confirm: a `resolution: reject` record appears
+   in `~/.robot-md/hotplug-events.jsonl` for that event_id; the
+   manifest still has the driver (manifest unbind is v2).
+
+3. **Voice-mode undo after window.** Same as #1 but the operator says
+   "undo" 60 s later. Claude still calls `hotplug_confirm({event_id},
+   "reject")`. Claude warns: "the manifest is already bound; want me
+   to help unbind by hand?"
+
+4. **Text-mode MEDIUM event.** With operator in text mode (no voice),
+   plug a generic CH340 dongle. Claude surfaces the alternatives in
+   chat. Operator picks one. Claude passes the choice to
+   `hotplug_confirm` with `choice_index`. Manifest gets the driver.
+
+5. **No-Claude-session durability.** Close the Claude session. Plug a
+   device. Reopen Claude. The event surfaces in the next interaction
+   via the resource update.
+
+6. **Resolved-elsewhere via terminal CLI.** With Claude session open,
+   from a separate shell: `robot-md hotplug confirm <event_id> --bind`.
+   Claude's next interaction acknowledges: "Got it — I see bind
+   happened from the terminal."
+```
+
+- [ ] **Step 2: Commit (Task 12)**
+
+```bash
+git add cli/tests/manual/span_smoke.md
+git commit -m "docs(span): manual smoke checklist (6 items)"
+```
+
+---
+
+## Implementation Order Summary
+
+```
+Phase A — robot-md://hotplug/pending resource
+  1. build_pending_payload — read-only view over EventQueue
+  2. Register the resource on the MCP server
+  3. Linux socket subscriber emits notifications/resources/updated
+  4. File-poll fallback for non-Linux + no-self-loop guard
+
+Phase B — skill text
+  5. Three new sections in using-robot-md.SKILL.md (synced canonical → mirror)
+
+Phase C — sandboxed harness contract tests
+  6. SkillTextHarness fixture
+  7. HIGH-tier voice-announce contract
+  8. undo-within / after-window contracts
+  9. MEDIUM-tier alternatives contract
+ 10. resolved-elsewhere acknowledgement contract
+
+Phase D — docs + smoke
+ 11. cli/docs/hotplug-roadmap.md (v2 follow-ups)
+ 12. cli/tests/manual/span_smoke.md (6-item checklist)
+```
+
+---
+
+## Success Criteria
+
+SP-AN v1 is done when:
+
+- [ ] All 12 tasks merged.
+- [ ] `robot-md://hotplug/pending` resource lists pending events; resource updates fire on socket-nudge (Linux) and file-poll (macOS / Windows).
+- [ ] Skill-text additions live in the canonical `using-robot-md.SKILL.md` and propagate to the CLI mirror via the existing sync script.
+- [ ] All resource-subscription unit tests pass on Linux (the socket-nudge tests skip cleanly on macOS / Windows; file-poll tests run on all three).
+- [ ] All skill-text harness tests pass (5/5 contract checks).
+- [ ] Manual smoke checklist (`cli/tests/manual/span_smoke.md`) passes 6/6 on bob.
+- [ ] `cli/docs/hotplug-roadmap.md` documents the v2 follow-ups (pendant surface, manifest unbind tool, operator preferences) so future SP-AN v2 work has a starting page.
+- [ ] Demo dry-run: operator in voice mode, no display attached on bob; replug SO-ARM101; Claude announces the bind audibly within 5 s; operator says "looks good"; conversation continues.
+
+---
+
+## Notes for the implementer
+
+- **No live model required for v1 contract tests.** The skill-text harness in Task 6 is regex-level — it asserts the rules are present in the skill file, not that Claude follows them. Real-model behavior is verified in the manual smoke (Task 12). If your shop has a Claude-powered integration harness (some superpowers projects do), you can extend `SkillTextHarness` to actually drive a model.
+- **Canonical / mirror skill-file editing** depends on whether the npm-side `robot-md-mcp` repo is checked out adjacent to this worktree. If yes, edit canonical first, run sync. If no, edit the CLI mirror, file a follow-up PR against the npm repo, and let CI's drift check catch divergence.
+- **The Linux socket subscriber connects as a CLIENT to the daemon's pre-bound socket.** Don't bind a second socket from the MCP server — that would conflict with SP-HP's daemon. The socket is one-way: daemon writes 1-byte nudges; subscriber reads them.
+- **`server.send_resource_updated(URI)` is illustrative.** The actual FastMCP API may differ; if it does, follow the same pattern the SP-HP plan's `notifications/tools/list_changed` emission uses (Task 17 in SP-HP plan) — those land first and establish the project convention.
+- **Each task ends with a commit.** Plan execution is incremental.

--- a/docs/superpowers/plans/2026-04-27-sp-hp-hotplug-daemon.md
+++ b/docs/superpowers/plans/2026-04-27-sp-hp-hotplug-daemon.md
@@ -1,0 +1,3432 @@
+# SP-HP — Hot-Plug Daemon Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Ship the SP-HP runtime hot-plug daemon — a sibling persistent OS-level service (`robot-md hotplug-daemon`) that watches for USB / serial device hot-plug events, classifies them by tier (HIGH / MEDIUM / LOW), auto-binds HIGH-tier matches into the manifest, queues MEDIUM/LOW for operator confirmation, and exposes `hotplug_review` + `hotplug_confirm` MCP tools. Cross-platform from v1: Linux (pyudev real-time, <50 ms), macOS (ioreg + pyserial.tools.list_ports polling, 1–2 s), Windows (pywin32 WM_DEVICECHANGE + polling fallback, 1–2 s).
+
+**Architecture:** Daemon lives in a new `cli/src/robot_md/hotplug/` package: per-platform `{linux,macos,windows}.py` watchers all yielding the same `DeviceEvent` shape; `matcher.py` classifies events by tier; `queue.py` writes a hash-chained `~/.robot-md/hotplug-events.jsonl`; `manifest.py` merges HIGH-tier auto-binds with schema validation BEFORE write; `audit.py` mirrors RRF's hash-chained audit-log shape per RRN. Daemon entry point at `daemon.py` composes everything + listens on a Linux Unix socket (`/run/user/$UID/robot-md-hotplug.sock`) for low-latency MCP wakeup nudges; macOS / Windows fall back to file-poll. MCP server gains: an inotify watch on `ROBOT.md` (kqueue on macOS via `watchdog`; ReadDirectoryChangesW on Windows) that reloads `RobotSpec` + emits `notifications/tools/list_changed`; a socket subscriber that drains the queue on nudge; two new tools (`hotplug_review`, `hotplug_confirm`). CLI surface: `robot-md hotplug-daemon start|stop|status`, `robot-md hotplug review|confirm`, `robot-md hotplug install-service`.
+
+**Tech Stack:** Python 3.10+, asyncio, `pyudev` (Linux watcher), `pyserial.tools.list_ports` + `subprocess` to `ioreg` (macOS), `pywin32` (Windows), `watchdog` (cross-platform inotify abstraction), existing `jsonschema` validation, existing `fcntl` / `msvcrt.locking` for cross-platform file locking, `importlib.metadata.entry_points` for backend lookup, `hashlib.sha256` for queue/audit hash chains.
+
+**Spec:** `docs/superpowers/specs/2026-04-27-sp-hp-hotplug-daemon-design.md`
+
+**Depends on:** SP3 capability-metadata addendum (`Capability` dataclass, `enumerate_capabilities`) — Phase A of SP3 plan must land first.
+
+---
+
+## File Structure
+
+**Daemon core (`cli/src/robot_md/hotplug/`):**
+- `cli/src/robot_md/hotplug/__init__.py` — NEW. Public API re-exports.
+- `cli/src/robot_md/hotplug/event.py` — NEW. `DeviceEvent` dataclass + transport-classification heuristic.
+- `cli/src/robot_md/hotplug/linux.py` — NEW. `watch_devices()` async-iterator wrapping `pyudev.Monitor`.
+- `cli/src/robot_md/hotplug/macos.py` — NEW. `watch_devices()` polling `ioreg -p IOUSB -l` + `pyserial.tools.list_ports`.
+- `cli/src/robot_md/hotplug/windows.py` — NEW. `watch_devices()` consuming `WM_DEVICECHANGE` + polling fallback.
+- `cli/src/robot_md/hotplug/matcher.py` — NEW. `BindProposal`, `Decision` dataclasses + `classify(evt)`.
+- `cli/src/robot_md/hotplug/presets_index.py` — NEW. VID:PID → preset lookup table; built from existing presets at import time.
+- `cli/src/robot_md/hotplug/queue.py` — NEW. `EventQueue` hash-chained append-only writer + reader.
+- `cli/src/robot_md/hotplug/audit.py` — NEW. `AuditLog` per-RRN hash-chained append-only.
+- `cli/src/robot_md/hotplug/manifest.py` — NEW. `merge(proposal, manifest_path)` with schema gate + fcntl lock.
+- `cli/src/robot_md/hotplug/socket_listener.py` — NEW. Linux-only Unix socket listener for MCP-server nudges.
+- `cli/src/robot_md/hotplug/daemon.py` — NEW. Async event loop composing watcher + matcher + queue + manifest + audit + socket.
+- `cli/src/robot_md/hotplug/config.py` — NEW. Reads `~/.robot-md/hotplug.toml` (`pending_ttl_days`, etc.).
+
+**MCP-server changes:**
+- `cli/src/robot_md/mcp/server.py` — MODIFY. Register `hotplug_review` + `hotplug_confirm` tools; install inotify watch on `ROBOT.md`; create socket subscriber on connect.
+- `cli/src/robot_md/mcp/tools/hotplug_review.py` — NEW. Reads pending events from `EventQueue`.
+- `cli/src/robot_md/mcp/tools/hotplug_confirm.py` — NEW. Writes resolution via daemon socket-or-file API.
+- `cli/src/robot_md/mcp/manifest_watcher.py` — NEW. inotify wrapper using `watchdog`; reloads `RobotSpec`, refreshes `BackendRegistry`, emits `notifications/tools/list_changed`.
+
+**CLI:**
+- `cli/src/robot_md/__main__.py` — MODIFY. Add `hotplug-daemon` and `hotplug` Typer subcommand groups.
+- `cli/src/robot_md/hotplug/cli.py` — NEW. Typer app for `start|stop|status|review|confirm|install-service`.
+- `cli/src/robot_md/hotplug/service_installers/linux_systemd.py` — NEW. Writes `~/.config/systemd/user/robot-md-hotplug.service`.
+- `cli/src/robot_md/hotplug/service_installers/macos_launchd.py` — NEW. Writes `~/Library/LaunchAgents/dev.robotmd.hotplug.plist`.
+- `cli/src/robot_md/hotplug/service_installers/windows_taskscheduler.py` — NEW. Creates Scheduled Task via `pywin32`.
+
+**Tests (`cli/tests/hotplug/`):**
+- Unit: `test_device_event.py`, `test_matcher_high_tier_*.py`, `test_matcher_medium_tier_*.py`, `test_matcher_low_tier_*.py`, `test_matcher_recent_reject_demotes.py`, `test_queue_append_pending_atomic.py`, `test_queue_resolution_first_writer_wins.py`, `test_queue_truncation_recovery.py`, `test_queue_hash_chain.py`, `test_queue_ttl_expiry.py`, `test_audit_log_append.py`, `test_manifest_merge_appends_driver.py`, `test_manifest_merge_validates_before_write.py`, `test_manifest_merge_locking.py`, `test_manifest_merge_no_manifest.py`, `test_socket_listener.py`, `test_daemon_starts_and_stops_clean.py`, `test_daemon_dedupes_replug.py`, `test_daemon_two_instances_eaddrinuse.py`, `test_daemon_handles_pending_ttl.py`.
+- Per-platform: `test_linux_watch_devices.py` (`@pytest.mark.linux`), `test_macos_watch_devices.py` (`@pytest.mark.darwin`), `test_windows_watch_devices.py` (`@pytest.mark.win32`), `test_device_event_shape_consistent_across_platforms.py`.
+- MCP-server: `test_mcp_inotify_reload_on_manifest_change.py`, `test_mcp_socket_subscribe_drains_queue.py`, `test_mcp_socket_fallback_to_polling.py`, `test_hotplug_review_returns_pending_only.py`, `test_hotplug_confirm_bind_writes_manifest.py`, `test_hotplug_confirm_reject_appends_resolution.py`.
+- CLI: `test_cli_hotplug_install_service_linux.py`, `test_cli_hotplug_install_service_macos.py`, `test_cli_hotplug_status_reports_running.py`, `test_cli_hotplug_review_lists_pending.py`.
+- Integration: `cli/tests/integration/test_sphp_replug_high_tier_end_to_end.py`.
+- Hardware: `cli/tests/hardware/test_sphp_replug_so_arm101_high_tier.py`, `test_sphp_unknown_device_low_tier.py` (both `@pytest.mark.hardware`).
+- Manual smoke: `cli/tests/manual/sphp_smoke.md`.
+
+---
+
+## Phase A — DeviceEvent + per-platform watchers
+
+### Task 1: Add `DeviceEvent` dataclass + transport heuristic
+
+**Files:**
+- Create: `cli/src/robot_md/hotplug/__init__.py`, `cli/src/robot_md/hotplug/event.py`
+- Test: `cli/tests/hotplug/test_device_event.py`
+
+- [ ] **Step 1: Write the dataclass test**
+
+```python
+# cli/tests/hotplug/test_device_event.py
+from __future__ import annotations
+
+import pytest
+
+from robot_md.hotplug.event import DeviceEvent, classify_transport
+
+
+def test_device_event_is_frozen() -> None:
+    e = DeviceEvent(
+        kind="usb_added",
+        vid="1a86", pid="7523", serial="AB12",
+        path="/dev/ttyACM0",
+        transport="feetech",
+        raw_metadata={},
+        detected_at="2026-04-27T19:30:11Z",
+    )
+    with pytest.raises(Exception):
+        e.path = "/dev/ttyACM1"
+
+
+def test_classify_transport_known_feetech_chip() -> None:
+    # CH340 — bog-standard feetech bus chip used by SO-ARM101.
+    assert classify_transport(vid="1a86", pid="7523", subsystem="tty") == "feetech"
+
+
+def test_classify_transport_realsense() -> None:
+    # Intel RealSense D435 vendor ID.
+    assert classify_transport(vid="8086", pid="0b07", subsystem="usb") == "realsense"
+
+
+def test_classify_transport_unknown() -> None:
+    assert classify_transport(vid="dead", pid="beef", subsystem="usb") == "unknown"
+```
+
+- [ ] **Step 2: Run test (expect FAIL — module missing)**
+
+```bash
+cd cli && PYTHONPATH=src python -m pytest tests/hotplug/test_device_event.py -v
+```
+
+- [ ] **Step 3: Create `event.py`**
+
+```python
+# cli/src/robot_md/hotplug/event.py
+from __future__ import annotations
+
+from dataclasses import dataclass
+from typing import Any, Literal
+
+
+# VID:PID lookup table for known transports. Community-curated; expand via PR.
+_TRANSPORT_TABLE: dict[tuple[str, str], str] = {
+    ("1a86", "7523"): "feetech",   # CH340 — SO-ARM101, generic feetech bus
+    ("0403", "6014"): "feetech",   # FTDI FT232H — alt feetech bus
+    ("8086", "0b07"): "realsense", # Intel RealSense D435
+    ("8086", "0b3a"): "realsense", # Intel RealSense D455
+    ("03e7", "2485"): "uvc",       # Luxonis OAK-D
+}
+
+
+@dataclass(frozen=True)
+class DeviceEvent:
+    kind: Literal["usb_added", "tty_added"]
+    vid: str | None
+    pid: str | None
+    serial: str | None
+    path: str
+    transport: Literal["feetech", "dynamixel", "realsense", "uvc", "unknown"]
+    raw_metadata: dict[str, Any]
+    detected_at: str  # ISO-8601 UTC
+
+
+def classify_transport(*, vid: str | None, pid: str | None, subsystem: str) -> str:
+    """Return a transport hint for a USB/tty device.
+
+    Looks up VID:PID in the curated table; falls back to "unknown".
+    """
+    if vid is None or pid is None:
+        return "unknown"
+    return _TRANSPORT_TABLE.get((vid.lower(), pid.lower()), "unknown")
+```
+
+Create `cli/src/robot_md/hotplug/__init__.py`:
+
+```python
+"""Public API for the hot-plug daemon."""
+
+from __future__ import annotations
+
+from robot_md.hotplug.event import DeviceEvent, classify_transport
+
+__all__ = ["DeviceEvent", "classify_transport"]
+```
+
+- [ ] **Step 4: Run test (expect PASS 4/4)**
+
+- [ ] **Step 5: Commit (Task 1)**
+
+```bash
+cd /home/craigm26/robot-md/.worktrees/sp3-sdk-adapter
+git add cli/src/robot_md/hotplug/__init__.py cli/src/robot_md/hotplug/event.py cli/tests/hotplug/test_device_event.py
+git commit -m "$(cat <<'EOF'
+feat(sphp): DeviceEvent dataclass + classify_transport heuristic
+
+frozen=True DeviceEvent (kind/vid/pid/serial/path/transport/raw_metadata/
+detected_at) shared across all three platform watchers.
+
+classify_transport: looks up VID:PID in a curated table (CH340, FT232H,
+Intel RealSense D435/D455, Luxonis OAK-D); returns "unknown" fallthrough
+which maps to LOW tier in the matcher.
+
+Table is community-curated via PR — no autoupdate.
+
+Co-Authored-By: Claude Opus 4.7 (1M context) <noreply@anthropic.com>
+EOF
+)"
+```
+
+---
+
+### Task 2: Linux `watch_devices()` (pyudev real-time)
+
+**Files:**
+- Create: `cli/src/robot_md/hotplug/linux.py`
+- Test: `cli/tests/hotplug/test_linux_watch_devices.py`
+
+- [ ] **Step 1: Write the linux watcher test**
+
+```python
+# cli/tests/hotplug/test_linux_watch_devices.py
+from __future__ import annotations
+
+import asyncio
+import sys
+import types
+from unittest.mock import MagicMock
+
+import pytest
+
+from robot_md.hotplug.event import DeviceEvent
+
+
+pytestmark = pytest.mark.skipif(sys.platform != "linux", reason="linux-only")
+
+
+def _install_fake_pyudev(monkeypatch, fake_events):
+    """Stand up a fake pyudev module that yields the supplied (action, device) pairs."""
+    fake = types.ModuleType("pyudev")
+
+    class _Context: ...
+
+    class _Monitor:
+        @classmethod
+        def from_netlink(cls, ctx):
+            m = cls()
+            m._events = list(fake_events)
+            return m
+
+        def filter_by(self, subsystem):
+            return self
+
+        def start(self):
+            return self
+
+        def __iter__(self):
+            return iter(self._events)
+
+    fake.Context = _Context
+    fake.Monitor = _Monitor
+    monkeypatch.setitem(sys.modules, "pyudev", fake)
+
+
+def _make_fake_udev_device(*, vid="1a86", pid="7523", serial="AB12", subsystem="tty", path="/dev/ttyACM0"):
+    dev = MagicMock()
+    dev.subsystem = subsystem
+    dev.device_node = path
+    dev.get.side_effect = lambda key, default=None: {
+        "ID_VENDOR_ID": vid,
+        "ID_MODEL_ID": pid,
+        "ID_SERIAL_SHORT": serial,
+    }.get(key, default)
+    return dev
+
+
+def test_watch_devices_yields_device_event_on_add(monkeypatch) -> None:
+    fake_dev = _make_fake_udev_device()
+    _install_fake_pyudev(monkeypatch, [("add", fake_dev)])
+
+    from robot_md.hotplug.linux import watch_devices
+
+    async def first():
+        async for evt in watch_devices():
+            return evt
+        return None
+
+    evt = asyncio.run(first())
+    assert isinstance(evt, DeviceEvent)
+    assert evt.vid == "1a86"
+    assert evt.pid == "7523"
+    assert evt.transport == "feetech"
+    assert evt.path == "/dev/ttyACM0"
+
+
+def test_watch_devices_skips_remove_actions(monkeypatch) -> None:
+    fake_remove = _make_fake_udev_device()
+    fake_add = _make_fake_udev_device(path="/dev/ttyACM1")
+    _install_fake_pyudev(monkeypatch, [("remove", fake_remove), ("add", fake_add)])
+
+    from robot_md.hotplug.linux import watch_devices
+
+    async def first():
+        async for evt in watch_devices():
+            return evt
+
+    evt = asyncio.run(first())
+    assert evt.path == "/dev/ttyACM1"  # remove was skipped
+```
+
+- [ ] **Step 2: Run test (expect FAIL — module missing)**
+
+- [ ] **Step 3: Implement `linux.py`**
+
+```python
+# cli/src/robot_md/hotplug/linux.py
+"""Linux pyudev-based real-time device watcher. <50ms latency."""
+
+from __future__ import annotations
+
+import asyncio
+from datetime import datetime, timezone
+from typing import AsyncIterator
+
+from robot_md.hotplug.event import DeviceEvent, classify_transport
+
+
+async def watch_devices() -> AsyncIterator[DeviceEvent]:
+    import pyudev
+
+    ctx = pyudev.Context()
+    monitor = pyudev.Monitor.from_netlink(ctx)
+    monitor.filter_by(subsystem="usb")
+    monitor.filter_by(subsystem="tty")
+    monitor.start()
+
+    loop = asyncio.get_running_loop()
+    queue: asyncio.Queue = asyncio.Queue()
+
+    def _drain():
+        for action, device in monitor:
+            if action != "add":
+                continue
+            evt = _device_to_event(device)
+            asyncio.run_coroutine_threadsafe(queue.put(evt), loop)
+
+    # Background reader so the iterator can yield without blocking the event loop.
+    asyncio.get_running_loop().run_in_executor(None, _drain)
+
+    while True:
+        evt = await queue.get()
+        yield evt
+
+
+def _device_to_event(device) -> DeviceEvent:
+    vid = device.get("ID_VENDOR_ID")
+    pid = device.get("ID_MODEL_ID")
+    serial = device.get("ID_SERIAL_SHORT")
+    subsystem = device.subsystem
+    return DeviceEvent(
+        kind=("tty_added" if subsystem == "tty" else "usb_added"),
+        vid=vid, pid=pid, serial=serial,
+        path=device.device_node or "",
+        transport=classify_transport(vid=vid, pid=pid, subsystem=subsystem),
+        raw_metadata={},
+        detected_at=datetime.now(timezone.utc).isoformat().replace("+00:00", "Z"),
+    )
+```
+
+(The test's fake-Monitor `__iter__` is synchronous; the production code's threadpool drain is the right shape but the test exercises the iterator's `_device_to_event` path directly via the synchronous `for` loop. Adapt the test if the real implementation needs more substantial loop integration — the goal is to assert the event-shape conversion, not the asyncio plumbing.)
+
+- [ ] **Step 4: Run test (expect PASS 2/2)**
+
+- [ ] **Step 5: Commit (Task 2)**
+
+```bash
+git add cli/src/robot_md/hotplug/linux.py cli/tests/hotplug/test_linux_watch_devices.py
+git commit -m "feat(sphp): linux watch_devices() via pyudev netlink monitor"
+```
+
+---
+
+### Task 3: macOS `watch_devices()` (ioreg + pyserial polling)
+
+**Files:**
+- Create: `cli/src/robot_md/hotplug/macos.py`
+- Test: `cli/tests/hotplug/test_macos_watch_devices.py`
+
+- [ ] **Step 1: Write the macOS watcher test**
+
+```python
+# cli/tests/hotplug/test_macos_watch_devices.py
+from __future__ import annotations
+
+import asyncio
+import sys
+from unittest.mock import patch
+
+import pytest
+
+from robot_md.hotplug.event import DeviceEvent
+
+
+pytestmark = pytest.mark.skipif(sys.platform != "darwin", reason="macOS-only")
+
+
+def _fake_enumerate_first_call() -> set:
+    return set()  # initial empty
+
+
+def _fake_enumerate_second_call() -> set:
+    return {("1a86", "7523", "AB12", "/dev/cu.usbmodem1234")}
+
+
+def test_watch_devices_emits_new_devices_on_diff(monkeypatch) -> None:
+    from robot_md.hotplug import macos as mod
+    calls = iter([_fake_enumerate_first_call(), _fake_enumerate_second_call()])
+
+    def fake_enum():
+        return next(calls)
+
+    monkeypatch.setattr(mod, "_enumerate_macos", fake_enum)
+    # Drop the polling delay so the test runs fast.
+    monkeypatch.setattr(mod, "_POLL_INTERVAL_S", 0.0)
+
+    async def first():
+        async for evt in mod.watch_devices():
+            return evt
+
+    evt = asyncio.run(asyncio.wait_for(first(), timeout=2.0))
+    assert isinstance(evt, DeviceEvent)
+    assert evt.vid == "1a86"
+    assert evt.path == "/dev/cu.usbmodem1234"
+```
+
+- [ ] **Step 2: Run test (expect FAIL — module missing)**
+
+- [ ] **Step 3: Implement `macos.py`**
+
+```python
+# cli/src/robot_md/hotplug/macos.py
+"""macOS device watcher. ioreg + pyserial polling, 1.5s tick."""
+
+from __future__ import annotations
+
+import asyncio
+import subprocess
+from datetime import datetime, timezone
+from typing import AsyncIterator
+
+from robot_md.hotplug.event import DeviceEvent, classify_transport
+
+_POLL_INTERVAL_S = 1.5
+
+
+def _enumerate_macos() -> set[tuple]:
+    """Return {(vid, pid, serial, path), ...} for currently-attached USB+serial devices."""
+    out: set[tuple] = set()
+    # Serial ports via pyserial.
+    try:
+        from serial.tools import list_ports
+        for p in list_ports.comports():
+            vid = f"{p.vid:04x}" if p.vid else None
+            pid = f"{p.pid:04x}" if p.pid else None
+            out.add((vid, pid, p.serial_number, p.device))
+    except Exception:
+        pass
+    # USB devices via ioreg.
+    try:
+        result = subprocess.run(
+            ["ioreg", "-p", "IOUSB", "-l", "-w", "0"],
+            capture_output=True, text=True, timeout=5,
+        )
+        out.update(_parse_ioreg(result.stdout))
+    except Exception:
+        pass
+    return out
+
+
+def _parse_ioreg(text: str) -> set[tuple]:
+    """Best-effort VID/PID/serial extraction from `ioreg -p IOUSB -l` output."""
+    out: set[tuple] = set()
+    blocks = text.split("+-o ")
+    for block in blocks:
+        vid = _extract(block, '"idVendor" = ')
+        pid = _extract(block, '"idProduct" = ')
+        serial = _extract(block, '"USB Serial Number" = "')
+        if vid is not None and pid is not None:
+            try:
+                vid_hex = f"{int(vid):04x}"
+                pid_hex = f"{int(pid):04x}"
+            except ValueError:
+                continue
+            out.add((vid_hex, pid_hex, (serial.strip('"') if serial else None), ""))
+    return out
+
+
+def _extract(block: str, marker: str) -> str | None:
+    idx = block.find(marker)
+    if idx == -1:
+        return None
+    rest = block[idx + len(marker):]
+    end = rest.find("\n")
+    return (rest[:end] if end != -1 else rest).strip()
+
+
+async def watch_devices() -> AsyncIterator[DeviceEvent]:
+    seen = _enumerate_macos()
+    while True:
+        await asyncio.sleep(_POLL_INTERVAL_S)
+        current = _enumerate_macos()
+        new = current - seen
+        seen = current
+        for (vid, pid, serial, path) in new:
+            yield DeviceEvent(
+                kind="tty_added" if path else "usb_added",
+                vid=vid, pid=pid, serial=serial,
+                path=path,
+                transport=classify_transport(vid=vid, pid=pid, subsystem=("tty" if path else "usb")),
+                raw_metadata={},
+                detected_at=datetime.now(timezone.utc).isoformat().replace("+00:00", "Z"),
+            )
+```
+
+- [ ] **Step 4: Run test (expect PASS)**
+
+- [ ] **Step 5: Commit (Task 3)**
+
+```bash
+git add cli/src/robot_md/hotplug/macos.py cli/tests/hotplug/test_macos_watch_devices.py
+git commit -m "feat(sphp): macOS watch_devices() via ioreg + pyserial polling"
+```
+
+---
+
+### Task 4: Windows `watch_devices()` (WM_DEVICECHANGE + polling fallback)
+
+**Files:**
+- Create: `cli/src/robot_md/hotplug/windows.py`
+- Test: `cli/tests/hotplug/test_windows_watch_devices.py`
+
+- [ ] **Step 1: Write the Windows watcher test**
+
+```python
+# cli/tests/hotplug/test_windows_watch_devices.py
+from __future__ import annotations
+
+import asyncio
+import sys
+
+import pytest
+
+from robot_md.hotplug.event import DeviceEvent
+
+
+pytestmark = pytest.mark.skipif(sys.platform != "win32", reason="Windows-only")
+
+
+def test_watch_devices_emits_event_on_polling_diff(monkeypatch) -> None:
+    from robot_md.hotplug import windows as mod
+    states = iter([set(), {("1a86", "7523", "ABC", "COM3")}])
+
+    monkeypatch.setattr(mod, "_enumerate_windows", lambda: next(states))
+    monkeypatch.setattr(mod, "_POLL_INTERVAL_S", 0.0)
+
+    async def first():
+        async for evt in mod.watch_devices():
+            return evt
+
+    evt = asyncio.run(asyncio.wait_for(first(), timeout=2.0))
+    assert isinstance(evt, DeviceEvent)
+    assert evt.path == "COM3"
+    assert evt.vid == "1a86"
+```
+
+- [ ] **Step 2: Run test (expect FAIL — module missing)**
+
+- [ ] **Step 3: Implement `windows.py`**
+
+```python
+# cli/src/robot_md/hotplug/windows.py
+"""Windows device watcher. WM_DEVICECHANGE preferred; polling fallback."""
+
+from __future__ import annotations
+
+import asyncio
+from datetime import datetime, timezone
+from typing import AsyncIterator
+
+from robot_md.hotplug.event import DeviceEvent, classify_transport
+
+_POLL_INTERVAL_S = 1.5
+
+
+def _enumerate_windows() -> set[tuple]:
+    """Return {(vid, pid, serial, path), ...} via pyserial.list_ports."""
+    out: set[tuple] = set()
+    try:
+        from serial.tools import list_ports
+        for p in list_ports.comports():
+            vid = f"{p.vid:04x}" if p.vid else None
+            pid = f"{p.pid:04x}" if p.pid else None
+            out.add((vid, pid, p.serial_number, p.device))
+    except Exception:
+        pass
+    return out
+
+
+async def watch_devices() -> AsyncIterator[DeviceEvent]:
+    """Polling fallback. The WM_DEVICECHANGE message-pump path is wired up
+    in Task 5's daemon entry when running under the systemtray app stub.
+    For test + headless service contexts, polling is sufficient."""
+    seen = _enumerate_windows()
+    while True:
+        await asyncio.sleep(_POLL_INTERVAL_S)
+        current = _enumerate_windows()
+        new = current - seen
+        seen = current
+        for (vid, pid, serial, path) in new:
+            yield DeviceEvent(
+                kind="tty_added",
+                vid=vid, pid=pid, serial=serial,
+                path=path,
+                transport=classify_transport(vid=vid, pid=pid, subsystem="tty"),
+                raw_metadata={},
+                detected_at=datetime.now(timezone.utc).isoformat().replace("+00:00", "Z"),
+            )
+```
+
+- [ ] **Step 4: Run test (expect PASS)**
+
+- [ ] **Step 5: Commit (Task 4)**
+
+```bash
+git add cli/src/robot_md/hotplug/windows.py cli/tests/hotplug/test_windows_watch_devices.py
+git commit -m "feat(sphp): Windows watch_devices() polling fallback (WM_DEVICECHANGE in Task 5)"
+```
+
+---
+
+### Task 5: Lock cross-platform DeviceEvent shape consistency
+
+**Files:**
+- Test: `cli/tests/hotplug/test_device_event_shape_consistent_across_platforms.py`
+
+- [ ] **Step 1: Write the consistency test**
+
+```python
+# cli/tests/hotplug/test_device_event_shape_consistent_across_platforms.py
+from __future__ import annotations
+
+from dataclasses import fields
+
+from robot_md.hotplug.event import DeviceEvent
+
+
+def test_all_event_field_names_stable() -> None:
+    """If anyone touches DeviceEvent's field set, they must update all three
+    watchers + the matcher together. This test pins the field names."""
+    expected = {
+        "kind", "vid", "pid", "serial", "path",
+        "transport", "raw_metadata", "detected_at",
+    }
+    actual = {f.name for f in fields(DeviceEvent)}
+    assert actual == expected, (
+        f"DeviceEvent fields drifted from canonical set. "
+        f"Expected {expected}, got {actual}. "
+        f"Update linux.py / macos.py / windows.py + matcher.py atomically."
+    )
+```
+
+- [ ] **Step 2: Run test (expect PASS)**
+
+- [ ] **Step 3: Commit (Task 5)**
+
+```bash
+git add cli/tests/hotplug/test_device_event_shape_consistent_across_platforms.py
+git commit -m "test(sphp): pin DeviceEvent field set across all three platforms"
+```
+
+---
+
+## Phase B — Matcher (tier classification)
+
+### Task 6: Add `BindProposal` + `Decision` dataclasses + presets-index helper
+
+**Files:**
+- Create: `cli/src/robot_md/hotplug/matcher.py` (dataclasses only — `classify` follows)
+- Create: `cli/src/robot_md/hotplug/presets_index.py`
+- Test: `cli/tests/hotplug/test_presets_index.py`
+
+- [ ] **Step 1: Write the presets-index test**
+
+```python
+# cli/tests/hotplug/test_presets_index.py
+from __future__ import annotations
+
+from robot_md.hotplug.presets_index import lookup_by_vid_pid
+
+
+def test_lookup_so_arm101_by_known_vid_pid() -> None:
+    matches = lookup_by_vid_pid(vid="1a86", pid="7523")
+    names = {m.preset_name for m in matches}
+    # All SO-ARM presets share the CH340 chip; they all match.
+    assert "so_arm101" in names
+    assert "so_arm101_leader" in names
+
+
+def test_lookup_unknown_vid_pid_returns_empty() -> None:
+    assert lookup_by_vid_pid(vid="dead", pid="beef") == []
+```
+
+- [ ] **Step 2: Run test (expect FAIL — module missing)**
+
+- [ ] **Step 3: Implement `presets_index.py`**
+
+```python
+# cli/src/robot_md/hotplug/presets_index.py
+"""VID:PID → preset lookup, built from existing presets at import time.
+
+We trade preset YAML round-tripping for an explicit hint table here: presets
+themselves don't currently declare VID:PID (that's a future SP3.x extension).
+Until they do, this module ships a hand-curated mapping derived from each
+preset's documented hardware.
+"""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+
+
+@dataclass(frozen=True)
+class PresetMatch:
+    preset_name: str
+    transport: str
+    confidence: str  # "exact_match" | "family_match"
+
+
+# Hand-curated initial table; expand via PR as new presets land.
+_VID_PID_TO_PRESETS: dict[tuple[str, str], list[PresetMatch]] = {
+    # CH340 — used by all SO-ARM family kits + many generic feetech rigs.
+    ("1a86", "7523"): [
+        PresetMatch("so_arm101", "feetech", "family_match"),
+        PresetMatch("so_arm101_leader", "feetech", "family_match"),
+        PresetMatch("koch_arm", "feetech", "family_match"),
+    ],
+    # FT232H — alternative feetech bus.
+    ("0403", "6014"): [
+        PresetMatch("aloha2", "feetech", "family_match"),
+    ],
+    # RealSense D435 / D455.
+    ("8086", "0b07"): [PresetMatch("scanrig_realsense", "realsense", "exact_match")],
+    ("8086", "0b3a"): [PresetMatch("scanrig_realsense", "realsense", "exact_match")],
+}
+
+
+def lookup_by_vid_pid(*, vid: str | None, pid: str | None) -> list[PresetMatch]:
+    if vid is None or pid is None:
+        return []
+    return list(_VID_PID_TO_PRESETS.get((vid.lower(), pid.lower()), []))
+```
+
+- [ ] **Step 4: Write the matcher dataclass test**
+
+```python
+# cli/tests/hotplug/test_matcher_dataclasses.py
+from __future__ import annotations
+
+from robot_md.hotplug.matcher import BindProposal, Decision
+
+
+def test_bind_proposal_is_frozen() -> None:
+    bp = BindProposal(
+        rrn="RRN-test",
+        driver_id_suggestion="arm_servos",
+        backend_name="lerobot",
+        preset_name="so_arm101",
+        capability_preview=[],
+        inferred_fields={"port": "/dev/ttyACM0"},
+    )
+    import pytest
+    with pytest.raises(Exception):
+        bp.backend_name = "feetech_depthai"
+
+
+def test_decision_dataclass_shape() -> None:
+    d = Decision(tier="HIGH", unambiguous=True, bind_proposal=None, alternatives=[], reasons=[])
+    assert d.tier == "HIGH"
+    assert d.alternatives == []
+```
+
+- [ ] **Step 5: Implement `matcher.py` (dataclasses only)**
+
+```python
+# cli/src/robot_md/hotplug/matcher.py
+"""Hot-plug event tier classifier. classify() lands in Task 7."""
+
+from __future__ import annotations
+
+from dataclasses import dataclass, field
+from typing import Literal
+
+from robot_md.backends.capability import Capability
+
+
+@dataclass(frozen=True)
+class BindProposal:
+    rrn: str | None
+    driver_id_suggestion: str
+    backend_name: str
+    preset_name: str | None
+    capability_preview: list[Capability]
+    inferred_fields: dict
+
+
+@dataclass(frozen=True)
+class Decision:
+    tier: Literal["HIGH", "MEDIUM", "LOW"]
+    unambiguous: bool
+    bind_proposal: BindProposal | None
+    alternatives: list[BindProposal] = field(default_factory=list)
+    reasons: list[str] = field(default_factory=list)
+```
+
+- [ ] **Step 6: Run tests (expect PASS)**
+
+- [ ] **Step 7: Commit (Task 6)**
+
+```bash
+git add cli/src/robot_md/hotplug/matcher.py cli/src/robot_md/hotplug/presets_index.py cli/tests/hotplug/test_presets_index.py cli/tests/hotplug/test_matcher_dataclasses.py
+git commit -m "feat(sphp): BindProposal + Decision dataclasses + presets-index lookup"
+```
+
+---
+
+### Task 7: Implement `classify(evt)` — HIGH/MEDIUM/LOW tiering
+
+**Files:**
+- Modify: `cli/src/robot_md/hotplug/matcher.py` (add `classify`)
+- Test: `cli/tests/hotplug/test_matcher_high_tier_exact.py`, `cli/tests/hotplug/test_matcher_medium_tier.py`, `cli/tests/hotplug/test_matcher_low_tier.py`
+
+- [ ] **Step 1: Write the HIGH-tier test**
+
+```python
+# cli/tests/hotplug/test_matcher_high_tier_exact.py
+from __future__ import annotations
+
+from unittest.mock import patch
+
+from robot_md.hotplug.event import DeviceEvent
+from robot_md.hotplug.matcher import classify
+from robot_md.hotplug.presets_index import PresetMatch
+
+
+def _evt() -> DeviceEvent:
+    return DeviceEvent(
+        kind="tty_added",
+        vid="1a86", pid="7523", serial="UNIQUE_SERIAL_AB12",
+        path="/dev/ttyACM0",
+        transport="feetech",
+        raw_metadata={},
+        detected_at="2026-04-27T19:30:11Z",
+    )
+
+
+def test_high_tier_when_serial_uniquely_identifies_preset_and_one_backend(monkeypatch) -> None:
+    # Single-preset match (override the table to simulate a serial-unique preset).
+    monkeypatch.setattr(
+        "robot_md.hotplug.presets_index.lookup_by_vid_pid",
+        lambda *, vid, pid: [PresetMatch("so_arm101", "feetech", "exact_match")],
+    )
+    # Only lerobot backend installed.
+    with patch("robot_md.hotplug.matcher._installed_backends_for_transport",
+               return_value=["lerobot"]):
+        decision = classify(_evt())
+    assert decision.tier == "HIGH"
+    assert decision.unambiguous is True
+    assert decision.bind_proposal is not None
+    assert decision.bind_proposal.backend_name == "lerobot"
+    assert decision.bind_proposal.preset_name == "so_arm101"
+```
+
+- [ ] **Step 2: Write the MEDIUM-tier test**
+
+```python
+# cli/tests/hotplug/test_matcher_medium_tier.py
+from __future__ import annotations
+
+from unittest.mock import patch
+
+from robot_md.hotplug.event import DeviceEvent
+from robot_md.hotplug.matcher import classify
+
+
+def _evt() -> DeviceEvent:
+    return DeviceEvent(
+        kind="tty_added", vid="1a86", pid="7523", serial=None,
+        path="/dev/ttyACM0", transport="feetech",
+        raw_metadata={}, detected_at="2026-04-27T19:30:11Z",
+    )
+
+
+def test_medium_tier_when_multi_preset_match() -> None:
+    # Default presets-index returns 3 matches for 1a86:7523.
+    with patch("robot_md.hotplug.matcher._installed_backends_for_transport",
+               return_value=["lerobot"]):
+        decision = classify(_evt())
+    assert decision.tier == "MEDIUM"
+    assert decision.unambiguous is False
+    assert len(decision.alternatives) >= 2
+```
+
+- [ ] **Step 3: Write the LOW-tier test**
+
+```python
+# cli/tests/hotplug/test_matcher_low_tier.py
+from __future__ import annotations
+
+from unittest.mock import patch
+
+from robot_md.hotplug.event import DeviceEvent
+from robot_md.hotplug.matcher import classify
+
+
+def _evt(transport="unknown", vid="dead", pid="beef") -> DeviceEvent:
+    return DeviceEvent(
+        kind="usb_added", vid=vid, pid=pid, serial=None,
+        path="/dev/ttyACM0", transport=transport,
+        raw_metadata={}, detected_at="2026-04-27T19:30:11Z",
+    )
+
+
+def test_low_tier_when_unknown_vid_pid() -> None:
+    decision = classify(_evt())
+    assert decision.tier == "LOW"
+    assert any("preset" in r.lower() for r in decision.reasons)
+
+
+def test_low_tier_when_known_transport_no_backend() -> None:
+    with patch("robot_md.hotplug.matcher._installed_backends_for_transport",
+               return_value=[]):
+        decision = classify(_evt(transport="feetech", vid="1a86", pid="7523"))
+    assert decision.tier == "LOW"
+    assert any("backend" in r.lower() for r in decision.reasons)
+```
+
+- [ ] **Step 4: Run tests (expect FAIL — `classify` not implemented)**
+
+- [ ] **Step 5: Implement `classify`**
+
+Append to `cli/src/robot_md/hotplug/matcher.py`:
+
+```python
+from robot_md.backends import BackendRegistry
+from robot_md.hotplug.event import DeviceEvent
+from robot_md.hotplug.presets_index import lookup_by_vid_pid
+
+
+def _installed_backends_for_transport(transport: str) -> list[str]:
+    """Return names of installed backends whose .protocols set includes transport."""
+    reg = BackendRegistry.from_entry_points()
+    return sorted(b.name for b in reg.backends if transport in b.protocols)
+
+
+def classify(evt: DeviceEvent) -> Decision:
+    """Tier-classify a hot-plug event.
+
+    HIGH:   single preset match (typically via VID:PID:serial triple) AND
+            exactly one matching backend installed → auto-bind.
+    MEDIUM: multi-preset match OR multi-backend match. Top-1 candidate +
+            alternatives surfaced; queued.
+    LOW:    no preset match OR known transport with no backend installed.
+    """
+    preset_matches = lookup_by_vid_pid(vid=evt.vid, pid=evt.pid)
+    if not preset_matches:
+        return Decision(
+            tier="LOW", unambiguous=False, bind_proposal=None,
+            alternatives=[],
+            reasons=[f"no preset match for VID:PID {evt.vid}:{evt.pid}"],
+        )
+
+    backends = _installed_backends_for_transport(evt.transport)
+    if not backends:
+        return Decision(
+            tier="LOW", unambiguous=False, bind_proposal=None,
+            alternatives=[],
+            reasons=[
+                f"no backend installed for transport {evt.transport!r}",
+                "hint: pip install 'robot-md[hardware]'",
+            ],
+        )
+
+    proposals: list[BindProposal] = []
+    for pm in preset_matches:
+        for backend_name in backends:
+            proposals.append(BindProposal(
+                rrn=None,
+                driver_id_suggestion="arm_servos",
+                backend_name=backend_name,
+                preset_name=pm.preset_name,
+                capability_preview=[],  # populated lazily by review tool
+                inferred_fields={"port": evt.path, "transport": evt.transport, "serial": evt.serial},
+            ))
+
+    if len(proposals) == 1 and preset_matches[0].confidence == "exact_match":
+        return Decision(
+            tier="HIGH", unambiguous=True, bind_proposal=proposals[0],
+            alternatives=[],
+            reasons=[
+                f"exact preset match {preset_matches[0].preset_name}",
+                f"single backend installed: {backends[0]}",
+            ],
+        )
+
+    return Decision(
+        tier="MEDIUM", unambiguous=False,
+        bind_proposal=proposals[0],
+        alternatives=proposals[1:],
+        reasons=[
+            f"VID:PID matches {len(preset_matches)} preset(s)",
+            f"{len(backends)} backend(s) could drive this transport",
+        ],
+    )
+```
+
+- [ ] **Step 6: Run tests (expect PASS)**
+
+- [ ] **Step 7: Commit (Task 7)**
+
+```bash
+git add cli/src/robot_md/hotplug/matcher.py cli/tests/hotplug/test_matcher_high_tier_exact.py cli/tests/hotplug/test_matcher_medium_tier.py cli/tests/hotplug/test_matcher_low_tier.py
+git commit -m "feat(sphp): classify(DeviceEvent) — HIGH/MEDIUM/LOW tier policy"
+```
+
+---
+
+### Task 8: Recent-reject demotion — HIGH-tier match becomes MEDIUM if same device was rejected within an hour
+
+**Files:**
+- Modify: `cli/src/robot_md/hotplug/matcher.py`
+- Test: `cli/tests/hotplug/test_matcher_recent_reject_demotes.py`
+
+- [ ] **Step 1: Write the demotion test**
+
+```python
+# cli/tests/hotplug/test_matcher_recent_reject_demotes.py
+from __future__ import annotations
+
+from datetime import datetime, timedelta, timezone
+from unittest.mock import patch
+
+from robot_md.hotplug.event import DeviceEvent
+from robot_md.hotplug.matcher import classify
+from robot_md.hotplug.presets_index import PresetMatch
+
+
+def _evt(serial="AB12") -> DeviceEvent:
+    return DeviceEvent(
+        kind="tty_added", vid="1a86", pid="7523", serial=serial,
+        path="/dev/ttyACM0", transport="feetech",
+        raw_metadata={}, detected_at=datetime.now(timezone.utc).isoformat().replace("+00:00", "Z"),
+    )
+
+
+def test_recent_reject_within_window_demotes_high_to_medium(monkeypatch) -> None:
+    monkeypatch.setattr(
+        "robot_md.hotplug.presets_index.lookup_by_vid_pid",
+        lambda *, vid, pid: [PresetMatch("so_arm101", "feetech", "exact_match")],
+    )
+    recent = (datetime.now(timezone.utc) - timedelta(minutes=30)).isoformat().replace("+00:00", "Z")
+    with patch("robot_md.hotplug.matcher._installed_backends_for_transport", return_value=["lerobot"]), \
+         patch("robot_md.hotplug.matcher._recent_reject_for", return_value=recent):
+        decision = classify(_evt())
+    assert decision.tier == "MEDIUM"
+    assert any("rejected" in r.lower() for r in decision.reasons)
+
+
+def test_old_reject_does_not_demote(monkeypatch) -> None:
+    monkeypatch.setattr(
+        "robot_md.hotplug.presets_index.lookup_by_vid_pid",
+        lambda *, vid, pid: [PresetMatch("so_arm101", "feetech", "exact_match")],
+    )
+    old = (datetime.now(timezone.utc) - timedelta(hours=4)).isoformat().replace("+00:00", "Z")
+    with patch("robot_md.hotplug.matcher._installed_backends_for_transport", return_value=["lerobot"]), \
+         patch("robot_md.hotplug.matcher._recent_reject_for", return_value=old):
+        decision = classify(_evt())
+    assert decision.tier == "HIGH"
+```
+
+- [ ] **Step 2: Run test (expect FAIL — `_recent_reject_for` doesn't exist)**
+
+- [ ] **Step 3: Add the demotion path**
+
+In `cli/src/robot_md/hotplug/matcher.py`, add a stub helper + integrate into `classify`:
+
+```python
+from datetime import datetime, timedelta, timezone
+
+_RECENT_REJECT_WINDOW = timedelta(hours=1)
+
+
+def _recent_reject_for(evt: DeviceEvent) -> str | None:
+    """Return the ISO timestamp of the most-recent reject for this device, or None.
+
+    Default implementation reads the queue file. Tests patch this to inject
+    fixtures. The queue file path lives in ~/.robot-md/hotplug-events.jsonl
+    (see Task 9).
+    """
+    # Implementation lives in queue.py once that exists; for now, return None
+    # so the production path defaults to "no recent reject" until Task 9 wires it.
+    return None
+```
+
+Update `classify` to call this and demote if within the window. Edit the HIGH-tier branch:
+
+```python
+    if len(proposals) == 1 and preset_matches[0].confidence == "exact_match":
+        recent = _recent_reject_for(evt)
+        if recent is not None:
+            recent_dt = datetime.fromisoformat(recent.replace("Z", "+00:00"))
+            if datetime.now(timezone.utc) - recent_dt < _RECENT_REJECT_WINDOW:
+                return Decision(
+                    tier="MEDIUM", unambiguous=False,
+                    bind_proposal=proposals[0],
+                    alternatives=[],
+                    reasons=[
+                        f"exact preset match {preset_matches[0].preset_name}",
+                        f"recently rejected at {recent}; not auto-binding",
+                    ],
+                )
+        return Decision(
+            tier="HIGH", unambiguous=True, bind_proposal=proposals[0],
+            alternatives=[],
+            reasons=[
+                f"exact preset match {preset_matches[0].preset_name}",
+                f"single backend installed: {backends[0]}",
+            ],
+        )
+```
+
+- [ ] **Step 4: Run test (expect PASS 2/2)**
+
+- [ ] **Step 5: Commit (Task 8)**
+
+```bash
+git add cli/src/robot_md/hotplug/matcher.py cli/tests/hotplug/test_matcher_recent_reject_demotes.py
+git commit -m "feat(sphp): demote HIGH→MEDIUM when device was rejected within 1h"
+```
+
+---
+
+## Phase C — Hash-chained queue + audit log
+
+### Task 9: `EventQueue.append_pending` + `append_resolution` (hash chain)
+
+**Files:**
+- Create: `cli/src/robot_md/hotplug/queue.py`
+- Test: `cli/tests/hotplug/test_queue_hash_chain.py`, `cli/tests/hotplug/test_queue_append_pending_atomic.py`
+
+- [ ] **Step 1: Write the hash-chain test**
+
+```python
+# cli/tests/hotplug/test_queue_hash_chain.py
+from __future__ import annotations
+
+import hashlib
+import json
+from pathlib import Path
+
+from robot_md.hotplug.event import DeviceEvent
+from robot_md.hotplug.matcher import Decision
+from robot_md.hotplug.queue import EventQueue
+
+
+def _evt() -> DeviceEvent:
+    return DeviceEvent(
+        kind="tty_added", vid="1a86", pid="7523", serial="AB12",
+        path="/dev/ttyACM0", transport="feetech",
+        raw_metadata={}, detected_at="2026-04-27T19:30:11Z",
+    )
+
+
+def test_first_record_uses_zero_prev_hash(tmp_path: Path) -> None:
+    q = EventQueue(path=tmp_path / "q.jsonl")
+    decision = Decision(tier="LOW", unambiguous=False, bind_proposal=None)
+    rec = q.append_pending(_evt(), decision)
+    assert rec.prev_hash == "sha256:" + ("0" * 64)
+
+
+def test_second_record_chains_to_first(tmp_path: Path) -> None:
+    q = EventQueue(path=tmp_path / "q.jsonl")
+    decision = Decision(tier="LOW", unambiguous=False, bind_proposal=None)
+    first = q.append_pending(_evt(), decision)
+    second = q.append_pending(_evt(), decision)
+    assert second.prev_hash == first.this_hash
+```
+
+- [ ] **Step 2: Write the atomicity test**
+
+```python
+# cli/tests/hotplug/test_queue_append_pending_atomic.py
+from __future__ import annotations
+
+import threading
+from pathlib import Path
+
+from robot_md.hotplug.event import DeviceEvent
+from robot_md.hotplug.matcher import Decision
+from robot_md.hotplug.queue import EventQueue
+
+
+def test_concurrent_appenders_all_records_present(tmp_path: Path) -> None:
+    q = EventQueue(path=tmp_path / "q.jsonl")
+    decision = Decision(tier="LOW", unambiguous=False, bind_proposal=None)
+
+    def append():
+        q.append_pending(DeviceEvent(
+            kind="tty_added", vid="1a86", pid="7523", serial=None,
+            path="/dev/ttyACM0", transport="feetech",
+            raw_metadata={}, detected_at="2026-04-27T19:30:11Z",
+        ), decision)
+
+    threads = [threading.Thread(target=append) for _ in range(20)]
+    for t in threads:
+        t.start()
+    for t in threads:
+        t.join()
+
+    lines = (tmp_path / "q.jsonl").read_text().splitlines()
+    assert len(lines) == 20
+```
+
+- [ ] **Step 3: Run tests (expect FAIL — module missing)**
+
+- [ ] **Step 4: Implement `queue.py`**
+
+```python
+# cli/src/robot_md/hotplug/queue.py
+"""Hash-chained append-only event queue at ~/.robot-md/hotplug-events.jsonl.
+
+Same shape as RRF's compliance audit trail: each record carries a sha256
+of (prev_hash || canonical_json(record_minus_hash)), so any tampering is
+detectable end-to-end.
+"""
+
+from __future__ import annotations
+
+import dataclasses
+import fcntl
+import hashlib
+import json
+import os
+import uuid
+from dataclasses import asdict, dataclass
+from datetime import datetime, timezone
+from pathlib import Path
+
+from robot_md.hotplug.event import DeviceEvent
+from robot_md.hotplug.matcher import Decision
+
+
+_DEFAULT_PATH = Path.home() / ".robot-md" / "hotplug-events.jsonl"
+_ZERO_HASH = "sha256:" + "0" * 64
+
+
+@dataclass(frozen=True)
+class QueueRecord:
+    id: str
+    ts: str
+    kind: str   # "pending" | "resolved" | "daemon_alert"
+    event: dict | None
+    decision: dict | None
+    ref: str | None  # set on "resolved" records → original "pending" id
+    resolution: str | None
+    by: str | None
+    outcome: dict | None
+    prev_hash: str
+    this_hash: str
+
+
+def _hash_record(prev_hash: str, body: dict) -> str:
+    canonical = json.dumps(body, sort_keys=True, separators=(",", ":"))
+    h = hashlib.sha256()
+    h.update(prev_hash.encode("ascii"))
+    h.update(b"\0")
+    h.update(canonical.encode("utf-8"))
+    return "sha256:" + h.hexdigest()
+
+
+def _now_iso() -> str:
+    return datetime.now(timezone.utc).isoformat().replace("+00:00", "Z")
+
+
+class EventQueue:
+    def __init__(self, *, path: Path = _DEFAULT_PATH) -> None:
+        self.path = path
+        self.path.parent.mkdir(parents=True, exist_ok=True)
+        self.path.touch(exist_ok=True)
+
+    def _last_hash(self) -> str:
+        with self.path.open("rb") as f:
+            data = f.read()
+        if not data:
+            return _ZERO_HASH
+        last_line = data.rstrip(b"\n").rsplit(b"\n", 1)[-1]
+        try:
+            return json.loads(last_line)["this_hash"]
+        except Exception:
+            return _ZERO_HASH
+
+    def append_pending(self, evt: DeviceEvent, decision: Decision) -> QueueRecord:
+        with self.path.open("ab") as f:
+            fcntl.flock(f.fileno(), fcntl.LOCK_EX)
+            try:
+                prev = self._last_hash()
+                body = {
+                    "id": "evt_" + uuid.uuid4().hex,
+                    "ts": _now_iso(),
+                    "kind": "pending",
+                    "event": asdict(evt),
+                    "decision": _decision_to_dict(decision),
+                    "ref": None,
+                    "resolution": None,
+                    "by": None,
+                    "outcome": None,
+                    "prev_hash": prev,
+                }
+                body["this_hash"] = _hash_record(prev, body)
+                line = json.dumps(body, sort_keys=True) + "\n"
+                f.write(line.encode("utf-8"))
+                f.flush()
+                os.fsync(f.fileno())
+            finally:
+                fcntl.flock(f.fileno(), fcntl.LOCK_UN)
+        return QueueRecord(**body)
+
+    def append_resolution(self, *, ref_id: str, resolution: str, by: str, outcome: dict | None) -> QueueRecord:
+        with self.path.open("ab") as f:
+            fcntl.flock(f.fileno(), fcntl.LOCK_EX)
+            try:
+                prev = self._last_hash()
+                body = {
+                    "id": "evt_" + uuid.uuid4().hex,
+                    "ts": _now_iso(),
+                    "kind": "resolved",
+                    "event": None,
+                    "decision": None,
+                    "ref": ref_id,
+                    "resolution": resolution,
+                    "by": by,
+                    "outcome": outcome,
+                    "prev_hash": prev,
+                }
+                body["this_hash"] = _hash_record(prev, body)
+                line = json.dumps(body, sort_keys=True) + "\n"
+                f.write(line.encode("utf-8"))
+                f.flush()
+                os.fsync(f.fileno())
+            finally:
+                fcntl.flock(f.fileno(), fcntl.LOCK_UN)
+        return QueueRecord(**body)
+
+
+def _decision_to_dict(d: Decision) -> dict:
+    out = dataclasses.asdict(d)
+    return out
+```
+
+- [ ] **Step 5: Run tests (expect PASS)**
+
+- [ ] **Step 6: Commit (Task 9)**
+
+```bash
+git add cli/src/robot_md/hotplug/queue.py cli/tests/hotplug/test_queue_hash_chain.py cli/tests/hotplug/test_queue_append_pending_atomic.py
+git commit -m "feat(sphp): hash-chained EventQueue with fcntl-locked atomic appends"
+```
+
+---
+
+### Task 10: Resolution semantics — first-writer-wins; truncation recovery; TTL expiry
+
+**Files:**
+- Modify: `cli/src/robot_md/hotplug/queue.py`
+- Test: `cli/tests/hotplug/test_queue_resolution_first_writer_wins.py`, `test_queue_truncation_recovery.py`, `test_queue_ttl_expiry.py`
+
+- [ ] **Step 1: Write the first-writer test**
+
+```python
+# cli/tests/hotplug/test_queue_resolution_first_writer_wins.py
+from __future__ import annotations
+
+from pathlib import Path
+
+import pytest
+
+from robot_md.hotplug.event import DeviceEvent
+from robot_md.hotplug.matcher import Decision
+from robot_md.hotplug.queue import EventQueue, AlreadyResolvedError
+
+
+def _evt() -> DeviceEvent:
+    return DeviceEvent(
+        kind="tty_added", vid="1a86", pid="7523", serial="AB12",
+        path="/dev/ttyACM0", transport="feetech",
+        raw_metadata={}, detected_at="2026-04-27T19:30:11Z",
+    )
+
+
+def test_second_resolution_for_same_event_raises(tmp_path: Path) -> None:
+    q = EventQueue(path=tmp_path / "q.jsonl")
+    pending = q.append_pending(_evt(), Decision(tier="MEDIUM", unambiguous=False, bind_proposal=None))
+    q.append_resolution(ref_id=pending.id, resolution="bind", by="claude", outcome={})
+    with pytest.raises(AlreadyResolvedError) as ex:
+        q.append_resolution(ref_id=pending.id, resolution="bind", by="cli", outcome={})
+    assert "claude" in str(ex.value)
+```
+
+- [ ] **Step 2: Write the truncation-recovery test**
+
+```python
+# cli/tests/hotplug/test_queue_truncation_recovery.py
+from __future__ import annotations
+
+from pathlib import Path
+
+from robot_md.hotplug.event import DeviceEvent
+from robot_md.hotplug.matcher import Decision
+from robot_md.hotplug.queue import EventQueue
+
+
+def _evt() -> DeviceEvent:
+    return DeviceEvent(
+        kind="tty_added", vid="1a86", pid="7523", serial=None,
+        path="/dev/ttyACM0", transport="feetech",
+        raw_metadata={}, detected_at="2026-04-27T19:30:11Z",
+    )
+
+
+def test_corrupt_last_line_drops_to_alert_and_continues(tmp_path: Path) -> None:
+    q = EventQueue(path=tmp_path / "q.jsonl")
+    q.append_pending(_evt(), Decision(tier="LOW", unambiguous=False, bind_proposal=None))
+    # Corrupt the file by appending a partial line.
+    with (tmp_path / "q.jsonl").open("ab") as f:
+        f.write(b'{"id":"truncat')
+    q2 = EventQueue(path=tmp_path / "q.jsonl")
+    pending = q2.append_pending(_evt(), Decision(tier="LOW", unambiguous=False, bind_proposal=None))
+    contents = (tmp_path / "q.jsonl").read_text()
+    assert "daemon_alert" in contents
+    assert pending.kind == "pending"  # subsequent append still works
+```
+
+- [ ] **Step 3: Write the TTL-expiry test**
+
+```python
+# cli/tests/hotplug/test_queue_ttl_expiry.py
+from __future__ import annotations
+
+from datetime import datetime, timedelta, timezone
+from pathlib import Path
+
+from robot_md.hotplug.event import DeviceEvent
+from robot_md.hotplug.matcher import Decision
+from robot_md.hotplug.queue import EventQueue
+
+
+def _evt() -> DeviceEvent:
+    return DeviceEvent(
+        kind="tty_added", vid="1a86", pid="7523", serial=None,
+        path="/dev/ttyACM0", transport="feetech",
+        raw_metadata={}, detected_at=(datetime.now(timezone.utc) - timedelta(days=10)).isoformat().replace("+00:00", "Z"),
+    )
+
+
+def test_expire_pending_older_than_ttl(tmp_path: Path) -> None:
+    q = EventQueue(path=tmp_path / "q.jsonl")
+    pending = q.append_pending(_evt(), Decision(tier="MEDIUM", unambiguous=False, bind_proposal=None))
+    # Force the queue's first record's ts to 10 days ago by direct manipulation
+    # is awkward — use the public API: expire_old() with ttl=1 day.
+    expired_ids = q.expire_old(ttl_days=1)
+    assert pending.id in expired_ids
+    contents = (tmp_path / "q.jsonl").read_text()
+    assert '"resolution": "expired"' in contents
+```
+
+- [ ] **Step 4: Run tests (expect FAIL — features missing)**
+
+- [ ] **Step 5: Implement first-writer-wins, truncation recovery, TTL**
+
+Append to `cli/src/robot_md/hotplug/queue.py`:
+
+```python
+class AlreadyResolvedError(Exception):
+    def __init__(self, *, ref_id: str, by: str) -> None:
+        super().__init__(f"event {ref_id} already resolved by {by}")
+        self.ref_id = ref_id
+        self.by = by
+
+
+def _safe_iter_records(path: Path) -> tuple[list[dict], int]:
+    """Yield valid JSON records; return list + count of dropped malformed lines."""
+    records: list[dict] = []
+    dropped = 0
+    if not path.exists():
+        return records, 0
+    for line in path.read_text().splitlines():
+        line = line.strip()
+        if not line:
+            continue
+        try:
+            records.append(json.loads(line))
+        except Exception:
+            dropped += 1
+    return records, dropped
+
+
+# Patch EventQueue with the missing methods.
+def _ensure_no_existing_resolution(self: EventQueue, ref_id: str) -> None:
+    records, _ = _safe_iter_records(self.path)
+    for rec in records:
+        if rec.get("kind") == "resolved" and rec.get("ref") == ref_id:
+            raise AlreadyResolvedError(ref_id=ref_id, by=rec.get("by") or "unknown")
+
+
+def _emit_alert_if_truncation_observed(self: EventQueue) -> None:
+    records, dropped = _safe_iter_records(self.path)
+    if dropped == 0:
+        return
+    # Append a daemon_alert record (uses the same hash chain shape).
+    with self.path.open("ab") as f:
+        fcntl.flock(f.fileno(), fcntl.LOCK_EX)
+        try:
+            prev = self._last_hash()
+            body = {
+                "id": "evt_" + uuid.uuid4().hex,
+                "ts": _now_iso(),
+                "kind": "daemon_alert",
+                "event": None, "decision": None,
+                "ref": None, "resolution": None, "by": "daemon",
+                "outcome": {"msg": "queue tail truncated", "dropped": dropped},
+                "prev_hash": prev,
+            }
+            body["this_hash"] = _hash_record(prev, body)
+            f.write((json.dumps(body, sort_keys=True) + "\n").encode("utf-8"))
+            f.flush()
+            os.fsync(f.fileno())
+        finally:
+            fcntl.flock(f.fileno(), fcntl.LOCK_UN)
+
+
+def _expire_old(self: EventQueue, ttl_days: float) -> list[str]:
+    records, _ = _safe_iter_records(self.path)
+    now = datetime.now(timezone.utc)
+    threshold = timedelta(days=ttl_days)
+
+    pending_by_id = {r["id"]: r for r in records if r.get("kind") == "pending"}
+    resolved_refs = {r["ref"] for r in records if r.get("kind") == "resolved" and r.get("ref")}
+
+    expired_ids: list[str] = []
+    for rid, rec in pending_by_id.items():
+        if rid in resolved_refs:
+            continue
+        ts = datetime.fromisoformat(rec["ts"].replace("Z", "+00:00"))
+        if (now - ts) > threshold:
+            self.append_resolution(ref_id=rid, resolution="expired", by="daemon", outcome=None)
+            expired_ids.append(rid)
+    return expired_ids
+
+
+# Bind the new methods to EventQueue.
+EventQueue.expire_old = _expire_old
+_orig_init = EventQueue.__init__
+
+
+def _patched_init(self, *, path: Path = _DEFAULT_PATH) -> None:
+    _orig_init(self, path=path)
+    _emit_alert_if_truncation_observed(self)
+
+
+EventQueue.__init__ = _patched_init
+
+_orig_append_resolution = EventQueue.append_resolution
+
+
+def _patched_append_resolution(self, *, ref_id: str, resolution: str, by: str, outcome: dict | None) -> QueueRecord:
+    _ensure_no_existing_resolution(self, ref_id)
+    return _orig_append_resolution(self, ref_id=ref_id, resolution=resolution, by=by, outcome=outcome)
+
+
+EventQueue.append_resolution = _patched_append_resolution
+```
+
+(The "patched_init / append_resolution" pattern at module bottom keeps the test seam clean — production code can still subclass `EventQueue` if needed without re-binding. If the project's style prefers methods declared inline in the class, refactor accordingly during implementation.)
+
+- [ ] **Step 6: Run tests (expect PASS)**
+
+- [ ] **Step 7: Commit (Task 10)**
+
+```bash
+git add cli/src/robot_md/hotplug/queue.py cli/tests/hotplug/test_queue_resolution_first_writer_wins.py cli/tests/hotplug/test_queue_truncation_recovery.py cli/tests/hotplug/test_queue_ttl_expiry.py
+git commit -m "feat(sphp): EventQueue first-writer-wins + truncation alert + TTL expiry"
+```
+
+---
+
+### Task 11: Per-RRN audit log
+
+**Files:**
+- Create: `cli/src/robot_md/hotplug/audit.py`
+- Test: `cli/tests/hotplug/test_audit_log_append.py`
+
+- [ ] **Step 1: Write the audit-log test**
+
+```python
+# cli/tests/hotplug/test_audit_log_append.py
+from __future__ import annotations
+
+import json
+from pathlib import Path
+
+from robot_md.hotplug.audit import AuditLog
+
+
+def test_append_chains_per_rrn(tmp_path: Path) -> None:
+    log = AuditLog(rrn="RRN-test", root=tmp_path / "audit")
+    log.append("hotplug_event", {"foo": "bar"})
+    log.append("hotplug_bind", {"driver_id": "arm_servos"})
+    contents = (tmp_path / "audit" / "RRN-test.jsonl").read_text().splitlines()
+    assert len(contents) == 2
+    rec1 = json.loads(contents[0])
+    rec2 = json.loads(contents[1])
+    assert rec2["prev_hash"] == rec1["this_hash"]
+```
+
+- [ ] **Step 2: Implement `audit.py`**
+
+```python
+# cli/src/robot_md/hotplug/audit.py
+"""Per-RRN hash-chained audit log. Mirrors RRF's audit trail shape."""
+
+from __future__ import annotations
+
+import fcntl
+import hashlib
+import json
+import os
+import uuid
+from datetime import datetime, timezone
+from pathlib import Path
+
+_DEFAULT_ROOT = Path.home() / ".robot-md" / "audit"
+_ZERO_HASH = "sha256:" + "0" * 64
+
+
+def _now_iso() -> str:
+    return datetime.now(timezone.utc).isoformat().replace("+00:00", "Z")
+
+
+def _hash(prev: str, body: dict) -> str:
+    canonical = json.dumps(body, sort_keys=True, separators=(",", ":"))
+    h = hashlib.sha256(); h.update(prev.encode()); h.update(b"\0"); h.update(canonical.encode())
+    return "sha256:" + h.hexdigest()
+
+
+class AuditLog:
+    def __init__(self, *, rrn: str, root: Path = _DEFAULT_ROOT) -> None:
+        self.rrn = rrn
+        self.path = root / f"{rrn}.jsonl"
+        self.path.parent.mkdir(parents=True, exist_ok=True)
+        self.path.touch(exist_ok=True)
+
+    def _last_hash(self) -> str:
+        data = self.path.read_bytes().rstrip(b"\n")
+        if not data:
+            return _ZERO_HASH
+        try:
+            return json.loads(data.rsplit(b"\n", 1)[-1])["this_hash"]
+        except Exception:
+            return _ZERO_HASH
+
+    def append(self, kind: str, payload: dict) -> dict:
+        with self.path.open("ab") as f:
+            fcntl.flock(f.fileno(), fcntl.LOCK_EX)
+            try:
+                prev = self._last_hash()
+                body = {
+                    "id": "audit_" + uuid.uuid4().hex,
+                    "ts": _now_iso(),
+                    "rrn": self.rrn,
+                    "kind": kind,
+                    "payload": payload,
+                    "prev_hash": prev,
+                }
+                body["this_hash"] = _hash(prev, body)
+                f.write((json.dumps(body, sort_keys=True) + "\n").encode())
+                f.flush()
+                os.fsync(f.fileno())
+            finally:
+                fcntl.flock(f.fileno(), fcntl.LOCK_UN)
+        return body
+```
+
+- [ ] **Step 3: Run test (expect PASS)**
+
+- [ ] **Step 4: Commit (Task 11)**
+
+```bash
+git add cli/src/robot_md/hotplug/audit.py cli/tests/hotplug/test_audit_log_append.py
+git commit -m "feat(sphp): per-RRN hash-chained audit log"
+```
+
+---
+
+## Phase D — Manifest merge
+
+### Task 12: `manifest.merge(proposal, manifest_path)` with schema gate
+
+**Files:**
+- Create: `cli/src/robot_md/hotplug/manifest.py`
+- Test: `cli/tests/hotplug/test_manifest_merge_appends_driver.py`, `test_manifest_merge_validates_before_write.py`, `test_manifest_merge_no_manifest.py`, `test_manifest_merge_locking.py`
+
+- [ ] **Step 1: Write the appends-driver test**
+
+```python
+# cli/tests/hotplug/test_manifest_merge_appends_driver.py
+from __future__ import annotations
+
+from pathlib import Path
+
+from robot_md.hotplug.manifest import merge, MergeOutcome
+from robot_md.hotplug.matcher import BindProposal
+
+
+def test_merge_appends_driver_preserves_others(tmp_path: Path) -> None:
+    manifest = tmp_path / "ROBOT.md"
+    manifest.write_text("""---
+id: RRN-test
+metadata:
+  manufacturer: Test
+  author: a@b
+drivers:
+  - id: existing
+    protocol: realsense
+    backend: realsense
+---
+""")
+    proposal = BindProposal(
+        rrn="RRN-test",
+        driver_id_suggestion="arm_servos",
+        backend_name="lerobot",
+        preset_name="so_arm101",
+        capability_preview=[],
+        inferred_fields={"port": "/dev/ttyACM0", "transport": "feetech"},
+    )
+    outcome = merge(proposal, manifest_path=manifest)
+    assert isinstance(outcome, MergeOutcome)
+    assert outcome.success is True
+    text = manifest.read_text()
+    assert "id: existing" in text          # preserved
+    assert "id: arm_servos" in text         # appended
+    assert "backend: lerobot" in text
+```
+
+- [ ] **Step 2: Write the validate-before-write test**
+
+```python
+# cli/tests/hotplug/test_manifest_merge_validates_before_write.py
+from __future__ import annotations
+
+from pathlib import Path
+
+from robot_md.hotplug.manifest import merge
+from robot_md.hotplug.matcher import BindProposal
+
+
+def test_invalid_proposal_does_not_write(tmp_path: Path) -> None:
+    manifest = tmp_path / "ROBOT.md"
+    manifest.write_text("""---
+id: RRN-test
+metadata:
+  manufacturer: Test
+  author: a@b
+drivers: []
+---
+""")
+    bad = BindProposal(
+        rrn="RRN-test",
+        driver_id_suggestion="bad name with spaces",  # invalid driver_id
+        backend_name="lerobot",
+        preset_name="so_arm101",
+        capability_preview=[],
+        inferred_fields={},
+    )
+    outcome = merge(bad, manifest_path=manifest)
+    assert outcome.success is False
+    assert "validation" in outcome.reason.lower()
+    # Original manifest unchanged.
+    assert "bad name with spaces" not in manifest.read_text()
+```
+
+- [ ] **Step 3: Write the no-manifest test + locking smoke**
+
+```python
+# cli/tests/hotplug/test_manifest_merge_no_manifest.py
+from __future__ import annotations
+
+from pathlib import Path
+
+from robot_md.hotplug.manifest import merge
+from robot_md.hotplug.matcher import BindProposal
+
+
+def test_merge_with_no_manifest_returns_clear_error(tmp_path: Path) -> None:
+    manifest = tmp_path / "MISSING.md"  # does not exist
+    outcome = merge(BindProposal(
+        rrn=None, driver_id_suggestion="arm_servos", backend_name="lerobot",
+        preset_name="so_arm101", capability_preview=[], inferred_fields={},
+    ), manifest_path=manifest)
+    assert outcome.success is False
+    assert outcome.reason == "no_manifest_in_cwd"
+```
+
+```python
+# cli/tests/hotplug/test_manifest_merge_locking.py
+from __future__ import annotations
+
+import threading
+from pathlib import Path
+
+from robot_md.hotplug.manifest import merge
+from robot_md.hotplug.matcher import BindProposal
+
+
+def _proposal(driver_id: str) -> BindProposal:
+    return BindProposal(
+        rrn="RRN-test", driver_id_suggestion=driver_id,
+        backend_name="lerobot", preset_name="so_arm101",
+        capability_preview=[], inferred_fields={"port": "/dev/ttyACM0", "transport": "feetech"},
+    )
+
+
+def test_concurrent_merges_serialize_via_fcntl(tmp_path: Path) -> None:
+    manifest = tmp_path / "ROBOT.md"
+    manifest.write_text("""---
+id: RRN-test
+metadata:
+  manufacturer: Test
+  author: a@b
+drivers: []
+---
+""")
+    results: list = []
+    def do(driver_id):
+        results.append(merge(_proposal(driver_id), manifest_path=manifest))
+    t1 = threading.Thread(target=do, args=("driver_one",))
+    t2 = threading.Thread(target=do, args=("driver_two",))
+    t1.start(); t2.start(); t1.join(); t2.join()
+    text = manifest.read_text()
+    assert "driver_one" in text
+    assert "driver_two" in text
+    assert all(r.success for r in results)
+```
+
+- [ ] **Step 4: Run tests (expect FAIL — module missing)**
+
+- [ ] **Step 5: Implement `manifest.py`**
+
+```python
+# cli/src/robot_md/hotplug/manifest.py
+"""HIGH-tier manifest merge — schema-gated, fcntl-locked, atomic."""
+
+from __future__ import annotations
+
+import fcntl
+import re
+from dataclasses import dataclass
+from pathlib import Path
+
+import yaml
+
+from robot_md.hotplug.matcher import BindProposal
+
+
+_DRIVER_ID_RE = re.compile(r"^[a-z][a-z0-9_]*$")
+_FRONTMATTER_RE = re.compile(r"^---\n(.*?)\n---\n", re.DOTALL)
+
+
+@dataclass(frozen=True)
+class MergeOutcome:
+    success: bool
+    rrn: str | None
+    driver_id: str | None
+    reason: str
+
+
+def merge(proposal: BindProposal, *, manifest_path: Path) -> MergeOutcome:
+    if not manifest_path.exists():
+        return MergeOutcome(success=False, rrn=proposal.rrn, driver_id=None, reason="no_manifest_in_cwd")
+
+    if not _DRIVER_ID_RE.match(proposal.driver_id_suggestion):
+        return MergeOutcome(success=False, rrn=proposal.rrn, driver_id=None,
+                            reason="validation_failed: driver_id must match [a-z][a-z0-9_]*")
+
+    with manifest_path.open("r+") as f:
+        fcntl.flock(f.fileno(), fcntl.LOCK_EX)
+        try:
+            text = f.read()
+            m = _FRONTMATTER_RE.match(text)
+            if m is None:
+                return MergeOutcome(success=False, rrn=proposal.rrn, driver_id=None,
+                                    reason="validation_failed: no frontmatter")
+            data = yaml.safe_load(m.group(1)) or {}
+            drivers = data.setdefault("drivers", [])
+
+            new_driver = {
+                "id": proposal.driver_id_suggestion,
+                "protocol": proposal.inferred_fields.get("transport", "unknown"),
+                "backend": proposal.backend_name,
+            }
+            if "port" in proposal.inferred_fields:
+                new_driver["port"] = proposal.inferred_fields["port"]
+
+            drivers.append(new_driver)
+
+            new_frontmatter = yaml.safe_dump(data, sort_keys=False).rstrip()
+            new_text = f"---\n{new_frontmatter}\n---\n" + text[m.end():]
+
+            f.seek(0)
+            f.truncate()
+            f.write(new_text)
+            f.flush()
+        finally:
+            fcntl.flock(f.fileno(), fcntl.LOCK_UN)
+
+    return MergeOutcome(success=True, rrn=proposal.rrn, driver_id=proposal.driver_id_suggestion, reason="ok")
+```
+
+- [ ] **Step 6: Run tests (expect PASS 4/4)**
+
+- [ ] **Step 7: Commit (Task 12)**
+
+```bash
+git add cli/src/robot_md/hotplug/manifest.py cli/tests/hotplug/test_manifest_merge_*.py
+git commit -m "feat(sphp): manifest.merge — schema-gated, fcntl-locked, atomic append"
+```
+
+---
+
+## Phase E — Daemon entry point
+
+### Task 13: Daemon config (`hotplug.toml`)
+
+**Files:**
+- Create: `cli/src/robot_md/hotplug/config.py`
+- Test: `cli/tests/hotplug/test_config.py`
+
+- [ ] **Step 1: Write the config-defaults test**
+
+```python
+# cli/tests/hotplug/test_config.py
+from __future__ import annotations
+
+from pathlib import Path
+
+from robot_md.hotplug.config import HotplugConfig
+
+
+def test_defaults_when_no_config_file(tmp_path: Path) -> None:
+    cfg = HotplugConfig.load(path=tmp_path / "hotplug.toml")
+    assert cfg.pending_ttl_days == 7.0
+
+
+def test_overrides_from_toml(tmp_path: Path) -> None:
+    p = tmp_path / "hotplug.toml"
+    p.write_text("pending_ttl_days = 3\n")
+    cfg = HotplugConfig.load(path=p)
+    assert cfg.pending_ttl_days == 3
+```
+
+- [ ] **Step 2: Implement `config.py`**
+
+```python
+# cli/src/robot_md/hotplug/config.py
+from __future__ import annotations
+
+from dataclasses import dataclass
+from pathlib import Path
+
+try:
+    import tomllib  # py3.11+
+except ImportError:
+    import tomli as tomllib  # type: ignore
+
+_DEFAULT_PATH = Path.home() / ".robot-md" / "hotplug.toml"
+
+
+@dataclass(frozen=True)
+class HotplugConfig:
+    pending_ttl_days: float = 7.0
+
+    @classmethod
+    def load(cls, *, path: Path = _DEFAULT_PATH) -> "HotplugConfig":
+        if not path.exists():
+            return cls()
+        data = tomllib.loads(path.read_text())
+        return cls(pending_ttl_days=float(data.get("pending_ttl_days", 7.0)))
+```
+
+- [ ] **Step 3: Run test (expect PASS)**
+
+- [ ] **Step 4: Commit (Task 13)**
+
+```bash
+git add cli/src/robot_md/hotplug/config.py cli/tests/hotplug/test_config.py
+git commit -m "feat(sphp): HotplugConfig (~/.robot-md/hotplug.toml)"
+```
+
+---
+
+### Task 14: Linux Unix socket listener
+
+**Files:**
+- Create: `cli/src/robot_md/hotplug/socket_listener.py`
+- Test: `cli/tests/hotplug/test_socket_listener.py`
+
+- [ ] **Step 1: Write the socket test**
+
+```python
+# cli/tests/hotplug/test_socket_listener.py
+from __future__ import annotations
+
+import asyncio
+import socket
+import sys
+from pathlib import Path
+
+import pytest
+
+from robot_md.hotplug.socket_listener import SocketListener
+
+
+pytestmark = pytest.mark.skipif(sys.platform != "linux", reason="Unix socket — Linux primary")
+
+
+def test_socket_bind_and_nudge(tmp_path: Path) -> None:
+    sock_path = tmp_path / "test.sock"
+    listener = SocketListener(path=sock_path)
+    received: list = []
+
+    async def serve():
+        await listener.start(on_nudge=lambda: received.append(1))
+        # Simulate a client nudge.
+        c = socket.socket(socket.AF_UNIX, socket.SOCK_STREAM)
+        c.connect(str(sock_path))
+        c.sendall(b"\x01")
+        c.close()
+        await asyncio.sleep(0.05)
+        await listener.stop()
+
+    asyncio.run(serve())
+    assert received == [1]
+
+
+def test_second_listener_eaddrinuse(tmp_path: Path) -> None:
+    sock_path = tmp_path / "test.sock"
+    listener = SocketListener(path=sock_path)
+    other = SocketListener(path=sock_path)
+
+    async def main():
+        await listener.start(on_nudge=lambda: None)
+        with pytest.raises(OSError):
+            await other.start(on_nudge=lambda: None)
+        await listener.stop()
+
+    asyncio.run(main())
+```
+
+- [ ] **Step 2: Implement `socket_listener.py`**
+
+```python
+# cli/src/robot_md/hotplug/socket_listener.py
+from __future__ import annotations
+
+import asyncio
+import os
+import socket as _socket
+from pathlib import Path
+from typing import Callable
+
+_DEFAULT_PATH = Path(f"/run/user/{os.getuid()}/robot-md-hotplug.sock") if hasattr(os, "getuid") else None
+
+
+class SocketListener:
+    def __init__(self, *, path: Path | None = None) -> None:
+        self.path = path or _DEFAULT_PATH
+        self._server: asyncio.AbstractServer | None = None
+
+    async def start(self, *, on_nudge: Callable[[], None]) -> None:
+        async def handler(reader, writer):
+            try:
+                _ = await reader.read(64)  # discard payload — presence is the nudge
+                on_nudge()
+            finally:
+                writer.close()
+
+        self.path.parent.mkdir(parents=True, exist_ok=True)
+        if self.path.exists() and self._server is None:
+            # Stale socket file? Try unlink.
+            try:
+                self.path.unlink()
+            except OSError:
+                pass
+        self._server = await asyncio.start_unix_server(handler, path=str(self.path))
+
+    async def stop(self) -> None:
+        if self._server is not None:
+            self._server.close()
+            await self._server.wait_closed()
+            self._server = None
+        try:
+            if self.path.exists():
+                self.path.unlink()
+        except OSError:
+            pass
+```
+
+- [ ] **Step 3: Run test (expect PASS 2/2)**
+
+- [ ] **Step 4: Commit (Task 14)**
+
+```bash
+git add cli/src/robot_md/hotplug/socket_listener.py cli/tests/hotplug/test_socket_listener.py
+git commit -m "feat(sphp): Linux Unix socket listener for MCP-server nudges"
+```
+
+---
+
+### Task 15: Daemon entry point — compose watcher + matcher + queue + manifest + audit
+
+**Files:**
+- Create: `cli/src/robot_md/hotplug/daemon.py`
+- Test: `cli/tests/hotplug/test_daemon_starts_and_stops_clean.py`, `test_daemon_dedupes_replug.py`
+
+- [ ] **Step 1: Write the start-stop test**
+
+```python
+# cli/tests/hotplug/test_daemon_starts_and_stops_clean.py
+from __future__ import annotations
+
+import asyncio
+from pathlib import Path
+from unittest.mock import patch
+
+from robot_md.hotplug.daemon import run_daemon
+from robot_md.hotplug.event import DeviceEvent
+
+
+async def _empty_watcher():
+    if False:
+        yield  # never yields; just an async generator
+
+
+def test_daemon_runs_until_stop_event(tmp_path: Path) -> None:
+    stop = asyncio.Event()
+
+    async def main():
+        task = asyncio.create_task(run_daemon(
+            stop_event=stop,
+            queue_path=tmp_path / "q.jsonl",
+            audit_root=tmp_path / "audit",
+            watcher_factory=_empty_watcher,
+        ))
+        await asyncio.sleep(0.05)
+        stop.set()
+        await asyncio.wait_for(task, timeout=2.0)
+
+    asyncio.run(main())
+```
+
+- [ ] **Step 2: Write the dedup test**
+
+```python
+# cli/tests/hotplug/test_daemon_dedupes_replug.py
+from __future__ import annotations
+
+import asyncio
+from datetime import datetime, timezone
+from pathlib import Path
+
+from robot_md.hotplug.daemon import run_daemon
+from robot_md.hotplug.event import DeviceEvent
+
+
+def _evt():
+    return DeviceEvent(
+        kind="tty_added", vid="1a86", pid="7523", serial="AB12",
+        path="/dev/ttyACM0", transport="feetech",
+        raw_metadata={}, detected_at=datetime.now(timezone.utc).isoformat().replace("+00:00", "Z"),
+    )
+
+
+def test_replug_within_dedup_window_emits_one_pending(tmp_path: Path) -> None:
+    events = [_evt(), _evt(), _evt()]
+
+    async def watcher():
+        for e in events:
+            yield e
+
+    stop = asyncio.Event()
+
+    async def main():
+        task = asyncio.create_task(run_daemon(
+            stop_event=stop,
+            queue_path=tmp_path / "q.jsonl",
+            audit_root=tmp_path / "audit",
+            watcher_factory=watcher,
+        ))
+        await asyncio.sleep(0.1)
+        stop.set()
+        await asyncio.wait_for(task, timeout=2.0)
+
+    asyncio.run(main())
+    # Exactly one pending record despite three events with same (vid,pid,serial,path).
+    text = (tmp_path / "q.jsonl").read_text()
+    pending_count = text.count('"kind": "pending"')
+    assert pending_count == 1
+```
+
+- [ ] **Step 3: Implement `daemon.py`**
+
+```python
+# cli/src/robot_md/hotplug/daemon.py
+from __future__ import annotations
+
+import asyncio
+from datetime import datetime, timedelta, timezone
+from pathlib import Path
+from typing import Awaitable, Callable, Optional
+
+from robot_md.hotplug.audit import AuditLog
+from robot_md.hotplug.event import DeviceEvent
+from robot_md.hotplug.matcher import classify
+from robot_md.hotplug.queue import EventQueue
+
+
+_DEDUP_WINDOW = timedelta(hours=1)
+
+
+async def run_daemon(
+    *,
+    stop_event: asyncio.Event,
+    queue_path: Path,
+    audit_root: Path,
+    watcher_factory: Callable[[], "asyncio.AsyncGenerator[DeviceEvent, None]"],
+    rrn: str = "RRN-current",
+) -> int:
+    queue = EventQueue(path=queue_path)
+    audit = AuditLog(rrn=rrn, root=audit_root)
+    seen: dict[tuple, datetime] = {}
+
+    async def event_loop():
+        async for evt in watcher_factory():
+            if stop_event.is_set():
+                break
+            key = (evt.vid, evt.pid, evt.serial, evt.path)
+            now = datetime.now(timezone.utc)
+            last = seen.get(key)
+            if last and (now - last) < _DEDUP_WINDOW:
+                continue
+            seen[key] = now
+            decision = classify(evt)
+            queue.append_pending(evt, decision)
+            audit.append("hotplug_event", {"event": evt.__dict__, "tier": decision.tier})
+
+    task = asyncio.create_task(event_loop())
+    await stop_event.wait()
+    task.cancel()
+    try:
+        await task
+    except asyncio.CancelledError:
+        pass
+    return 0
+```
+
+- [ ] **Step 4: Run tests (expect PASS)**
+
+- [ ] **Step 5: Commit (Task 15)**
+
+```bash
+git add cli/src/robot_md/hotplug/daemon.py cli/tests/hotplug/test_daemon_starts_and_stops_clean.py cli/tests/hotplug/test_daemon_dedupes_replug.py
+git commit -m "feat(sphp): daemon entry — watcher + matcher + queue + audit + dedup"
+```
+
+---
+
+### Task 16: Daemon EADDRINUSE protection (second instance)
+
+**Files:**
+- Modify: `cli/src/robot_md/hotplug/daemon.py` (wrap socket listener bind)
+- Test: `cli/tests/hotplug/test_daemon_two_instances_eaddrinuse.py`
+
+- [ ] **Step 1: Write the test**
+
+```python
+# cli/tests/hotplug/test_daemon_two_instances_eaddrinuse.py
+from __future__ import annotations
+
+import asyncio
+import sys
+from pathlib import Path
+
+import pytest
+
+from robot_md.hotplug.daemon import run_daemon
+from robot_md.hotplug.socket_listener import SocketListener
+
+
+pytestmark = pytest.mark.skipif(sys.platform != "linux", reason="socket-bind contention is Linux-only")
+
+
+async def _empty_watcher():
+    if False:
+        yield
+
+
+def test_second_daemon_exits_with_eaddrinuse(tmp_path: Path) -> None:
+    sock_path = tmp_path / "hotplug.sock"
+    listener = SocketListener(path=sock_path)
+    stop1 = asyncio.Event()
+    stop2 = asyncio.Event()
+
+    async def main():
+        # Pre-bind the socket to simulate a running daemon.
+        await listener.start(on_nudge=lambda: None)
+        # Second daemon's socket bind should raise EADDRINUSE.
+        from robot_md.hotplug.daemon import run_daemon_with_socket
+        rc = await run_daemon_with_socket(
+            stop_event=stop2,
+            queue_path=tmp_path / "q.jsonl",
+            audit_root=tmp_path / "audit",
+            watcher_factory=_empty_watcher,
+            socket_path=sock_path,
+        )
+        assert rc == 2
+        await listener.stop()
+
+    asyncio.run(main())
+```
+
+- [ ] **Step 2: Add `run_daemon_with_socket` wrapper**
+
+```python
+# Append to daemon.py
+import errno
+from robot_md.hotplug.socket_listener import SocketListener
+
+
+async def run_daemon_with_socket(
+    *,
+    stop_event: asyncio.Event,
+    queue_path: Path,
+    audit_root: Path,
+    watcher_factory,
+    socket_path: Path,
+    rrn: str = "RRN-current",
+) -> int:
+    listener = SocketListener(path=socket_path)
+    try:
+        await listener.start(on_nudge=lambda: None)
+    except OSError as e:
+        if e.errno == errno.EADDRINUSE or "address already in use" in str(e).lower():
+            return 2
+        raise
+
+    try:
+        return await run_daemon(
+            stop_event=stop_event,
+            queue_path=queue_path,
+            audit_root=audit_root,
+            watcher_factory=watcher_factory,
+            rrn=rrn,
+        )
+    finally:
+        await listener.stop()
+```
+
+- [ ] **Step 3: Run test (expect PASS)**
+
+- [ ] **Step 4: Commit (Task 16)**
+
+```bash
+git add cli/src/robot_md/hotplug/daemon.py cli/tests/hotplug/test_daemon_two_instances_eaddrinuse.py
+git commit -m "feat(sphp): second daemon exits status 2 on socket EADDRINUSE"
+```
+
+---
+
+## Phase F — MCP server changes
+
+### Task 17: Manifest watcher — inotify reload + `notifications/tools/list_changed`
+
+**Files:**
+- Create: `cli/src/robot_md/mcp/manifest_watcher.py`
+- Test: `cli/tests/hotplug/test_mcp_inotify_reload_on_manifest_change.py`
+
+- [ ] **Step 1: Write the watcher test**
+
+```python
+# cli/tests/hotplug/test_mcp_inotify_reload_on_manifest_change.py
+from __future__ import annotations
+
+import time
+from pathlib import Path
+
+from robot_md.mcp.manifest_watcher import ManifestWatcher
+
+
+def test_watcher_fires_on_change(tmp_path: Path) -> None:
+    manifest = tmp_path / "ROBOT.md"
+    manifest.write_text("---\nid: RRN-test\n---\n")
+    received: list = []
+    w = ManifestWatcher(manifest_path=manifest, on_change=lambda: received.append(1))
+    w.start()
+    try:
+        time.sleep(0.2)
+        manifest.write_text("---\nid: RRN-test\nmetadata:\n  author: a@b\n---\n")
+        time.sleep(0.5)
+    finally:
+        w.stop()
+    assert received, "ManifestWatcher did not observe the change"
+```
+
+- [ ] **Step 2: Implement `manifest_watcher.py`**
+
+```python
+# cli/src/robot_md/mcp/manifest_watcher.py
+from __future__ import annotations
+
+from pathlib import Path
+from typing import Callable
+
+from watchdog.events import FileSystemEventHandler
+from watchdog.observers import Observer
+
+
+class ManifestWatcher:
+    def __init__(self, *, manifest_path: Path, on_change: Callable[[], None]) -> None:
+        self.manifest_path = manifest_path
+        self._observer = Observer()
+        self._handler = _Handler(target=manifest_path, on_change=on_change)
+
+    def start(self) -> None:
+        self._observer.schedule(self._handler, str(self.manifest_path.parent), recursive=False)
+        self._observer.start()
+
+    def stop(self) -> None:
+        self._observer.stop()
+        self._observer.join(timeout=2.0)
+
+
+class _Handler(FileSystemEventHandler):
+    def __init__(self, *, target: Path, on_change: Callable[[], None]) -> None:
+        self._target = target.resolve()
+        self._on_change = on_change
+
+    def on_modified(self, event):
+        if Path(event.src_path).resolve() == self._target:
+            self._on_change()
+
+    def on_created(self, event):
+        if Path(event.src_path).resolve() == self._target:
+            self._on_change()
+```
+
+- [ ] **Step 3: Run test (expect PASS — may need slight sleep tuning)**
+
+- [ ] **Step 4: Commit (Task 17)**
+
+```bash
+git add cli/src/robot_md/mcp/manifest_watcher.py cli/tests/hotplug/test_mcp_inotify_reload_on_manifest_change.py
+git commit -m "feat(sphp): MCP-server manifest watcher (watchdog) — fires on ROBOT.md change"
+```
+
+---
+
+### Task 18: `hotplug_review` MCP tool
+
+**Files:**
+- Create: `cli/src/robot_md/mcp/tools/hotplug_review.py`
+- Modify: `cli/src/robot_md/mcp/server.py` (register tool)
+- Test: `cli/tests/hotplug/test_hotplug_review_returns_pending_only.py`
+
+- [ ] **Step 1: Write the tool test**
+
+```python
+# cli/tests/hotplug/test_hotplug_review_returns_pending_only.py
+from __future__ import annotations
+
+from pathlib import Path
+
+from robot_md.hotplug.event import DeviceEvent
+from robot_md.hotplug.matcher import Decision
+from robot_md.hotplug.queue import EventQueue
+from robot_md.mcp.tools.hotplug_review import hotplug_review_tool
+
+
+def _evt():
+    return DeviceEvent(
+        kind="tty_added", vid="1a86", pid="7523", serial="AB12",
+        path="/dev/ttyACM0", transport="feetech",
+        raw_metadata={}, detected_at="2026-04-27T19:30:11Z",
+    )
+
+
+def test_review_returns_pending_only(tmp_path: Path) -> None:
+    q = EventQueue(path=tmp_path / "q.jsonl")
+    pending1 = q.append_pending(_evt(), Decision(tier="MEDIUM", unambiguous=False, bind_proposal=None))
+    pending2 = q.append_pending(_evt(), Decision(tier="LOW", unambiguous=False, bind_proposal=None))
+    q.append_resolution(ref_id=pending1.id, resolution="bind", by="claude", outcome={})
+
+    result = hotplug_review_tool(_queue=q)
+    ids = {entry["event_id"] for entry in result["pending"]}
+    assert pending2.id in ids
+    assert pending1.id not in ids
+```
+
+- [ ] **Step 2: Implement the tool**
+
+```python
+# cli/src/robot_md/mcp/tools/hotplug_review.py
+"""MCP tool: hotplug_review — list pending (un-resolved) hot-plug events."""
+
+from __future__ import annotations
+
+import json
+from pathlib import Path
+
+from robot_md.hotplug.queue import EventQueue
+
+
+def hotplug_review_tool(_queue: EventQueue | None = None) -> dict:
+    q = _queue or EventQueue()
+    records = []
+    for line in q.path.read_text().splitlines():
+        line = line.strip()
+        if not line:
+            continue
+        try:
+            records.append(json.loads(line))
+        except Exception:
+            continue
+    pending_ids = {r["id"] for r in records if r.get("kind") == "pending"}
+    resolved_refs = {r["ref"] for r in records if r.get("kind") == "resolved" and r.get("ref")}
+    pending_unresolved = pending_ids - resolved_refs
+
+    out = []
+    for r in records:
+        if r.get("kind") == "pending" and r["id"] in pending_unresolved:
+            out.append({
+                "event_id": r["id"],
+                "tier": r["decision"]["tier"],
+                "device": r["event"],
+                "decision": r["decision"],
+            })
+    return {"pending": out}
+```
+
+- [ ] **Step 3: Register in `server.py`**
+
+In `cli/src/robot_md/mcp/server.py`, add (alongside existing `@server.tool()` decorators):
+
+```python
+    @server.tool()
+    def hotplug_review() -> dict:
+        """Return all currently-pending (unresolved) hot-plug events for operator review."""
+        from robot_md.mcp.tools.hotplug_review import hotplug_review_tool
+        return hotplug_review_tool()
+```
+
+- [ ] **Step 4: Run test (expect PASS)**
+
+- [ ] **Step 5: Commit (Task 18)**
+
+```bash
+git add cli/src/robot_md/mcp/tools/hotplug_review.py cli/src/robot_md/mcp/server.py cli/tests/hotplug/test_hotplug_review_returns_pending_only.py
+git commit -m "feat(sphp): hotplug_review MCP tool"
+```
+
+---
+
+### Task 19: `hotplug_confirm` MCP tool — calls back to daemon
+
+**Files:**
+- Create: `cli/src/robot_md/mcp/tools/hotplug_confirm.py`
+- Modify: `cli/src/robot_md/mcp/server.py`
+- Test: `cli/tests/hotplug/test_hotplug_confirm_bind_writes_manifest.py`, `test_hotplug_confirm_reject_appends_resolution.py`
+
+- [ ] **Step 1: Write the bind test**
+
+```python
+# cli/tests/hotplug/test_hotplug_confirm_bind_writes_manifest.py
+from __future__ import annotations
+
+from pathlib import Path
+
+from robot_md.hotplug.event import DeviceEvent
+from robot_md.hotplug.matcher import BindProposal, Decision
+from robot_md.hotplug.queue import EventQueue
+from robot_md.mcp.tools.hotplug_confirm import hotplug_confirm_tool
+
+
+def test_confirm_bind_writes_manifest_and_appends_resolution(tmp_path: Path) -> None:
+    manifest = tmp_path / "ROBOT.md"
+    manifest.write_text("""---
+id: RRN-test
+metadata: {manufacturer: T, author: a@b}
+drivers: []
+---
+""")
+    q = EventQueue(path=tmp_path / "q.jsonl")
+    proposal = BindProposal(
+        rrn="RRN-test", driver_id_suggestion="arm_servos",
+        backend_name="lerobot", preset_name="so_arm101",
+        capability_preview=[],
+        inferred_fields={"port": "/dev/ttyACM0", "transport": "feetech"},
+    )
+    decision = Decision(tier="MEDIUM", unambiguous=False, bind_proposal=proposal,
+                        alternatives=[], reasons=[])
+    pending = q.append_pending(DeviceEvent(
+        kind="tty_added", vid="1a86", pid="7523", serial="AB12",
+        path="/dev/ttyACM0", transport="feetech",
+        raw_metadata={}, detected_at="2026-04-27T19:30:11Z",
+    ), decision)
+    out = hotplug_confirm_tool(
+        event_id=pending.id, decision="bind", choice_index=None,
+        _queue=q, _manifest_path=manifest, _by="claude",
+    )
+    assert out["ok"] is True
+    assert "backend: lerobot" in manifest.read_text()
+```
+
+- [ ] **Step 2: Write the reject test**
+
+```python
+# cli/tests/hotplug/test_hotplug_confirm_reject_appends_resolution.py
+from __future__ import annotations
+
+from pathlib import Path
+
+from robot_md.hotplug.event import DeviceEvent
+from robot_md.hotplug.matcher import Decision
+from robot_md.hotplug.queue import EventQueue
+from robot_md.mcp.tools.hotplug_confirm import hotplug_confirm_tool
+
+
+def test_reject_appends_resolution_no_manifest_change(tmp_path: Path) -> None:
+    manifest = tmp_path / "ROBOT.md"
+    manifest.write_text("---\nid: RRN-test\nmetadata: {a: 1}\ndrivers: []\n---\n")
+    before = manifest.read_text()
+    q = EventQueue(path=tmp_path / "q.jsonl")
+    pending = q.append_pending(DeviceEvent(
+        kind="tty_added", vid="1a86", pid="7523", serial=None,
+        path="/dev/ttyACM0", transport="feetech",
+        raw_metadata={}, detected_at="2026-04-27T19:30:11Z",
+    ), Decision(tier="MEDIUM", unambiguous=False, bind_proposal=None))
+    out = hotplug_confirm_tool(
+        event_id=pending.id, decision="reject", choice_index=None,
+        _queue=q, _manifest_path=manifest, _by="claude",
+    )
+    assert out["ok"] is True
+    assert manifest.read_text() == before
+    assert '"resolution": "reject"' in (tmp_path / "q.jsonl").read_text()
+```
+
+- [ ] **Step 3: Implement `hotplug_confirm.py`**
+
+```python
+# cli/src/robot_md/mcp/tools/hotplug_confirm.py
+"""MCP tool: hotplug_confirm — bind or reject a pending hot-plug event."""
+
+from __future__ import annotations
+
+import json
+from pathlib import Path
+
+from robot_md.hotplug.manifest import merge as manifest_merge
+from robot_md.hotplug.matcher import BindProposal
+from robot_md.hotplug.queue import AlreadyResolvedError, EventQueue
+
+
+def hotplug_confirm_tool(
+    *,
+    event_id: str,
+    decision: str,
+    choice_index: int | None = None,
+    _queue: EventQueue | None = None,
+    _manifest_path: Path | None = None,
+    _by: str = "claude",
+) -> dict:
+    if decision not in {"bind", "reject"}:
+        return {"ok": False, "error": f"decision must be 'bind' or 'reject', got {decision!r}"}
+
+    q = _queue or EventQueue()
+    manifest_path = _manifest_path or Path.cwd() / "ROBOT.md"
+
+    # Find the pending record.
+    target = None
+    for line in q.path.read_text().splitlines():
+        line = line.strip()
+        if not line:
+            continue
+        try:
+            r = json.loads(line)
+        except Exception:
+            continue
+        if r.get("kind") == "pending" and r.get("id") == event_id:
+            target = r
+            break
+    if target is None:
+        return {"ok": False, "error": f"event {event_id!r} not found"}
+
+    if decision == "reject":
+        try:
+            q.append_resolution(ref_id=event_id, resolution="reject", by=_by, outcome=None)
+        except AlreadyResolvedError as e:
+            return {"ok": False, "error": "already_resolved", "by": e.by}
+        return {"ok": True}
+
+    # decision == "bind"
+    decision_blob = target["decision"]
+    proposals = []
+    if decision_blob.get("bind_proposal"):
+        proposals.append(decision_blob["bind_proposal"])
+    proposals.extend(decision_blob.get("alternatives", []) or [])
+    if not proposals:
+        return {"ok": False, "error": "no bind_proposal available for this event"}
+    if choice_index is None:
+        choice_index = 0
+    chosen = proposals[choice_index]
+    proposal_obj = BindProposal(
+        rrn=chosen.get("rrn"),
+        driver_id_suggestion=chosen["driver_id_suggestion"],
+        backend_name=chosen["backend_name"],
+        preset_name=chosen.get("preset_name"),
+        capability_preview=[],
+        inferred_fields=chosen.get("inferred_fields") or {},
+    )
+
+    outcome = manifest_merge(proposal_obj, manifest_path=manifest_path)
+    if not outcome.success:
+        return {"ok": False, "error": "merge_failed", "reason": outcome.reason}
+
+    try:
+        q.append_resolution(
+            ref_id=event_id, resolution="bind", by=_by,
+            outcome={"driver_id": outcome.driver_id, "rrn": outcome.rrn},
+        )
+    except AlreadyResolvedError as e:
+        return {"ok": False, "error": "already_resolved", "by": e.by}
+    return {"ok": True, "driver_id": outcome.driver_id}
+```
+
+- [ ] **Step 4: Register in `server.py`**
+
+```python
+    @server.tool()
+    def hotplug_confirm(event_id: str, decision: str, choice_index: int | None = None) -> dict:
+        """Confirm or reject a pending hot-plug event."""
+        from robot_md.mcp.tools.hotplug_confirm import hotplug_confirm_tool
+        return hotplug_confirm_tool(event_id=event_id, decision=decision, choice_index=choice_index)
+```
+
+- [ ] **Step 5: Run tests (expect PASS 2/2)**
+
+- [ ] **Step 6: Commit (Task 19)**
+
+```bash
+git add cli/src/robot_md/mcp/tools/hotplug_confirm.py cli/src/robot_md/mcp/server.py cli/tests/hotplug/test_hotplug_confirm_bind_writes_manifest.py cli/tests/hotplug/test_hotplug_confirm_reject_appends_resolution.py
+git commit -m "feat(sphp): hotplug_confirm MCP tool — bind via manifest.merge / reject via queue"
+```
+
+---
+
+## Phase G — CLI subcommands
+
+### Task 20: `robot-md hotplug-daemon start|stop|status`
+
+**Files:**
+- Create: `cli/src/robot_md/hotplug/cli.py`
+- Modify: `cli/src/robot_md/__main__.py` (register the subcommand group)
+- Test: `cli/tests/hotplug/test_cli_hotplug_status_reports_running.py`
+
+- [ ] **Step 1: Write the status test**
+
+```python
+# cli/tests/hotplug/test_cli_hotplug_status_reports_running.py
+from __future__ import annotations
+
+import subprocess
+import sys
+from pathlib import Path
+
+
+def test_status_when_no_daemon_running() -> None:
+    env = {"PYTHONPATH": str(Path(__file__).parents[2] / "src")}
+    proc = subprocess.run(
+        [sys.executable, "-m", "robot_md", "hotplug-daemon", "status"],
+        capture_output=True, text=True, env={**env},
+    )
+    assert proc.returncode == 0
+    assert "not running" in proc.stdout.lower() or "stopped" in proc.stdout.lower()
+```
+
+- [ ] **Step 2: Implement `hotplug/cli.py`**
+
+```python
+# cli/src/robot_md/hotplug/cli.py
+"""Typer subcommands for the hotplug daemon + operator review."""
+
+from __future__ import annotations
+
+import asyncio
+import os
+import signal
+from pathlib import Path
+
+import typer
+
+app = typer.Typer(help="Hot-plug daemon control")
+
+
+_PIDFILE = Path.home() / ".robot-md" / "hotplug-daemon.pid"
+
+
+@app.command("start")
+def start() -> None:
+    if _PIDFILE.exists():
+        try:
+            pid = int(_PIDFILE.read_text())
+            os.kill(pid, 0)
+            typer.echo(f"daemon already running, pid={pid}")
+            raise typer.Exit(0)
+        except (ProcessLookupError, ValueError):
+            _PIDFILE.unlink(missing_ok=True)
+
+    pid = os.fork() if hasattr(os, "fork") else 0
+    if pid == 0:
+        # Child (or Windows fall-through).
+        from robot_md.hotplug.daemon import run_daemon_with_socket
+        from robot_md.hotplug.socket_listener import _DEFAULT_PATH as SOCK
+        import sys as _sys
+        if sys_platform := __import__("sys").platform:
+            pass
+        # Pick the right watcher for the platform.
+        if __import__("sys").platform == "linux":
+            from robot_md.hotplug.linux import watch_devices
+        elif __import__("sys").platform == "darwin":
+            from robot_md.hotplug.macos import watch_devices
+        else:
+            from robot_md.hotplug.windows import watch_devices
+
+        stop = asyncio.Event()
+        def _on_sig(*_): stop.set()
+        signal.signal(signal.SIGTERM, _on_sig)
+        signal.signal(signal.SIGINT, _on_sig)
+
+        _PIDFILE.parent.mkdir(parents=True, exist_ok=True)
+        _PIDFILE.write_text(str(os.getpid()))
+        try:
+            asyncio.run(run_daemon_with_socket(
+                stop_event=stop,
+                queue_path=Path.home() / ".robot-md" / "hotplug-events.jsonl",
+                audit_root=Path.home() / ".robot-md" / "audit",
+                watcher_factory=watch_devices,
+                socket_path=SOCK,
+            ))
+        finally:
+            _PIDFILE.unlink(missing_ok=True)
+    else:
+        typer.echo(f"daemon started, pid={pid}")
+
+
+@app.command("stop")
+def stop() -> None:
+    if not _PIDFILE.exists():
+        typer.echo("daemon not running")
+        raise typer.Exit(0)
+    pid = int(_PIDFILE.read_text())
+    try:
+        os.kill(pid, signal.SIGTERM)
+        typer.echo(f"sent SIGTERM to pid {pid}")
+    except ProcessLookupError:
+        _PIDFILE.unlink(missing_ok=True)
+        typer.echo("daemon not running (stale pidfile cleared)")
+
+
+@app.command("status")
+def status() -> None:
+    if not _PIDFILE.exists():
+        typer.echo("daemon: not running")
+        raise typer.Exit(0)
+    pid = int(_PIDFILE.read_text())
+    try:
+        os.kill(pid, 0)
+    except ProcessLookupError:
+        _PIDFILE.unlink(missing_ok=True)
+        typer.echo("daemon: not running (stale pidfile cleared)")
+        raise typer.Exit(0)
+    queue = Path.home() / ".robot-md" / "hotplug-events.jsonl"
+    depth = sum(1 for _ in queue.read_text().splitlines()) if queue.exists() else 0
+    typer.echo(f"daemon: running (pid={pid}); queue records: {depth}")
+```
+
+Register in `__main__.py`:
+
+```python
+from robot_md.hotplug.cli import app as hotplug_app
+
+app.add_typer(hotplug_app, name="hotplug-daemon")
+```
+
+- [ ] **Step 3: Run test (expect PASS)**
+
+- [ ] **Step 4: Commit (Task 20)**
+
+```bash
+git add cli/src/robot_md/hotplug/cli.py cli/src/robot_md/__main__.py cli/tests/hotplug/test_cli_hotplug_status_reports_running.py
+git commit -m "feat(sphp): robot-md hotplug-daemon start|stop|status"
+```
+
+---
+
+### Task 21: `robot-md hotplug review|confirm` CLI subcommands
+
+**Files:**
+- Modify: `cli/src/robot_md/hotplug/cli.py`
+- Test: `cli/tests/hotplug/test_cli_hotplug_review_lists_pending.py`
+
+- [ ] **Step 1: Write the test**
+
+```python
+# cli/tests/hotplug/test_cli_hotplug_review_lists_pending.py
+from __future__ import annotations
+
+import subprocess
+import sys
+from pathlib import Path
+
+
+def test_review_lists_pending_table() -> None:
+    env = {"PYTHONPATH": str(Path(__file__).parents[2] / "src")}
+    proc = subprocess.run(
+        [sys.executable, "-m", "robot_md", "hotplug", "review"],
+        capture_output=True, text=True, env={**env},
+    )
+    assert proc.returncode == 0
+    # Table header should appear even with empty queue.
+    assert "event_id" in proc.stdout.lower() or "no pending" in proc.stdout.lower()
+```
+
+- [ ] **Step 2: Add a second Typer app for operator-facing commands**
+
+In `cli/src/robot_md/hotplug/cli.py`, append:
+
+```python
+operator_app = typer.Typer(help="Hot-plug operator review / confirm")
+
+
+@operator_app.command("review")
+def review() -> None:
+    from robot_md.mcp.tools.hotplug_review import hotplug_review_tool
+    out = hotplug_review_tool()
+    pending = out["pending"]
+    if not pending:
+        typer.echo("no pending events")
+        raise typer.Exit(0)
+    typer.echo(f"{'event_id':40} {'tier':6} {'transport':12} {'path'}")
+    for p in pending:
+        d = p["device"]
+        typer.echo(f"{p['event_id']:40} {p['tier']:6} {d['transport']:12} {d['path']}")
+
+
+@operator_app.command("confirm")
+def confirm(
+    event_id: str,
+    bind: bool = typer.Option(False, "--bind"),
+    reject: bool = typer.Option(False, "--reject"),
+    choice_index: int | None = typer.Option(None, "--choice"),
+) -> None:
+    if bind == reject:
+        typer.echo("specify exactly one of --bind / --reject", err=True)
+        raise typer.Exit(2)
+    from robot_md.mcp.tools.hotplug_confirm import hotplug_confirm_tool
+    out = hotplug_confirm_tool(
+        event_id=event_id,
+        decision="bind" if bind else "reject",
+        choice_index=choice_index,
+        _by="cli",
+    )
+    if not out.get("ok"):
+        typer.echo(f"failed: {out.get('error')} {out.get('reason') or ''}", err=True)
+        raise typer.Exit(1)
+    typer.echo("ok")
+```
+
+Register in `__main__.py`:
+
+```python
+from robot_md.hotplug.cli import operator_app as hotplug_op_app
+
+app.add_typer(hotplug_op_app, name="hotplug")
+```
+
+- [ ] **Step 3: Run test (expect PASS)**
+
+- [ ] **Step 4: Commit (Task 21)**
+
+```bash
+git add cli/src/robot_md/hotplug/cli.py cli/src/robot_md/__main__.py cli/tests/hotplug/test_cli_hotplug_review_lists_pending.py
+git commit -m "feat(sphp): robot-md hotplug review|confirm operator CLI"
+```
+
+---
+
+### Task 22: `robot-md hotplug install-service` (systemd / launchd / Scheduled Task)
+
+**Files:**
+- Create: `cli/src/robot_md/hotplug/service_installers/{__init__,linux_systemd,macos_launchd,windows_taskscheduler}.py`
+- Modify: `cli/src/robot_md/hotplug/cli.py`
+- Test: `cli/tests/hotplug/test_cli_hotplug_install_service_linux.py`, `test_cli_hotplug_install_service_macos.py`
+
+- [ ] **Step 1: Write the linux installer test**
+
+```python
+# cli/tests/hotplug/test_cli_hotplug_install_service_linux.py
+from __future__ import annotations
+
+import sys
+from pathlib import Path
+
+import pytest
+
+from robot_md.hotplug.service_installers.linux_systemd import write_unit_file
+
+
+pytestmark = pytest.mark.skipif(sys.platform != "linux", reason="systemd-only test")
+
+
+def test_unit_file_contents(tmp_path: Path) -> None:
+    target = tmp_path / "robot-md-hotplug.service"
+    write_unit_file(target=target)
+    text = target.read_text()
+    assert "[Unit]" in text and "[Service]" in text and "[Install]" in text
+    assert "robot-md hotplug-daemon start" in text
+    assert "Restart=on-failure" in text
+    assert "WantedBy=default.target" in text
+```
+
+- [ ] **Step 2: Write the macOS installer test**
+
+```python
+# cli/tests/hotplug/test_cli_hotplug_install_service_macos.py
+from __future__ import annotations
+
+import plistlib
+import sys
+from pathlib import Path
+
+import pytest
+
+from robot_md.hotplug.service_installers.macos_launchd import write_plist
+
+
+pytestmark = pytest.mark.skipif(sys.platform != "darwin", reason="launchd-only test")
+
+
+def test_plist_contents(tmp_path: Path) -> None:
+    target = tmp_path / "dev.robotmd.hotplug.plist"
+    write_plist(target=target)
+    data = plistlib.loads(target.read_bytes())
+    assert data["Label"] == "dev.robotmd.hotplug"
+    assert "robot-md" in data["ProgramArguments"][0]
+    assert data["KeepAlive"] is True
+```
+
+- [ ] **Step 3: Implement installers**
+
+```python
+# cli/src/robot_md/hotplug/service_installers/linux_systemd.py
+from __future__ import annotations
+
+from pathlib import Path
+
+_TEMPLATE = """[Unit]
+Description=robot-md hot-plug daemon
+After=network.target
+
+[Service]
+ExecStart=robot-md hotplug-daemon start --foreground
+Restart=on-failure
+RestartPreventExitStatus=2
+
+[Install]
+WantedBy=default.target
+"""
+
+
+def write_unit_file(*, target: Path) -> None:
+    target.parent.mkdir(parents=True, exist_ok=True)
+    target.write_text(_TEMPLATE)
+```
+
+```python
+# cli/src/robot_md/hotplug/service_installers/macos_launchd.py
+from __future__ import annotations
+
+import plistlib
+import shutil
+from pathlib import Path
+
+
+def write_plist(*, target: Path) -> None:
+    target.parent.mkdir(parents=True, exist_ok=True)
+    program = shutil.which("robot-md") or "/usr/local/bin/robot-md"
+    plist = {
+        "Label": "dev.robotmd.hotplug",
+        "ProgramArguments": [program, "hotplug-daemon", "start", "--foreground"],
+        "KeepAlive": True,
+        "RunAtLoad": True,
+    }
+    with target.open("wb") as f:
+        plistlib.dump(plist, f)
+```
+
+```python
+# cli/src/robot_md/hotplug/service_installers/windows_taskscheduler.py
+from __future__ import annotations
+
+
+def write_scheduled_task() -> None:
+    """Stub — calls into pywin32 to register a Scheduled Task. Implementation
+    deferred to Windows-platform refinement; smoke-test on the target host."""
+    raise NotImplementedError("Windows installer landing in SP-HP follow-up")
+```
+
+Add a CLI command in `cli.py`:
+
+```python
+@operator_app.command("install-service")
+def install_service() -> None:
+    import sys
+    if sys.platform == "linux":
+        from robot_md.hotplug.service_installers.linux_systemd import write_unit_file
+        target = Path.home() / ".config" / "systemd" / "user" / "robot-md-hotplug.service"
+        write_unit_file(target=target)
+        typer.echo(f"wrote {target}")
+        typer.echo("enable: systemctl --user enable --now robot-md-hotplug")
+    elif sys.platform == "darwin":
+        from robot_md.hotplug.service_installers.macos_launchd import write_plist
+        target = Path.home() / "Library" / "LaunchAgents" / "dev.robotmd.hotplug.plist"
+        write_plist(target=target)
+        typer.echo(f"wrote {target}")
+        typer.echo("load: launchctl load -w " + str(target))
+    elif sys.platform == "win32":
+        typer.echo("Windows installer is a follow-up; run `robot-md hotplug-daemon start` manually for now")
+    else:
+        typer.echo(f"unsupported platform: {sys.platform}", err=True)
+        raise typer.Exit(2)
+```
+
+- [ ] **Step 4: Run tests (expect PASS on the matching platform)**
+
+- [ ] **Step 5: Commit (Task 22)**
+
+```bash
+git add cli/src/robot_md/hotplug/service_installers/ cli/src/robot_md/hotplug/cli.py cli/tests/hotplug/test_cli_hotplug_install_service_*.py
+git commit -m "feat(sphp): hotplug install-service (systemd / launchd; Windows stub)"
+```
+
+---
+
+## Phase H — Integration + hardware + smoke
+
+### Task 23: End-to-end integration test — daemon binds HIGH-tier match into manifest
+
+**Files:**
+- Create: `cli/tests/integration/test_sphp_replug_high_tier_end_to_end.py`
+
+- [ ] **Step 1: Write the integration test**
+
+```python
+# cli/tests/integration/test_sphp_replug_high_tier_end_to_end.py
+from __future__ import annotations
+
+import asyncio
+from datetime import datetime, timezone
+from pathlib import Path
+from unittest.mock import patch
+
+import pytest
+
+from robot_md.hotplug.daemon import run_daemon
+from robot_md.hotplug.event import DeviceEvent
+from robot_md.hotplug.presets_index import PresetMatch
+
+
+def _evt():
+    return DeviceEvent(
+        kind="tty_added", vid="1a86", pid="7523", serial="UNIQUE_SERIAL",
+        path="/dev/ttyACM0", transport="feetech",
+        raw_metadata={}, detected_at=datetime.now(timezone.utc).isoformat().replace("+00:00", "Z"),
+    )
+
+
+@pytest.mark.skip(reason="end-to-end harness — fill in during execution; needs HIGH-tier auto-bind path wired through daemon (currently only queues)")
+def test_high_tier_auto_bind_writes_manifest(tmp_path: Path) -> None:
+    """Daemon classifies HIGH → calls manifest.merge → writes ROBOT.md.
+
+    The Task 15 daemon implementation only queues; this integration test
+    drives the implementer to add the HIGH-tier auto-bind path inside
+    run_daemon. Replace skip with a real assertion once that path lands.
+    """
+    pass
+```
+
+- [ ] **Step 2: Run test (expect SKIP)**
+
+- [ ] **Step 3: Implement the HIGH-tier auto-bind path inside `run_daemon`**
+
+In `cli/src/robot_md/hotplug/daemon.py`, after `queue.append_pending(...)`:
+
+```python
+            if decision.tier == "HIGH" and decision.unambiguous and decision.bind_proposal:
+                outcome = manifest_merge(decision.bind_proposal, manifest_path=Path.cwd() / "ROBOT.md")
+                if outcome.success:
+                    queue.append_resolution(
+                        ref_id=record.id, resolution="bind", by="daemon",
+                        outcome={"driver_id": outcome.driver_id, "rrn": outcome.rrn},
+                    )
+                    audit.append("hotplug_bind", {"driver_id": outcome.driver_id})
+                else:
+                    queue.append_resolution(
+                        ref_id=record.id, resolution="bind", by="daemon",
+                        outcome={"merge_failed": outcome.reason},
+                    )
+                    audit.append("merge_failed", {"reason": outcome.reason})
+```
+
+(Note: this requires `record = queue.append_pending(...)` to capture the return value; adjust `event_loop` accordingly.)
+
+- [ ] **Step 4: Remove the skip + fill in the integration test body**
+
+```python
+def test_high_tier_auto_bind_writes_manifest(tmp_path: Path) -> None:
+    manifest = tmp_path / "ROBOT.md"
+    manifest.write_text("---\nid: RRN-test\nmetadata: {a: 1}\ndrivers: []\n---\n")
+
+    async def watcher():
+        yield _evt()
+
+    stop = asyncio.Event()
+
+    async def main():
+        with patch(
+            "robot_md.hotplug.presets_index.lookup_by_vid_pid",
+            lambda *, vid, pid: [PresetMatch("so_arm101", "feetech", "exact_match")],
+        ), patch(
+            "robot_md.hotplug.matcher._installed_backends_for_transport",
+            return_value=["lerobot"],
+        ), patch("pathlib.Path.cwd", return_value=tmp_path):
+            task = asyncio.create_task(run_daemon(
+                stop_event=stop,
+                queue_path=tmp_path / "q.jsonl",
+                audit_root=tmp_path / "audit",
+                watcher_factory=watcher,
+            ))
+            await asyncio.sleep(0.1)
+            stop.set()
+            await asyncio.wait_for(task, timeout=2.0)
+
+    asyncio.run(main())
+    text = manifest.read_text()
+    assert "backend: lerobot" in text
+    assert "id: arm_servos" in text
+```
+
+- [ ] **Step 5: Run test (expect PASS)**
+
+- [ ] **Step 6: Commit (Task 23)**
+
+```bash
+git add cli/src/robot_md/hotplug/daemon.py cli/tests/integration/test_sphp_replug_high_tier_end_to_end.py
+git commit -m "feat(sphp): HIGH-tier auto-bind path in run_daemon + end-to-end integration test"
+```
+
+---
+
+### Task 24: Hardware-test stubs + manual smoke checklist
+
+**Files:**
+- Create: `cli/tests/hardware/test_sphp_replug_so_arm101_high_tier.py`, `test_sphp_unknown_device_low_tier.py`
+- Create: `cli/tests/manual/sphp_smoke.md`
+
+- [ ] **Step 1: Write the hardware test stubs**
+
+```python
+# cli/tests/hardware/test_sphp_replug_so_arm101_high_tier.py
+from __future__ import annotations
+
+import pytest
+
+pytestmark = pytest.mark.hardware
+
+
+def test_replug_so_arm101_results_in_high_tier_auto_bind() -> None:
+    """Run on bob with daemon active. Replug SO-ARM101. Within 1 s wall
+    clock the manifest should gain a new drivers[] entry with backend: lerobot."""
+    # Fixture: pre-snapshot ROBOT.md, replug, observe diff, assert backend: lerobot appended.
+    pytest.skip("manual replug step required — see cli/tests/manual/sphp_smoke.md")
+```
+
+```python
+# cli/tests/hardware/test_sphp_unknown_device_low_tier.py
+from __future__ import annotations
+
+import pytest
+
+pytestmark = pytest.mark.hardware
+
+
+def test_unknown_vid_pid_lands_as_low_tier() -> None:
+    """Plug a CH340 dev board (or any device whose VID:PID isn't in the curated
+    table). Expect a queue record at tier=LOW with `missing_preset_match` reason."""
+    pytest.skip("manual plug step required — see cli/tests/manual/sphp_smoke.md")
+```
+
+- [ ] **Step 2: Write the manual smoke checklist**
+
+Create `cli/tests/manual/sphp_smoke.md`:
+
+```markdown
+# SP-HP smoke — manual checks on bob
+
+Daemon must be running (`robot-md hotplug-daemon start`) before each step.
+
+1. **Linux: HIGH-tier auto-bind.** Replug SO-ARM101 USB cable on bob.
+   Within 1 s the daemon's pyudev path catches it, classify returns HIGH
+   (single-preset family, single backend installed), `manifest.merge` writes
+   a new `drivers[]` entry with `backend: lerobot`. MCP server in an open
+   Claude session emits `notifications/tools/list_changed`.
+
+2. **Linux: MEDIUM-tier queue + confirm.** Plug a generic CH340 dongle (no
+   serial-unique preset). Daemon classifies MEDIUM. `robot-md hotplug review`
+   shows it. `robot-md hotplug confirm <event_id> --bind --choice 0` writes
+   the manifest.
+
+3. **macOS: file-poll path.** Same as #1 on macOS. Verify 1–2 s detection
+   latency.
+
+4. **Windows: polling fallback.** Same as #1 on Windows. WM_DEVICECHANGE
+   message-pump integration is a Windows-host follow-up; polling alone is
+   sufficient for v1.
+
+5. **Daemon survives Claude restart.** Plug a generic feetech bus chip mid-
+   Claude-session. Kill the Claude session before confirming. Reopen Claude.
+   `hotplug_review` still surfaces the pending event.
+
+6. **TTL expiry.** Set `pending_ttl_days = 0.001` in `~/.robot-md/hotplug.toml`.
+   Plug a device, leave it pending. Wait 90 s. Daemon's expiry sweep
+   appends `resolution: expired` for the original pending record.
+```
+
+- [ ] **Step 3: Verify hardware tests skip in default CI**
+
+```bash
+cd cli && PYTHONPATH=src python -m pytest tests/hardware/test_sphp_*.py -v
+```
+
+Expected: SKIPPED.
+
+- [ ] **Step 4: Commit (Task 24)**
+
+```bash
+git add cli/tests/hardware/test_sphp_*.py cli/tests/manual/sphp_smoke.md
+git commit -m "test(sphp): hardware-test stubs + manual smoke checklist"
+```
+
+---
+
+## Implementation Order Summary
+
+```
+Phase A — DeviceEvent + per-platform watchers
+  1. DeviceEvent + classify_transport
+  2. linux watch_devices() (pyudev)
+  3. macos watch_devices() (ioreg + pyserial polling)
+  4. windows watch_devices() (polling fallback)
+  5. cross-platform field-set lock test
+
+Phase B — matcher
+  6. BindProposal + Decision + presets_index
+  7. classify(evt) — HIGH/MEDIUM/LOW
+  8. recent-reject demotion (HIGH→MEDIUM within 1h)
+
+Phase C — queue + audit
+  9. EventQueue (hash-chained appends, atomic)
+ 10. first-writer-wins + truncation alert + TTL expiry
+ 11. per-RRN audit log
+
+Phase D — manifest merge
+ 12. manifest.merge — schema gate + fcntl lock
+
+Phase E — daemon
+ 13. HotplugConfig (~/.robot-md/hotplug.toml)
+ 14. Linux Unix socket listener
+ 15. daemon entry — composes everything
+ 16. EADDRINUSE protection (second instance exit 2)
+
+Phase F — MCP server
+ 17. ManifestWatcher (watchdog inotify)
+ 18. hotplug_review MCP tool
+ 19. hotplug_confirm MCP tool
+
+Phase G — CLI
+ 20. robot-md hotplug-daemon start|stop|status
+ 21. robot-md hotplug review|confirm
+ 22. robot-md hotplug install-service (systemd / launchd; Windows stub)
+
+Phase H — integration + smoke
+ 23. end-to-end: HIGH-tier auto-bind writes manifest
+ 24. hardware-test stubs + manual smoke checklist
+```
+
+---
+
+## Success Criteria
+
+SP-HP is done when:
+
+- [ ] All 24 tasks merged.
+- [ ] Linux + macOS + Windows watchers all yield the same `DeviceEvent` shape (Task 5's lock test passes on each platform).
+- [ ] `robot-md hotplug-daemon start` survives a 24 h idle soak: no socket leaks, no queue corruption, no audit-log gaps.
+- [ ] Manual smoke (`cli/tests/manual/sphp_smoke.md`) passes 6/6 on bob.
+- [ ] Hardware tests pass on bob (HIGH-tier replug end-to-end < 1 s wall clock; LOW-tier unknown device).
+- [ ] `robot-md hotplug install-service` writes a working systemd unit on Linux + a working launchd plist on macOS.
+- [ ] Cross-platform CI (Linux + macOS + Windows runners) green for every test except the `@pytest.mark.hardware` set, which is bob-local.
+
+---
+
+## Notes for the implementer
+
+- **DeviceEvent immutability is load-bearing.** Watcher A produces events that flow through Tasks 6–24 unchanged. If a future task wants to mutate, that's a refactor — not an in-place edit. Task 5's drift guard catches accidental field renames.
+- **Hash-chain integrity is non-negotiable.** Tests in Tasks 9 and 10 lock the chain; if a refactor breaks the algorithm, RRF audit-trail tooling stops accepting the queue. Don't regenerate hashes "for cleanup."
+- **`fcntl` is Linux+macOS only.** Windows uses `msvcrt.locking`. The `queue.py` and `manifest.py` implementations as written assume POSIX; add a thin shim if Windows file-locking semantics surface as an issue (currently mitigated because the Windows daemon path is more polling-heavy and contention is rare).
+- **`run_daemon` v1 only handles HIGH-tier auto-bind for the cwd manifest** (`Path.cwd() / "ROBOT.md"`). Multi-host or multi-manifest setups are out of scope. If the daemon runs as a systemd unit, its cwd is the operator's home; document that the daemon expects to find the active manifest there or via `--manifest-path` flag (follow-up).
+- **Each task ends with a commit.** Plan execution is incremental.

--- a/docs/superpowers/plans/2026-04-27-sp3-sdk-adapter-pattern.md
+++ b/docs/superpowers/plans/2026-04-27-sp3-sdk-adapter-pattern.md
@@ -398,9 +398,11 @@ from robot_md.backends.registry import (
         "Arm.pick",    # uppercase
         "arm-pick",    # hyphen
         ".arm.pick",   # leading dot
-        "arm.",        # trailing dot
+        "arm.",        # trailing dot in vendor segment (empty name)
         "1arm.pick",   # leading digit
         "arm. pick",   # whitespace
+        "arm.pick.",   # trailing dot in name segment
+        "",            # empty
     ],
 )
 def test_malformed_capability_rejected(bad_capability: str) -> None:
@@ -426,7 +428,7 @@ Edit `cli/src/robot_md/backends/registry.py`. After the existing imports (line 1
 import re
 
 CORE_CAPABILITY_PREFIXES = frozenset({"arm.", "nav.", "perceive.", "gripper.", "safety."})
-_VENDOR_CAPABILITY_PATTERN = re.compile(r"^[a-z][a-z0-9_]*\.[a-z][a-z0-9_.]*$")
+_VENDOR_CAPABILITY_PATTERN = re.compile(r"^[a-z][a-z0-9_]*\.[a-z]([a-z0-9_.]*[a-z0-9_])?$")
 
 
 class BackendRegistrationError(Exception):
@@ -436,29 +438,52 @@ class BackendRegistrationError(Exception):
 def _validate_capability_namespace(backend_name: str, caps: frozenset[str]) -> None:
     """Reject backend registration if any capability is malformed.
 
-    Allowed:
-      - Core: starts with one of CORE_CAPABILITY_PREFIXES.
-      - Vendor: matches r"^[a-z][a-z0-9_]*\\.[a-z][a-z0-9_.]*$".
+    Every capability name must match `<vendor>.<name>` shape:
+    `^[a-z][a-z0-9_]*\\.[a-z]([a-z0-9_.]*[a-z0-9_])?$`. Core capabilities
+    (`arm.pick`, `nav.go_to`, etc.) match the same regex by design.
 
-    Raises BackendRegistrationError on first violation.
+    Allowed characters are ASCII lowercase letters, digits, and underscore.
+    Multi-dot hierarchies are valid (`acme.robotics.servo`,
+    `lerobot.motion.cartesian`) — the vendor is the first component, the
+    name is everything after the first dot. The name segment must not
+    start or end with a dot.
+
+    `CORE_CAPABILITY_PREFIXES` identifies which prefixes are RRF-canonical
+    "core"; downstream consumers (Task 5's `describe_default()`, Task 7's
+    `enumerate_capabilities()`) use it for tier classification. A
+    well-formed capability whose prefix is not in that set is treated as
+    vendor-shaped.
+
+    Args:
+        backend_name: entry-point name of the backend being registered;
+            used in the error message to identify the offender.
+        caps: the set returned from `backend.capabilities()`.
+
+    Raises:
+        BackendRegistrationError on first violation.
 
     Note: the existing feetech_depthai backend declares `vision.describe`
-    and `status.report`. Both pass the vendor regex (they look like
+    and `status.report`. Both match the regex (they look like
     <vendor>.<name>) so the registry accepts them as vendor-shaped, even
     though they're shipped in a first-party backend. Do NOT expand
-    CORE_CAPABILITY_PREFIXES here without coordinating with the SP3 spec
-    section on namespacing (the prefix list is RRF-canonical for core
-    capabilities only).
+    CORE_CAPABILITY_PREFIXES here — that list is RRF-canonical core only.
     """
     for cap in caps:
-        is_core = any(cap.startswith(p) for p in CORE_CAPABILITY_PREFIXES)
-        is_vendor_shaped = bool(_VENDOR_CAPABILITY_PATTERN.match(cap))
-        if not (is_core or is_vendor_shaped):
+        if not _VENDOR_CAPABILITY_PATTERN.match(cap):
             raise BackendRegistrationError(
                 f"Backend '{backend_name}' declared capability '{cap}': "
-                f"not a core prefix and not in <vendor>.<name> form."
+                f"not in <vendor>.<name> form "
+                f"(e.g. 'arm.pick', 'lerobot.teleop')."
             )
 ```
+
+> **Why a single regex check (no `is_core` short-circuit):** the original draft used
+> `is_core = any(cap.startswith(p) for p in CORE_CAPABILITY_PREFIXES)` as a fast path,
+> but `"arm."` and `"arm. pike"` both `.startswith("arm.")`, so they would pass the
+> `is_core` check and bypass the regex. The regex correctly rejects both. Since core
+> capabilities like `arm.pick` match the regex by design, the prefix short-circuit
+> adds no value and creates a hole. The malformed-rejected test (Step 3) exercises
+> exactly these cases.
 
 - [ ] **Step 6: Run all three validator tests to verify they pass**
 
@@ -593,7 +618,7 @@ from robot_md.robot_spec import RobotSpec
 _log = logging.getLogger(__name__)
 
 CORE_CAPABILITY_PREFIXES = frozenset({"arm.", "nav.", "perceive.", "gripper.", "safety."})
-_VENDOR_CAPABILITY_PATTERN = re.compile(r"^[a-z][a-z0-9_]*\.[a-z][a-z0-9_.]*$")
+_VENDOR_CAPABILITY_PATTERN = re.compile(r"^[a-z][a-z0-9_]*\.[a-z]([a-z0-9_.]*[a-z0-9_])?$")
 
 
 class BackendRegistrationError(Exception):
@@ -603,12 +628,11 @@ class BackendRegistrationError(Exception):
 def _validate_capability_namespace(backend_name: str, caps: frozenset[str]) -> None:
     """(See Task 2 docstring — body unchanged.)"""
     for cap in caps:
-        is_core = any(cap.startswith(p) for p in CORE_CAPABILITY_PREFIXES)
-        is_vendor_shaped = bool(_VENDOR_CAPABILITY_PATTERN.match(cap))
-        if not (is_core or is_vendor_shaped):
+        if not _VENDOR_CAPABILITY_PATTERN.match(cap):
             raise BackendRegistrationError(
                 f"Backend '{backend_name}' declared capability '{cap}': "
-                f"not a core prefix and not in <vendor>.<name> form."
+                f"not in <vendor>.<name> form "
+                f"(e.g. 'arm.pick', 'lerobot.teleop')."
             )
 
 

--- a/docs/superpowers/plans/2026-04-27-sp3-sdk-adapter-pattern.md
+++ b/docs/superpowers/plans/2026-04-27-sp3-sdk-adapter-pattern.md
@@ -147,6 +147,7 @@ Expected: FAIL with `FileNotFoundError` because `cli/src/robot_md/schemas/capabi
     "arm.pick": {
       "type": "object",
       "required": ["target"],
+      "additionalProperties": false,
       "properties": {
         "target": {
           "type": "string",
@@ -158,6 +159,7 @@ Expected: FAIL with `FileNotFoundError` because `cli/src/robot_md/schemas/capabi
     "arm.place": {
       "type": "object",
       "required": ["destination"],
+      "additionalProperties": false,
       "properties": {
         "destination": {"type": "string"},
         "release_height_mm": {"type": "number", "minimum": 0, "default": 30}
@@ -171,6 +173,7 @@ Expected: FAIL with `FileNotFoundError` because `cli/src/robot_md/schemas/capabi
     "nav.go_to": {
       "type": "object",
       "required": ["pose"],
+      "additionalProperties": false,
       "properties": {"pose": {"type": "object"}}
     },
     "safety.estop": {"type": "object", "additionalProperties": false}
@@ -226,6 +229,30 @@ def test_arm_pick_rejects_wrong_target_type() -> None:
 def test_arm_home_rejects_extra_properties() -> None:
     with pytest.raises(jsonschema.ValidationError):
         jsonschema.validate({"surprise": True}, _load_def("arm.home"))
+
+
+def test_arm_pick_rejects_extra_properties() -> None:
+    with pytest.raises(jsonschema.ValidationError):
+        jsonschema.validate(
+            {"target": "red_lego", "apporoach_height_mm": 100},
+            _load_def("arm.pick"),
+        )
+
+
+def test_arm_place_rejects_extra_properties() -> None:
+    with pytest.raises(jsonschema.ValidationError):
+        jsonschema.validate(
+            {"destination": "bin", "release_hieght_mm": 30},
+            _load_def("arm.place"),
+        )
+
+
+def test_nav_go_to_rejects_extra_properties() -> None:
+    with pytest.raises(jsonschema.ValidationError):
+        jsonschema.validate(
+            {"pose": {}, "speed": 0.5},
+            _load_def("nav.go_to"),
+        )
 ```
 
 - [ ] **Step 6: Run validation tests**
@@ -234,7 +261,17 @@ def test_arm_home_rejects_extra_properties() -> None:
 cd cli && PYTHONPATH=src python -m pytest tests/backends/test_capabilities_schema_arg_validation.py -v
 ```
 
-Expected: PASS (4/4).
+Expected: PASS (7/7).
+
+> **Schema closure note:** Every capability uses `additionalProperties: false`. Typo in
+> a parameter name → ValidationError, not silent acceptance. Param-bearing capabilities
+> (`arm.pick`, `arm.place`, `nav.go_to`) gain new optional fields by adding them to
+> `properties:` here first, then in the backend handler — additive evolution by design.
+>
+> **Known debt — `nav.go_to.pose` shape.** `pose` is currently `{"type": "object"}` with no
+> property constraints. The first nav backend (post-SP3) must lock down whether `pose` is
+> 2D `{x, y, theta}`, 3D `{frame_id, xyz, quaternion}`, or both, and update this schema +
+> drift tests. Tracked at the moment a nav backend lands; not blocking SP3.
 
 - [ ] **Step 7: Add the all-core-prefixes-present drift test**
 

--- a/docs/superpowers/plans/2026-04-27-sp3-sdk-adapter-pattern.md
+++ b/docs/superpowers/plans/2026-04-27-sp3-sdk-adapter-pattern.md
@@ -1,0 +1,4519 @@
+# SP3 — SDK Adapter Pattern Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Ship the SP3 SDK adapter pattern — two new in-tree backends (`lerobot`, `realsense`), the capability-metadata addendum (`Capability` dataclass + optional `describe_capabilities()` ABC method + `enumerate_capabilities(registry)` walker), the capability-tier validator at backend registration, the core `capabilities.json` JSON-Schema, an authoring guide + copy-paste backend template, and updated SO-ARM presets that hint at `lerobot`. Existing `feetech_depthai` continues to work unchanged.
+
+**Architecture:** Add `cli/src/robot_md/backends/{lerobot,realsense}/` adapter packages implementing the existing `CapabilityBackend` ABC. Extend `CapabilityBackend` with a concrete-default `describe_capabilities()` returning rich `Capability` metadata; preserve the `capabilities() -> frozenset[str]` method for backward compatibility. Add a tier validator in `backends/registry.py` (core prefix or `<vendor>.<name>` regex; malformed names cause the backend to be skipped during discovery). Add `enumerate_capabilities(registry)` as the public walker downstream consumers (SP-HP daemon, future robot-md-http bridge, the new `robot-md describe-capabilities` CLI) plug into. Per the SP1-5 simplification-revisions Revision 3, add a `[hardware]` meta-extra in `cli/pyproject.toml` that pulls all common backends; granular `[lerobot]` / `[realsense]` extras stay for advanced installs.
+
+**Tech Stack:** Python 3.10+, pytest, FastMCP (`mcp.server.fastmcp`), HuggingFace LeRobot (`lerobot>=0.5,<0.8`), `pyrealsense2>=2.55`, existing `jsonschema` Draft 2020-12 validation, `importlib.metadata.entry_points` for backend discovery.
+
+**Spec:** `docs/superpowers/specs/2026-04-26-sp3-sdk-adapter-pattern-design.md` (with the 2026-04-27 capability-metadata addendum).
+
+---
+
+## File Structure
+
+**Capability metadata foundation (the addendum):**
+- `cli/src/robot_md/backends/capability.py` — NEW. `Capability` dataclass + namespace-derivation helper.
+- `cli/src/robot_md/backends/_capability_default.py` — NEW. `describe_default(backend_name, caps)` builds `Capability` objects from `capabilities.json` lookup.
+- `cli/src/robot_md/backends/base.py` — MODIFY. Add concrete `describe_capabilities()` default method on `CapabilityBackend`.
+- `cli/src/robot_md/backends/registry.py` — MODIFY. Add `CORE_CAPABILITY_PREFIXES`, `_VENDOR_CAPABILITY_PATTERN`, `BackendRegistrationError`, `_validate_capability_namespace`; wire validator into `discover_backends()`; add `iter_classes()` method on `BackendRegistry`.
+- `cli/src/robot_md/backends/__init__.py` — MODIFY. Re-export `Capability`; add `enumerate_capabilities(registry)` module function.
+- `cli/src/robot_md/schemas/capabilities.json` — NEW. JSON-Schema (Draft 2020-12) for core capability arg shapes.
+
+**RealSense backend (camera-only):**
+- `cli/src/robot_md/backends/realsense/__init__.py` — NEW. `RealsenseBackend` class.
+- `cli/src/robot_md/backends/realsense/perception.py` — NEW. `perceive.rgb` / `perceive.depth` handlers.
+- `cli/src/robot_md/backends/realsense/doctor.py` — NEW. Device enumeration health probe.
+- `cli/src/robot_md/backends/realsense/capabilities.py` — NEW. Capability dispatch table.
+
+**LeRobot backend (motion + camera):**
+- `cli/src/robot_md/backends/lerobot/__init__.py` — NEW. `LerobotBackend` class.
+- `cli/src/robot_md/backends/lerobot/motion.py` — NEW. `arm.pick` / `arm.place` / `arm.home` / `gripper.*` handlers.
+- `cli/src/robot_md/backends/lerobot/perception.py` — NEW. `perceive.rgb` / `perceive.depth` via LeRobot's camera pipeline.
+- `cli/src/robot_md/backends/lerobot/servo.py` — NEW. Direct joint reads/writes via LeRobot's `MotorBus`.
+- `cli/src/robot_md/backends/lerobot/doctor.py` — NEW. Port-reachability + motor-enumeration probe.
+- `cli/src/robot_md/backends/lerobot/capabilities.py` — NEW. Capability dispatch table.
+
+**pyproject + entry-points:**
+- `cli/pyproject.toml` — MODIFY. Add `[hardware]` (meta), `[lerobot]`, `[realsense]` optional-dependency groups; add `lerobot` and `realsense` entry-point declarations under `[project.entry-points."robot_md.backends"]`.
+
+**Presets:**
+- `cli/src/robot_md/presets/so_arm101.yaml` — MODIFY. Add `preferred_backend: lerobot` to the arm-servos driver entry.
+- `cli/src/robot_md/presets/so_arm101_leader.yaml` — MODIFY. Same.
+- `cli/src/robot_md/presets/koch_arm.yaml` — MODIFY. Same.
+- `cli/src/robot_md/presets/aloha2.yaml` — MODIFY. Same.
+
+**CLI consumer of `enumerate_capabilities()` (proves the API end-to-end):**
+- `cli/src/robot_md/__main__.py` — MODIFY. Add `describe-capabilities` Typer subcommand.
+
+**Authoring guide + backend template:**
+- `docs/authoring-a-backend.md` — NEW. ~2000-word adapter authoring guide (8 sections per spec § 7).
+- `examples/backend-template/README.md` — NEW. 5-step bring-up.
+- `examples/backend-template/pyproject.toml` — NEW. Skeleton with entry-point block.
+- `examples/backend-template/src/my_backend/__init__.py` — NEW. `MyBackend(CapabilityBackend)` skeleton with TODO comments.
+- `examples/backend-template/src/my_backend/capabilities.py` — NEW. Dispatch-table skeleton.
+- `examples/backend-template/src/my_backend/motion.py` — NEW. `arm.*` skeleton handlers (raise `NotImplementedError`).
+- `examples/backend-template/tests/test_my_backend.py` — NEW. Mock-hardware test fixture + 3 example tests.
+
+**Tests (under `cli/tests/`):**
+- `cli/tests/backends/test_capability_dataclass.py` — NEW.
+- `cli/tests/backends/test_capability_metadata_default.py` — NEW.
+- `cli/tests/backends/test_enumerate_capabilities.py` — NEW.
+- `cli/tests/backends/test_capability_namespace_core_accepted.py` — NEW.
+- `cli/tests/backends/test_capability_namespace_vendor_accepted.py` — NEW.
+- `cli/tests/backends/test_capability_namespace_malformed_rejected.py` — NEW.
+- `cli/tests/backends/test_capability_namespace_skips_in_discovery.py` — NEW.
+- `cli/tests/backends/test_capabilities_schema_loads.py` — NEW.
+- `cli/tests/backends/test_capabilities_schema_arg_validation.py` — NEW.
+- `cli/tests/backends/test_capabilities_schema_all_core_caps_present.py` — NEW.
+- `cli/tests/backends/test_existing_capabilities_method_unchanged.py` — NEW.
+- `cli/tests/backends/test_lerobot_backend_protocols.py` — NEW.
+- `cli/tests/backends/test_lerobot_backend_capabilities_valid.py` — NEW.
+- `cli/tests/backends/test_lerobot_backend_open_mocked.py` — NEW.
+- `cli/tests/backends/test_lerobot_build_config_so_arm101.py` — NEW.
+- `cli/tests/backends/test_lerobot_execute_arm_pick_mocked.py` — NEW.
+- `cli/tests/backends/test_lerobot_execute_unknown_capability.py` — NEW.
+- `cli/tests/backends/test_lerobot_dry_run.py` — NEW.
+- `cli/tests/backends/test_lerobot_capabilities_schema_compliance.py` — NEW.
+- `cli/tests/backends/test_realsense_backend_protocols.py` — NEW.
+- `cli/tests/backends/test_realsense_capabilities_camera_only.py` — NEW.
+- `cli/tests/backends/test_realsense_open_mocked.py` — NEW.
+- `cli/tests/backends/test_realsense_scene_describe_mocked.py` — NEW.
+- `cli/tests/backends/test_realsense_no_arm_capability.py` — NEW.
+- `cli/tests/backends/test_describe_capabilities_cli.py` — NEW. End-to-end CLI smoke for the new subcommand.
+- `cli/tests/integration/test_init_sp3_lerobot_resolves.py` — NEW.
+- `cli/tests/integration/test_init_sp3_realsense_camera_only.py` — NEW.
+- `cli/tests/integration/test_init_sp3_no_lerobot_falls_back.py` — NEW.
+- `cli/tests/integration/test_runtime_dispatches_to_correct_backend.py` — NEW.
+- `cli/tests/integration/test_runtime_two_backends_same_protocol_explicit_wins.py` — NEW.
+- `cli/tests/backends/test_backend_template_scaffolds.py` — NEW.
+- `cli/tests/backends/test_backend_template_tests_pass.py` — NEW.
+- `cli/tests/backends/test_backend_template_validates_namespace.py` — NEW.
+- `cli/tests/docs/test_docs_authoring_examples_executable.py` — NEW.
+- `cli/tests/hardware/test_sp3_lerobot_so_arm101_pick.py` — NEW (`@pytest.mark.hardware`).
+- `cli/tests/hardware/test_sp3_realsense_d435_perceive.py` — NEW (`@pytest.mark.hardware`).
+
+**Manual smoke checklist:**
+- `cli/tests/manual/sp3_adapter_smoke.md` — NEW.
+
+---
+
+## Phase A — Capability metadata foundation
+
+These tasks deliver the spec's "Capability Metadata Addendum (2026-04-27)" plus the tier validator. Nothing else binds without them.
+
+### Task 1: Add `capabilities.json` core schema
+
+**Files:**
+- Create: `cli/src/robot_md/schemas/capabilities.json`
+- Test: `cli/tests/backends/test_capabilities_schema_loads.py`, `cli/tests/backends/test_capabilities_schema_arg_validation.py`, `cli/tests/backends/test_capabilities_schema_all_core_caps_present.py`
+
+- [ ] **Step 1: Write the loads-and-parses test**
+
+```python
+# cli/tests/backends/test_capabilities_schema_loads.py
+from __future__ import annotations
+
+import json
+from pathlib import Path
+
+
+def test_capabilities_schema_parses_as_json() -> None:
+    path = Path(__file__).parents[2] / "src" / "robot_md" / "schemas" / "capabilities.json"
+    data = json.loads(path.read_text())
+    assert data["$schema"] == "https://json-schema.org/draft/2020-12/schema"
+    assert "definitions" in data
+```
+
+- [ ] **Step 2: Run test to verify it fails**
+
+```bash
+cd cli && PYTHONPATH=src python -m pytest tests/backends/test_capabilities_schema_loads.py -v
+```
+
+Expected: FAIL with `FileNotFoundError` because `cli/src/robot_md/schemas/capabilities.json` does not exist yet.
+
+- [ ] **Step 3: Create the schema file**
+
+```json
+// cli/src/robot_md/schemas/capabilities.json
+{
+  "$id": "https://robotmd.dev/schemas/capabilities.json",
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "title": "robot-md core capability arg shapes",
+  "definitions": {
+    "arm.pick": {
+      "type": "object",
+      "required": ["target"],
+      "properties": {
+        "target": {
+          "type": "string",
+          "description": "Object descriptor id from manifest.vision.object_descriptors"
+        },
+        "approach_height_mm": {"type": "number", "minimum": 0, "default": 50}
+      }
+    },
+    "arm.place": {
+      "type": "object",
+      "required": ["destination"],
+      "properties": {
+        "destination": {"type": "string"},
+        "release_height_mm": {"type": "number", "minimum": 0, "default": 30}
+      }
+    },
+    "arm.home": {"type": "object", "additionalProperties": false},
+    "perceive.rgb": {"type": "object", "additionalProperties": false},
+    "perceive.depth": {"type": "object", "additionalProperties": false},
+    "gripper.open": {"type": "object", "additionalProperties": false},
+    "gripper.close": {"type": "object", "additionalProperties": false},
+    "nav.go_to": {
+      "type": "object",
+      "required": ["pose"],
+      "properties": {"pose": {"type": "object"}}
+    },
+    "safety.estop": {"type": "object", "additionalProperties": false}
+  }
+}
+```
+
+(Note: drop the `//` comment line when actually saving — JSON-Schema doesn't permit comments. The leading `//` is a marker for the engineer.)
+
+- [ ] **Step 4: Run test to verify it passes**
+
+```bash
+cd cli && PYTHONPATH=src python -m pytest tests/backends/test_capabilities_schema_loads.py -v
+```
+
+Expected: PASS.
+
+- [ ] **Step 5: Add the arg-validation test**
+
+```python
+# cli/tests/backends/test_capabilities_schema_arg_validation.py
+from __future__ import annotations
+
+import json
+from pathlib import Path
+
+import jsonschema
+import pytest
+
+
+_SCHEMA_PATH = Path(__file__).parents[2] / "src" / "robot_md" / "schemas" / "capabilities.json"
+
+
+def _load_def(name: str) -> dict:
+    schema = json.loads(_SCHEMA_PATH.read_text())
+    return schema["definitions"][name]
+
+
+def test_arm_pick_accepts_minimal_valid_args() -> None:
+    jsonschema.validate({"target": "red_lego"}, _load_def("arm.pick"))
+
+
+def test_arm_pick_rejects_missing_target() -> None:
+    with pytest.raises(jsonschema.ValidationError):
+        jsonschema.validate({}, _load_def("arm.pick"))
+
+
+def test_arm_pick_rejects_wrong_target_type() -> None:
+    with pytest.raises(jsonschema.ValidationError):
+        jsonschema.validate({"target": 42}, _load_def("arm.pick"))
+
+
+def test_arm_home_rejects_extra_properties() -> None:
+    with pytest.raises(jsonschema.ValidationError):
+        jsonschema.validate({"surprise": True}, _load_def("arm.home"))
+```
+
+- [ ] **Step 6: Run validation tests**
+
+```bash
+cd cli && PYTHONPATH=src python -m pytest tests/backends/test_capabilities_schema_arg_validation.py -v
+```
+
+Expected: PASS (4/4).
+
+- [ ] **Step 7: Add the all-core-prefixes-present drift test**
+
+```python
+# cli/tests/backends/test_capabilities_schema_all_core_caps_present.py
+from __future__ import annotations
+
+import json
+from pathlib import Path
+
+
+_SCHEMA_PATH = Path(__file__).parents[2] / "src" / "robot_md" / "schemas" / "capabilities.json"
+
+# Mirrors backends/registry.py CORE_CAPABILITY_PREFIXES (introduced in Task 2).
+_CORE_PREFIXES = ("arm.", "nav.", "perceive.", "gripper.", "safety.")
+
+
+def test_every_core_prefix_has_at_least_one_capability_defined() -> None:
+    schema = json.loads(_SCHEMA_PATH.read_text())
+    defined = set(schema["definitions"].keys())
+    for prefix in _CORE_PREFIXES:
+        assert any(name.startswith(prefix) for name in defined), (
+            f"capabilities.json has no capability for core prefix {prefix!r}"
+        )
+```
+
+- [ ] **Step 8: Run drift test**
+
+```bash
+cd cli && PYTHONPATH=src python -m pytest tests/backends/test_capabilities_schema_all_core_caps_present.py -v
+```
+
+Expected: PASS.
+
+- [ ] **Step 9: Commit**
+
+```bash
+cd /home/craigm26/robot-md/.worktrees/sp3-sdk-adapter
+git add cli/src/robot_md/schemas/capabilities.json cli/tests/backends/test_capabilities_schema_loads.py cli/tests/backends/test_capabilities_schema_arg_validation.py cli/tests/backends/test_capabilities_schema_all_core_caps_present.py
+git commit -m "$(cat <<'EOF'
+feat(sp3): add core capabilities.json JSON-Schema
+
+JSON-Schema (Draft 2020-12) for the nine core capability arg shapes
+(arm.pick / arm.place / arm.home / perceive.rgb / perceive.depth /
+gripper.open / gripper.close / nav.go_to / safety.estop). Used at adapter
+test time and at execute_capability dispatch time to validate operator-
+or skill-supplied args before the backend ever sees them.
+
+Tests: parses-as-JSON-Schema, valid/invalid arg validation per shape,
+drift guard that every core prefix has at least one defined capability.
+
+Vendor capabilities are NOT schemaed in this file — adapter authors
+define their own arg shapes (see Task 5's describe_capabilities() default).
+
+Co-Authored-By: Claude Opus 4.7 (1M context) <noreply@anthropic.com>
+EOF
+)"
+```
+
+---
+
+### Task 2: Add capability tier validator (core / vendor namespaces)
+
+**Files:**
+- Modify: `cli/src/robot_md/backends/registry.py` (add `CORE_CAPABILITY_PREFIXES`, `_VENDOR_CAPABILITY_PATTERN`, `BackendRegistrationError`, `_validate_capability_namespace`)
+- Test: `cli/tests/backends/test_capability_namespace_core_accepted.py`, `cli/tests/backends/test_capability_namespace_vendor_accepted.py`, `cli/tests/backends/test_capability_namespace_malformed_rejected.py`
+
+- [ ] **Step 1: Write the core-accepted test**
+
+```python
+# cli/tests/backends/test_capability_namespace_core_accepted.py
+from __future__ import annotations
+
+from robot_md.backends.registry import _validate_capability_namespace
+
+
+def test_core_prefixes_accepted() -> None:
+    # Should not raise — these are all core-prefixed.
+    _validate_capability_namespace(
+        "test_backend",
+        frozenset({"arm.pick", "nav.go_to", "perceive.rgb", "gripper.open", "safety.estop"}),
+    )
+```
+
+- [ ] **Step 2: Write the vendor-accepted test**
+
+```python
+# cli/tests/backends/test_capability_namespace_vendor_accepted.py
+from __future__ import annotations
+
+from robot_md.backends.registry import _validate_capability_namespace
+
+
+def test_vendor_namespaced_accepted() -> None:
+    _validate_capability_namespace(
+        "test_backend",
+        frozenset({
+            "lerobot.teleop",
+            "realsense.aligned_depth",
+            "franka.cartesian_impedance",
+            "my_corp.skill_x",
+        }),
+    )
+```
+
+- [ ] **Step 3: Write the malformed-rejected test**
+
+```python
+# cli/tests/backends/test_capability_namespace_malformed_rejected.py
+from __future__ import annotations
+
+import pytest
+
+from robot_md.backends.registry import (
+    BackendRegistrationError,
+    _validate_capability_namespace,
+)
+
+
+@pytest.mark.parametrize(
+    "bad_capability",
+    [
+        "pick",        # no namespace
+        "Arm.pick",    # uppercase
+        "arm-pick",    # hyphen
+        ".arm.pick",   # leading dot
+        "arm.",        # trailing dot
+        "1arm.pick",   # leading digit
+        "arm. pick",   # whitespace
+    ],
+)
+def test_malformed_capability_rejected(bad_capability: str) -> None:
+    with pytest.raises(BackendRegistrationError) as excinfo:
+        _validate_capability_namespace("bad_backend", frozenset({bad_capability}))
+    assert "bad_backend" in str(excinfo.value)
+    assert bad_capability in str(excinfo.value)
+```
+
+- [ ] **Step 4: Run all three tests to verify they fail**
+
+```bash
+cd cli && PYTHONPATH=src python -m pytest tests/backends/test_capability_namespace_core_accepted.py tests/backends/test_capability_namespace_vendor_accepted.py tests/backends/test_capability_namespace_malformed_rejected.py -v
+```
+
+Expected: FAIL — `ImportError: cannot import name 'BackendRegistrationError' / '_validate_capability_namespace' from 'robot_md.backends.registry'`.
+
+- [ ] **Step 5: Add validator to `registry.py`**
+
+Edit `cli/src/robot_md/backends/registry.py`. After the existing imports (line 1-8), insert:
+
+```python
+import re
+
+CORE_CAPABILITY_PREFIXES = frozenset({"arm.", "nav.", "perceive.", "gripper.", "safety."})
+_VENDOR_CAPABILITY_PATTERN = re.compile(r"^[a-z][a-z0-9_]*\.[a-z][a-z0-9_.]*$")
+
+
+class BackendRegistrationError(Exception):
+    """Raised when a backend declares a malformed capability name."""
+
+
+def _validate_capability_namespace(backend_name: str, caps: frozenset[str]) -> None:
+    """Reject backend registration if any capability is malformed.
+
+    Allowed:
+      - Core: starts with one of CORE_CAPABILITY_PREFIXES.
+      - Vendor: matches r"^[a-z][a-z0-9_]*\\.[a-z][a-z0-9_.]*$".
+
+    Raises BackendRegistrationError on first violation.
+
+    Note: the existing feetech_depthai backend declares `vision.describe`
+    and `status.report`. Both pass the vendor regex (they look like
+    <vendor>.<name>) so the registry accepts them as vendor-shaped, even
+    though they're shipped in a first-party backend. Do NOT expand
+    CORE_CAPABILITY_PREFIXES here without coordinating with the SP3 spec
+    section on namespacing (the prefix list is RRF-canonical for core
+    capabilities only).
+    """
+    for cap in caps:
+        is_core = any(cap.startswith(p) for p in CORE_CAPABILITY_PREFIXES)
+        is_vendor_shaped = bool(_VENDOR_CAPABILITY_PATTERN.match(cap))
+        if not (is_core or is_vendor_shaped):
+            raise BackendRegistrationError(
+                f"Backend '{backend_name}' declared capability '{cap}': "
+                f"not a core prefix and not in <vendor>.<name> form."
+            )
+```
+
+- [ ] **Step 6: Run all three validator tests to verify they pass**
+
+```bash
+cd cli && PYTHONPATH=src python -m pytest tests/backends/test_capability_namespace_core_accepted.py tests/backends/test_capability_namespace_vendor_accepted.py tests/backends/test_capability_namespace_malformed_rejected.py -v
+```
+
+Expected: PASS (1 + 1 + 7 parametrized = 9 tests).
+
+- [ ] **Step 7: Commit**
+
+```bash
+cd /home/craigm26/robot-md/.worktrees/sp3-sdk-adapter
+git add cli/src/robot_md/backends/registry.py cli/tests/backends/test_capability_namespace_core_accepted.py cli/tests/backends/test_capability_namespace_vendor_accepted.py cli/tests/backends/test_capability_namespace_malformed_rejected.py
+git commit -m "$(cat <<'EOF'
+feat(sp3): capability tier validator at backend registration
+
+CORE_CAPABILITY_PREFIXES = {arm., nav., perceive., gripper., safety.};
+vendor regex ^[a-z][a-z0-9_]*\.[a-z][a-z0-9_.]*$. Backends that declare a
+capability matching neither raise BackendRegistrationError at registration
+time.
+
+The existing feetech_depthai backend declares vision.describe and
+status.report — these pass the vendor regex (look like <vendor>.<name>),
+so feetech_depthai ships green. Do NOT add vision./status. to
+CORE_CAPABILITY_PREFIXES — that list is RRF-canonical core only.
+
+Wired into discover_backends() in the next task.
+
+Co-Authored-By: Claude Opus 4.7 (1M context) <noreply@anthropic.com>
+EOF
+)"
+```
+
+---
+
+### Task 3: Wire validator into `discover_backends()`
+
+**Files:**
+- Modify: `cli/src/robot_md/backends/registry.py` (extend `discover_backends()` to call the validator and skip on failure)
+- Test: `cli/tests/backends/test_capability_namespace_skips_in_discovery.py`
+
+- [ ] **Step 1: Write the discovery-skip test**
+
+```python
+# cli/tests/backends/test_capability_namespace_skips_in_discovery.py
+from __future__ import annotations
+
+from unittest.mock import MagicMock, patch
+
+from robot_md.backends.base import CapabilityBackend
+from robot_md.backends.registry import discover_backends
+
+
+class _GoodBackend(CapabilityBackend):
+    name = "good"
+    protocols = frozenset({"feetech"})
+
+    def open(self, spec):
+        pass
+
+    def close(self):
+        pass
+
+    def capabilities(self) -> frozenset[str]:
+        return frozenset({"arm.pick"})
+
+    def execute(self, capability, args, *, dry_run, estop):
+        raise NotImplementedError
+
+
+class _BadBackend(CapabilityBackend):
+    name = "bad"
+    protocols = frozenset({"feetech"})
+
+    def open(self, spec):
+        pass
+
+    def close(self):
+        pass
+
+    def capabilities(self) -> frozenset[str]:
+        return frozenset({"NOT-VALID"})
+
+    def execute(self, capability, args, *, dry_run, estop):
+        raise NotImplementedError
+
+
+def _fake_entry_points(group: str):
+    assert group == "robot_md.backends"
+    good_ep = MagicMock()
+    good_ep.name = "good"
+    good_ep.load.return_value = _GoodBackend
+    bad_ep = MagicMock()
+    bad_ep.name = "bad"
+    bad_ep.load.return_value = _BadBackend
+    return [good_ep, bad_ep]
+
+
+def test_malformed_backend_skipped_others_keep_loading() -> None:
+    with patch("robot_md.backends.registry.entry_points", _fake_entry_points):
+        out = discover_backends()
+    names = sorted(b.name for b in out)
+    assert names == ["good"], f"expected only 'good' to load, got {names}"
+```
+
+- [ ] **Step 2: Run test to verify it fails**
+
+```bash
+cd cli && PYTHONPATH=src python -m pytest tests/backends/test_capability_namespace_skips_in_discovery.py -v
+```
+
+Expected: FAIL — either `ImportError` on the `entry_points` patch target (current code imports inside the function), or both backends load (since the validator isn't wired yet).
+
+- [ ] **Step 3: Refactor `discover_backends()` to import `entry_points` at module level + call the validator**
+
+Edit `cli/src/robot_md/backends/registry.py`. Replace the entire `discover_backends()` function plus restructure the imports:
+
+```python
+"""Backend discovery + deterministic resolution."""
+
+from __future__ import annotations
+
+import logging
+import re
+from dataclasses import dataclass, field
+from importlib.metadata import entry_points
+
+from robot_md.backends.base import CapabilityBackend
+from robot_md.robot_spec import RobotSpec
+
+_log = logging.getLogger(__name__)
+
+CORE_CAPABILITY_PREFIXES = frozenset({"arm.", "nav.", "perceive.", "gripper.", "safety."})
+_VENDOR_CAPABILITY_PATTERN = re.compile(r"^[a-z][a-z0-9_]*\.[a-z][a-z0-9_.]*$")
+
+
+class BackendRegistrationError(Exception):
+    """Raised when a backend declares a malformed capability name."""
+
+
+def _validate_capability_namespace(backend_name: str, caps: frozenset[str]) -> None:
+    """(See Task 2 docstring — body unchanged.)"""
+    for cap in caps:
+        is_core = any(cap.startswith(p) for p in CORE_CAPABILITY_PREFIXES)
+        is_vendor_shaped = bool(_VENDOR_CAPABILITY_PATTERN.match(cap))
+        if not (is_core or is_vendor_shaped):
+            raise BackendRegistrationError(
+                f"Backend '{backend_name}' declared capability '{cap}': "
+                f"not a core prefix and not in <vendor>.<name> form."
+            )
+
+
+def discover_backends() -> list[CapabilityBackend]:
+    """Load backends registered under the `robot_md.backends` entry-point group.
+
+    Backends with malformed capability names are logged and skipped — the rest
+    of the registry continues to load.
+    """
+    try:
+        eps = entry_points(group="robot_md.backends")
+    except TypeError:
+        # Python 3.9 compatibility fallback — not expected here, but harmless.
+        all_eps = entry_points()
+        eps = all_eps.get("robot_md.backends", []) if hasattr(all_eps, "get") else []
+    out: list[CapabilityBackend] = []
+    for ep in sorted(eps, key=lambda e: e.name):
+        try:
+            cls = ep.load()
+            instance = cls()
+        except Exception as e:  # noqa: BLE001 — adapter import failures are non-fatal
+            _log.warning("backend %r failed to load: %s", ep.name, e)
+            continue
+        try:
+            _validate_capability_namespace(ep.name, instance.capabilities())
+        except BackendRegistrationError as e:
+            _log.warning("%s — skipping backend.", e)
+            continue
+        out.append(instance)
+    return out
+```
+
+(Note: the validator and `BackendRegistrationError` introduced in Task 2 are now at module top level — the same definitions, just relocated above `discover_backends()`. Delete the duplicate definitions you added in Task 2 if they ended up below the function during that edit.)
+
+- [ ] **Step 4: Run discovery-skip test**
+
+```bash
+cd cli && PYTHONPATH=src python -m pytest tests/backends/test_capability_namespace_skips_in_discovery.py -v
+```
+
+Expected: PASS.
+
+- [ ] **Step 5: Run all backends tests to confirm no regression**
+
+```bash
+cd cli && PYTHONPATH=src python -m pytest tests/backends/ -v
+```
+
+Expected: all PASS (Task 1 + Task 2 + Task 3 tests).
+
+- [ ] **Step 6: Run full test suite to confirm `feetech_depthai` still loads green**
+
+```bash
+cd cli && PYTHONPATH=src python -m pytest tests/ -q --ignore=tests/integration --ignore=tests/spatial_eval -x
+```
+
+Expected: all PASS. The feetech_depthai backend declares `vision.describe` and `status.report` — both vendor-shaped, both pass the validator.
+
+- [ ] **Step 7: Commit**
+
+```bash
+cd /home/craigm26/robot-md/.worktrees/sp3-sdk-adapter
+git add cli/src/robot_md/backends/registry.py cli/tests/backends/test_capability_namespace_skips_in_discovery.py
+git commit -m "$(cat <<'EOF'
+feat(sp3): wire capability tier validator into backend discovery
+
+discover_backends() now calls _validate_capability_namespace on each
+backend's capabilities() set after instantiation. On BackendRegistrationError
+the offending backend is logged and skipped; the remaining registry
+continues to load.
+
+Hoists the entry_points import to module scope so tests can patch it
+deterministically. Existing alphabetical sort + Python 3.9 fallback
+preserved.
+
+The existing feetech_depthai backend (vision.describe + status.report)
+ships green — both pass the vendor regex.
+
+Co-Authored-By: Claude Opus 4.7 (1M context) <noreply@anthropic.com>
+EOF
+)"
+```
+
+---
+
+### Task 4: Add `Capability` dataclass + namespace-derivation helper
+
+**Files:**
+- Create: `cli/src/robot_md/backends/capability.py`
+- Test: `cli/tests/backends/test_capability_dataclass.py`
+
+- [ ] **Step 1: Write the dataclass shape + namespace-derivation test**
+
+```python
+# cli/tests/backends/test_capability_dataclass.py
+from __future__ import annotations
+
+import pytest
+
+from robot_md.backends.capability import Capability, derive_namespace
+
+
+def test_capability_is_frozen_dataclass() -> None:
+    cap = Capability(name="arm.pick", namespace="core", arg_schema=None, description="")
+    with pytest.raises(Exception):
+        cap.name = "arm.place"  # frozen — must raise
+
+
+def test_derive_namespace_core_prefixes() -> None:
+    for name in ("arm.pick", "nav.go_to", "perceive.rgb", "gripper.open", "safety.estop"):
+        assert derive_namespace(name) == "core"
+
+
+def test_derive_namespace_vendor() -> None:
+    for name in ("lerobot.teleop", "realsense.aligned_depth", "my_corp.skill_x"):
+        assert derive_namespace(name) == "vendor"
+
+
+def test_derive_namespace_vendor_for_existing_feetech_capabilities() -> None:
+    # vision.describe and status.report are NOT in CORE_CAPABILITY_PREFIXES;
+    # they are vendor-shaped and should be classified as vendor.
+    assert derive_namespace("vision.describe") == "vendor"
+    assert derive_namespace("status.report") == "vendor"
+```
+
+- [ ] **Step 2: Run test to verify it fails**
+
+```bash
+cd cli && PYTHONPATH=src python -m pytest tests/backends/test_capability_dataclass.py -v
+```
+
+Expected: FAIL — `ImportError: cannot import name 'Capability' from 'robot_md.backends.capability'`.
+
+- [ ] **Step 3: Create `capability.py`**
+
+```python
+# cli/src/robot_md/backends/capability.py
+"""Public Capability metadata API.
+
+See SP3 spec § Capability Metadata Addendum (2026-04-27).
+"""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+from typing import Literal
+
+from robot_md.backends.registry import CORE_CAPABILITY_PREFIXES
+
+
+@dataclass(frozen=True)
+class Capability:
+    """Rich metadata for a capability declared by a backend.
+
+    name        — e.g. "arm.pick", "lerobot.teleop"
+    namespace   — "core" if name starts with a CORE_CAPABILITY_PREFIXES entry,
+                  otherwise "vendor"
+    arg_schema  — JSON-Schema fragment from capabilities.json, or None for
+                  vendor capabilities not in the schema
+    description — short human-readable; "" if none available
+    """
+
+    name: str
+    namespace: Literal["core", "vendor"]
+    arg_schema: dict | None
+    description: str
+
+
+def derive_namespace(capability_name: str) -> Literal["core", "vendor"]:
+    """Return 'core' if the name starts with a core prefix, else 'vendor'."""
+    if any(capability_name.startswith(p) for p in CORE_CAPABILITY_PREFIXES):
+        return "core"
+    return "vendor"
+```
+
+- [ ] **Step 4: Run test to verify it passes**
+
+```bash
+cd cli && PYTHONPATH=src python -m pytest tests/backends/test_capability_dataclass.py -v
+```
+
+Expected: PASS (4/4).
+
+- [ ] **Step 5: Commit**
+
+```bash
+cd /home/craigm26/robot-md/.worktrees/sp3-sdk-adapter
+git add cli/src/robot_md/backends/capability.py cli/tests/backends/test_capability_dataclass.py
+git commit -m "$(cat <<'EOF'
+feat(sp3): Capability dataclass + namespace-derivation helper
+
+frozen=True dataclass with name/namespace/arg_schema/description fields.
+derive_namespace() classifies a capability name as 'core' (starts with
+arm./nav./perceive./gripper./safety.) or 'vendor' (anything else that
+passes the registration regex).
+
+vision.describe and status.report (declared by feetech_depthai) are
+classified as 'vendor' — documented behavior.
+
+Co-Authored-By: Claude Opus 4.7 (1M context) <noreply@anthropic.com>
+EOF
+)"
+```
+
+---
+
+### Task 5: Add `describe_capabilities()` default impl on `CapabilityBackend`
+
+**Files:**
+- Create: `cli/src/robot_md/backends/_capability_default.py`
+- Modify: `cli/src/robot_md/backends/base.py` (add the concrete default `describe_capabilities()` method)
+- Test: `cli/tests/backends/test_capability_metadata_default.py`, `cli/tests/backends/test_existing_capabilities_method_unchanged.py`
+
+- [ ] **Step 1: Write the default-impl test**
+
+```python
+# cli/tests/backends/test_capability_metadata_default.py
+from __future__ import annotations
+
+from robot_md.backends._capability_default import describe_default
+
+
+def test_default_returns_capability_objects() -> None:
+    out = describe_default("test_backend", frozenset({"arm.pick"}))
+    assert len(out) == 1
+    cap = out[0]
+    assert cap.name == "arm.pick"
+    assert cap.namespace == "core"
+    assert cap.arg_schema is not None
+    assert cap.arg_schema.get("required") == ["target"]
+
+
+def test_default_for_core_capability_with_no_schema_entry() -> None:
+    # No core capability is currently absent from capabilities.json,
+    # but the default must handle the drift case gracefully.
+    out = describe_default("test_backend", frozenset({"arm.future_capability"}))
+    assert len(out) == 1
+    cap = out[0]
+    assert cap.name == "arm.future_capability"
+    assert cap.namespace == "core"
+    assert cap.arg_schema is None
+    assert cap.description == ""
+
+
+def test_default_for_vendor_capability() -> None:
+    out = describe_default("lerobot", frozenset({"lerobot.teleop"}))
+    assert len(out) == 1
+    cap = out[0]
+    assert cap.name == "lerobot.teleop"
+    assert cap.namespace == "vendor"
+    assert cap.arg_schema is None
+    assert cap.description == ""
+
+
+def test_default_for_existing_feetech_capabilities() -> None:
+    # vision.describe and status.report from feetech_depthai → vendor with None schema.
+    out = describe_default(
+        "feetech_depthai",
+        frozenset({"vision.describe", "status.report"}),
+    )
+    by_name = {c.name: c for c in out}
+    assert by_name["vision.describe"].namespace == "vendor"
+    assert by_name["vision.describe"].arg_schema is None
+    assert by_name["status.report"].namespace == "vendor"
+    assert by_name["status.report"].arg_schema is None
+```
+
+- [ ] **Step 2: Run test to verify it fails**
+
+```bash
+cd cli && PYTHONPATH=src python -m pytest tests/backends/test_capability_metadata_default.py -v
+```
+
+Expected: FAIL — `ImportError: cannot import name 'describe_default'`.
+
+- [ ] **Step 3: Create `_capability_default.py`**
+
+```python
+# cli/src/robot_md/backends/_capability_default.py
+"""Default impl of describe_capabilities() — looks up arg_schema in capabilities.json."""
+
+from __future__ import annotations
+
+import json
+from functools import lru_cache
+from pathlib import Path
+
+from robot_md.backends.capability import Capability, derive_namespace
+
+_SCHEMA_PATH = Path(__file__).parent.parent / "schemas" / "capabilities.json"
+
+
+@lru_cache(maxsize=1)
+def _load_capabilities_schema() -> dict:
+    return json.loads(_SCHEMA_PATH.read_text())
+
+
+def describe_default(backend_name: str, caps: frozenset[str]) -> list[Capability]:
+    """Build Capability objects for each capability the backend declared.
+
+    For each capability:
+      - Look up arg_schema in capabilities.json under definitions[name]; None if absent.
+      - description: schema's "description" field if present, else "".
+      - namespace: derive_namespace(name) — "core" or "vendor".
+
+    Vendor capabilities NOT in capabilities.json get arg_schema=None;
+    adapter authors who want richer metadata override describe_capabilities()
+    on their CapabilityBackend subclass.
+    """
+    schema = _load_capabilities_schema()
+    defs = schema.get("definitions", {})
+    out: list[Capability] = []
+    for cap in sorted(caps):
+        entry = defs.get(cap)
+        out.append(
+            Capability(
+                name=cap,
+                namespace=derive_namespace(cap),
+                arg_schema=entry,
+                description=(entry or {}).get("description", "") if entry else "",
+            )
+        )
+    return out
+```
+
+- [ ] **Step 4: Run default-impl test**
+
+```bash
+cd cli && PYTHONPATH=src python -m pytest tests/backends/test_capability_metadata_default.py -v
+```
+
+Expected: PASS (4/4).
+
+- [ ] **Step 5: Add `describe_capabilities()` method to `CapabilityBackend`**
+
+Edit `cli/src/robot_md/backends/base.py`. After the existing abstract `execute(...)` method (line 54-61), and before `scene_describe()` (line 63), insert:
+
+```python
+    def describe_capabilities(self) -> "list[Capability]":
+        """Return rich metadata for each capability this backend declares.
+
+        Default: walk self.capabilities(), look each up in
+        cli/src/robot_md/schemas/capabilities.json for arg_schema +
+        description; vendor capabilities not in the schema get
+        arg_schema=None, description="".
+
+        Adapters MAY override to provide richer vendor metadata
+        (e.g., lerobot.teleop description, dynamixel.indirect_address
+        arg shapes).
+        """
+        from robot_md.backends._capability_default import describe_default
+        return describe_default(self.name, self.capabilities())
+```
+
+The `from robot_md.backends.capability import Capability` is referenced via string annotation to avoid an import cycle.
+
+- [ ] **Step 6: Add the backward-compatibility test**
+
+```python
+# cli/tests/backends/test_existing_capabilities_method_unchanged.py
+from __future__ import annotations
+
+from robot_md.backends.feetech_depthai import FeetechDepthaiBackend
+
+
+def test_capabilities_method_returns_frozenset() -> None:
+    b = FeetechDepthaiBackend()
+    caps = b.capabilities()
+    assert isinstance(caps, frozenset)
+    expected = frozenset({
+        "arm.pick", "arm.place", "arm.reach", "arm.home",
+        "vision.describe", "status.report",
+    })
+    assert caps == expected
+
+
+def test_describe_capabilities_default_works_for_feetech() -> None:
+    b = FeetechDepthaiBackend()
+    out = b.describe_capabilities()
+    by_name = {c.name: c for c in out}
+    # Core capabilities have arg_schema; vendor (vision., status.) do not.
+    assert by_name["arm.pick"].arg_schema is not None
+    assert by_name["arm.pick"].namespace == "core"
+    assert by_name["vision.describe"].arg_schema is None
+    assert by_name["vision.describe"].namespace == "vendor"
+```
+
+- [ ] **Step 7: Run backward-compat test**
+
+```bash
+cd cli && PYTHONPATH=src python -m pytest tests/backends/test_existing_capabilities_method_unchanged.py -v
+```
+
+Expected: PASS (2/2).
+
+- [ ] **Step 8: Commit**
+
+```bash
+cd /home/craigm26/robot-md/.worktrees/sp3-sdk-adapter
+git add cli/src/robot_md/backends/_capability_default.py cli/src/robot_md/backends/base.py cli/tests/backends/test_capability_metadata_default.py cli/tests/backends/test_existing_capabilities_method_unchanged.py
+git commit -m "$(cat <<'EOF'
+feat(sp3): describe_capabilities() default impl on CapabilityBackend
+
+Adds a concrete (non-abstract) describe_capabilities() method to the
+CapabilityBackend ABC. Default implementation walks self.capabilities()
+and looks each name up in capabilities.json — core capabilities get the
+schema fragment; vendor capabilities not in the schema get arg_schema=None
+and description="". Adapter authors MAY override.
+
+Existing capabilities() -> frozenset[str] is preserved unchanged.
+feetech_depthai ships green: arm.pick / arm.place / arm.reach / arm.home
+get core arg_schemas; vision.describe + status.report are correctly
+classified as vendor with None schema.
+
+Co-Authored-By: Claude Opus 4.7 (1M context) <noreply@anthropic.com>
+EOF
+)"
+```
+
+---
+
+### Task 6: Add `iter_classes()` to `BackendRegistry`
+
+**Files:**
+- Modify: `cli/src/robot_md/backends/registry.py` (add `iter_classes()` method on `BackendRegistry`)
+- Test: `cli/tests/backends/test_enumerate_capabilities.py` (just the iter_classes test for now; full enumerate test in Task 7)
+
+- [ ] **Step 1: Write the iter_classes test**
+
+```python
+# cli/tests/backends/test_enumerate_capabilities.py
+from __future__ import annotations
+
+from robot_md.backends.base import CapabilityBackend
+from robot_md.backends.registry import BackendRegistry
+
+
+class _StubBackend(CapabilityBackend):
+    name = "stub"
+    protocols = frozenset({"feetech"})
+
+    def open(self, spec):
+        pass
+
+    def close(self):
+        pass
+
+    def capabilities(self) -> frozenset[str]:
+        return frozenset({"arm.pick"})
+
+    def execute(self, capability, args, *, dry_run, estop):
+        raise NotImplementedError
+
+
+def test_iter_classes_yields_name_class_pairs() -> None:
+    reg = BackendRegistry(backends=[_StubBackend()])
+    pairs = list(reg.iter_classes())
+    assert len(pairs) == 1
+    name, cls = pairs[0]
+    assert name == "stub"
+    assert cls is _StubBackend
+```
+
+- [ ] **Step 2: Run test to verify it fails**
+
+```bash
+cd cli && PYTHONPATH=src python -m pytest tests/backends/test_enumerate_capabilities.py::test_iter_classes_yields_name_class_pairs -v
+```
+
+Expected: FAIL — `AttributeError: 'BackendRegistry' object has no attribute 'iter_classes'`.
+
+- [ ] **Step 3: Add `iter_classes()` to `BackendRegistry`**
+
+Edit `cli/src/robot_md/backends/registry.py`. After the `resolve()` method on `BackendRegistry`, add:
+
+```python
+    def iter_classes(self) -> "list[tuple[str, type[CapabilityBackend]]]":
+        """Return [(backend.name, type(backend)), ...] for every loaded backend.
+
+        Used by enumerate_capabilities() in backends/__init__.py to walk the
+        catalog without re-instantiating. The registry already holds live
+        instances; iter_classes() exposes (name, class) for callers that
+        specifically need the class object.
+        """
+        return [(b.name, type(b)) for b in self.backends]
+```
+
+- [ ] **Step 4: Run iter_classes test**
+
+```bash
+cd cli && PYTHONPATH=src python -m pytest tests/backends/test_enumerate_capabilities.py::test_iter_classes_yields_name_class_pairs -v
+```
+
+Expected: PASS.
+
+- [ ] **Step 5: Commit**
+
+```bash
+cd /home/craigm26/robot-md/.worktrees/sp3-sdk-adapter
+git add cli/src/robot_md/backends/registry.py cli/tests/backends/test_enumerate_capabilities.py
+git commit -m "$(cat <<'EOF'
+feat(sp3): BackendRegistry.iter_classes()
+
+Returns [(backend.name, type(backend)), ...] over loaded backends so
+callers that need the class object (rather than the instance) — primarily
+the upcoming enumerate_capabilities() module function — can walk the
+catalog without re-instantiating.
+
+Co-Authored-By: Claude Opus 4.7 (1M context) <noreply@anthropic.com>
+EOF
+)"
+```
+
+---
+
+### Task 7: Add `enumerate_capabilities(registry)` module function
+
+**Files:**
+- Modify: `cli/src/robot_md/backends/__init__.py` (re-export `Capability`; add `enumerate_capabilities`)
+- Test: `cli/tests/backends/test_enumerate_capabilities.py` (extend with the walker test)
+
+- [ ] **Step 1: Inspect current `backends/__init__.py`**
+
+```bash
+cat cli/src/robot_md/backends/__init__.py
+```
+
+If it does not yet re-export `BackendRegistry`, prepare to add re-exports for `BackendRegistry`, `Capability`, and `enumerate_capabilities`.
+
+- [ ] **Step 2: Add the enumerate-walker test**
+
+Append to `cli/tests/backends/test_enumerate_capabilities.py`:
+
+```python
+from robot_md.backends import enumerate_capabilities, Capability
+
+
+class _SecondStubBackend(CapabilityBackend):
+    name = "stub2"
+    protocols = frozenset({"realsense"})
+
+    def open(self, spec):
+        pass
+
+    def close(self):
+        pass
+
+    def capabilities(self) -> frozenset[str]:
+        return frozenset({"perceive.rgb", "stub2.vendor_thing"})
+
+    def execute(self, capability, args, *, dry_run, estop):
+        raise NotImplementedError
+
+
+def test_enumerate_capabilities_walks_registry() -> None:
+    reg = BackendRegistry(backends=[_StubBackend(), _SecondStubBackend()])
+    pairs = enumerate_capabilities(reg)
+    # 1 cap from stub + 2 caps from stub2 = 3 pairs.
+    assert len(pairs) == 3
+    by_backend = {}
+    for backend_name, cap in pairs:
+        assert isinstance(cap, Capability)
+        by_backend.setdefault(backend_name, []).append(cap.name)
+    assert sorted(by_backend["stub"]) == ["arm.pick"]
+    assert sorted(by_backend["stub2"]) == ["perceive.rgb", "stub2.vendor_thing"]
+
+
+def test_enumerate_capabilities_uses_describe_capabilities_override() -> None:
+    """If a backend overrides describe_capabilities(), that wins over the default."""
+    custom_cap = Capability(
+        name="lerobot.teleop",
+        namespace="vendor",
+        arg_schema={"type": "object", "properties": {"leader_port": {"type": "string"}}},
+        description="Drive follower from leader.",
+    )
+
+    class _OverrideBackend(_StubBackend):
+        name = "override"
+
+        def capabilities(self) -> frozenset[str]:
+            return frozenset({"lerobot.teleop"})
+
+        def describe_capabilities(self) -> list[Capability]:
+            return [custom_cap]
+
+    reg = BackendRegistry(backends=[_OverrideBackend()])
+    pairs = enumerate_capabilities(reg)
+    assert len(pairs) == 1
+    backend_name, cap = pairs[0]
+    assert backend_name == "override"
+    assert cap is custom_cap  # exact object — override wins
+```
+
+- [ ] **Step 3: Run new tests to verify they fail**
+
+```bash
+cd cli && PYTHONPATH=src python -m pytest tests/backends/test_enumerate_capabilities.py -v
+```
+
+Expected: FAIL — `ImportError: cannot import name 'enumerate_capabilities' from 'robot_md.backends'`.
+
+- [ ] **Step 4: Implement `enumerate_capabilities` in `backends/__init__.py`**
+
+Replace `cli/src/robot_md/backends/__init__.py` with:
+
+```python
+"""Public backend API.
+
+Re-exports CapabilityBackend, BackendRegistry, Capability, and the
+enumerate_capabilities walker.
+"""
+
+from __future__ import annotations
+
+from robot_md.backends.base import CapabilityBackend, ExecutionEvent, ExecutionResult, SceneSnapshot
+from robot_md.backends.capability import Capability, derive_namespace
+from robot_md.backends.registry import (
+    BackendRegistrationError,
+    BackendRegistry,
+    CORE_CAPABILITY_PREFIXES,
+    discover_backends,
+)
+
+
+def enumerate_capabilities(registry: BackendRegistry) -> list[tuple[str, Capability]]:
+    """Walk all registered backends, return (backend_name, Capability) pairs.
+
+    Used by:
+      - The `robot-md describe-capabilities` CLI subcommand (Task 8).
+      - Future SP-HP daemon — preview a backend's capabilities at hot-plug time.
+      - Future robot-md-http OpenAPI generator.
+
+    Backends MAY override describe_capabilities() to provide richer metadata;
+    the override is preserved here.
+    """
+    out: list[tuple[str, Capability]] = []
+    for backend in registry.backends:
+        for cap in backend.describe_capabilities():
+            out.append((backend.name, cap))
+    return out
+
+
+__all__ = [
+    "BackendRegistrationError",
+    "BackendRegistry",
+    "CORE_CAPABILITY_PREFIXES",
+    "Capability",
+    "CapabilityBackend",
+    "ExecutionEvent",
+    "ExecutionResult",
+    "SceneSnapshot",
+    "derive_namespace",
+    "discover_backends",
+    "enumerate_capabilities",
+]
+```
+
+- [ ] **Step 5: Run enumerate tests**
+
+```bash
+cd cli && PYTHONPATH=src python -m pytest tests/backends/test_enumerate_capabilities.py -v
+```
+
+Expected: PASS (3/3 — iter_classes + walker + override).
+
+- [ ] **Step 6: Run full backends test suite to confirm no regression**
+
+```bash
+cd cli && PYTHONPATH=src python -m pytest tests/backends/ -v
+```
+
+Expected: all PASS.
+
+- [ ] **Step 7: Commit**
+
+```bash
+cd /home/craigm26/robot-md/.worktrees/sp3-sdk-adapter
+git add cli/src/robot_md/backends/__init__.py cli/tests/backends/test_enumerate_capabilities.py
+git commit -m "$(cat <<'EOF'
+feat(sp3): enumerate_capabilities(registry) public walker
+
+Module-level function that walks all backends in a BackendRegistry and
+returns [(backend_name, Capability), ...] using each backend's
+describe_capabilities() — overrides honored.
+
+Public API surface for SP-HP (hot-plug capability preview), the eventual
+robot-md-http OpenAPI generator, and the robot-md describe-capabilities
+CLI subcommand (Task 8).
+
+Re-exports Capability, BackendRegistry, BackendRegistrationError,
+CORE_CAPABILITY_PREFIXES, and the existing CapabilityBackend ABC + result
+dataclasses for one stable import path.
+
+Co-Authored-By: Claude Opus 4.7 (1M context) <noreply@anthropic.com>
+EOF
+)"
+```
+
+---
+
+### Task 8: Add `robot-md describe-capabilities` CLI subcommand (proves the API end-to-end)
+
+**Files:**
+- Modify: `cli/src/robot_md/__main__.py` (add the Typer subcommand)
+- Test: `cli/tests/backends/test_describe_capabilities_cli.py`
+
+- [ ] **Step 1: Inspect the existing Typer app structure**
+
+```bash
+grep -n "app = typer.Typer\|@app.command\|^def \(init\|doctor\|mcp\)" cli/src/robot_md/__main__.py | head -30
+```
+
+Note where commands are registered. The new `describe-capabilities` subcommand follows the same pattern as `init`, `doctor`, etc. — `@app.command("describe-capabilities")` decorating a `def describe_capabilities(...)` function.
+
+- [ ] **Step 2: Write the CLI smoke test**
+
+```python
+# cli/tests/backends/test_describe_capabilities_cli.py
+from __future__ import annotations
+
+import json
+import subprocess
+import sys
+from pathlib import Path
+
+
+def test_describe_capabilities_json_output_lists_feetech_caps() -> None:
+    cmd = [
+        sys.executable,
+        "-m",
+        "robot_md",
+        "describe-capabilities",
+        "--json",
+    ]
+    env = {"PYTHONPATH": str(Path(__file__).parents[2] / "src")}
+    proc = subprocess.run(cmd, capture_output=True, text=True, env={**env}, check=False)
+    assert proc.returncode == 0, proc.stderr
+    payload = json.loads(proc.stdout)
+    # feetech_depthai is the in-tree default; should appear with its caps.
+    by_backend = {entry["backend"]: entry for entry in payload}
+    assert "feetech_depthai" in by_backend
+    cap_names = {c["name"] for c in by_backend["feetech_depthai"]["capabilities"]}
+    assert "arm.pick" in cap_names
+    assert "vision.describe" in cap_names
+
+
+def test_describe_capabilities_text_output_groups_by_namespace() -> None:
+    cmd = [sys.executable, "-m", "robot_md", "describe-capabilities"]
+    env = {"PYTHONPATH": str(Path(__file__).parents[2] / "src")}
+    proc = subprocess.run(cmd, capture_output=True, text=True, env={**env}, check=False)
+    assert proc.returncode == 0, proc.stderr
+    out = proc.stdout
+    assert "feetech_depthai" in out
+    assert "core" in out  # section header for core capabilities
+    assert "vendor" in out
+    assert "arm.pick" in out
+```
+
+- [ ] **Step 3: Run the test to verify it fails**
+
+```bash
+cd cli && PYTHONPATH=src python -m pytest tests/backends/test_describe_capabilities_cli.py -v
+```
+
+Expected: FAIL — Typer reports unknown command `describe-capabilities`.
+
+- [ ] **Step 4: Add the subcommand to `__main__.py`**
+
+In `cli/src/robot_md/__main__.py`, find the section near other `@app.command(...)` registrations and add:
+
+```python
+@app.command("describe-capabilities")
+def describe_capabilities(
+    json_output: bool = typer.Option(
+        False, "--json", help="Emit JSON instead of human-readable text."
+    ),
+) -> None:
+    """List capabilities exposed by every installed backend.
+
+    Walks the entry-point group `robot_md.backends`, builds a BackendRegistry,
+    and dumps Capability metadata grouped by backend + namespace.
+    """
+    import json as _json
+
+    from robot_md.backends import BackendRegistry, enumerate_capabilities
+
+    reg = BackendRegistry.from_entry_points()
+    pairs = enumerate_capabilities(reg)
+
+    by_backend: dict[str, list] = {}
+    for backend_name, cap in pairs:
+        by_backend.setdefault(backend_name, []).append(cap)
+
+    if json_output:
+        payload = [
+            {
+                "backend": backend_name,
+                "capabilities": [
+                    {
+                        "name": c.name,
+                        "namespace": c.namespace,
+                        "arg_schema": c.arg_schema,
+                        "description": c.description,
+                    }
+                    for c in caps
+                ],
+            }
+            for backend_name, caps in sorted(by_backend.items())
+        ]
+        typer.echo(_json.dumps(payload, indent=2, sort_keys=True))
+        return
+
+    for backend_name in sorted(by_backend):
+        typer.echo(f"\n{backend_name}")
+        typer.echo("=" * len(backend_name))
+        caps = by_backend[backend_name]
+        core = [c for c in caps if c.namespace == "core"]
+        vendor = [c for c in caps if c.namespace == "vendor"]
+        if core:
+            typer.echo("  core:")
+            for c in sorted(core, key=lambda x: x.name):
+                desc = f" — {c.description}" if c.description else ""
+                typer.echo(f"    {c.name}{desc}")
+        if vendor:
+            typer.echo("  vendor:")
+            for c in sorted(vendor, key=lambda x: x.name):
+                desc = f" — {c.description}" if c.description else ""
+                typer.echo(f"    {c.name}{desc}")
+```
+
+(If the file uses `import typer` already, reuse it. If `app` is named differently, follow the existing convention.)
+
+- [ ] **Step 5: Run CLI test**
+
+```bash
+cd cli && PYTHONPATH=src python -m pytest tests/backends/test_describe_capabilities_cli.py -v
+```
+
+Expected: PASS (2/2).
+
+- [ ] **Step 6: Run a manual smoke against the live registry**
+
+```bash
+cd cli && PYTHONPATH=src python -m robot_md describe-capabilities
+```
+
+Expected output: a section for `feetech_depthai` listing its core capabilities (arm.pick / arm.place / arm.reach / arm.home) and vendor capabilities (vision.describe / status.report). Other backends only appear once their entry-points are added in Phase D.
+
+- [ ] **Step 7: Commit**
+
+```bash
+cd /home/craigm26/robot-md/.worktrees/sp3-sdk-adapter
+git add cli/src/robot_md/__main__.py cli/tests/backends/test_describe_capabilities_cli.py
+git commit -m "$(cat <<'EOF'
+feat(sp3): robot-md describe-capabilities CLI subcommand
+
+Concrete first consumer of enumerate_capabilities(). Lists every
+backend's capability metadata (core vs vendor namespaces, arg_schema if
+present from capabilities.json, description) in human-readable text or
+JSON via --json.
+
+Today: shows feetech_depthai. After Phase D's entry-point declarations,
+also shows lerobot + realsense. Future: SP-HP and robot-md-http use the
+same enumerate_capabilities() path.
+
+Co-Authored-By: Claude Opus 4.7 (1M context) <noreply@anthropic.com>
+EOF
+)"
+```
+
+---
+
+## Phase B — RealSense backend (camera-only)
+
+Simpler than LeRobot (no motion). Builds confidence in the adapter pattern + tier validator + describe_capabilities() integration before tackling the heavier LeRobot adapter.
+
+### Task 9: Stub `RealsenseBackend` class + class-attr tests
+
+**Files:**
+- Create: `cli/src/robot_md/backends/realsense/__init__.py`
+- Test: `cli/tests/backends/test_realsense_backend_protocols.py`, `cli/tests/backends/test_realsense_capabilities_camera_only.py`
+
+- [ ] **Step 1: Write the protocols + class-attr test**
+
+```python
+# cli/tests/backends/test_realsense_backend_protocols.py
+from __future__ import annotations
+
+from robot_md.backends.realsense import RealsenseBackend
+
+
+def test_name_and_protocols() -> None:
+    b = RealsenseBackend()
+    assert b.name == "realsense"
+    assert b.protocols == frozenset({"realsense"})
+
+
+def test_read_only_capabilities_marks_perception() -> None:
+    b = RealsenseBackend()
+    assert b.read_only_capabilities == frozenset({"perceive.rgb", "perceive.depth"})
+```
+
+- [ ] **Step 2: Write the camera-only-capabilities test**
+
+```python
+# cli/tests/backends/test_realsense_capabilities_camera_only.py
+from __future__ import annotations
+
+from robot_md.backends.realsense import RealsenseBackend
+
+
+def test_capabilities_are_perception_plus_aligned_depth() -> None:
+    b = RealsenseBackend()
+    caps = b.capabilities()
+    assert caps == frozenset({
+        "perceive.rgb",
+        "perceive.depth",
+        "realsense.aligned_depth",
+    })
+
+
+def test_no_arm_or_gripper_capabilities() -> None:
+    b = RealsenseBackend()
+    caps = b.capabilities()
+    for cap in caps:
+        assert not cap.startswith("arm."), f"unexpected arm capability {cap}"
+        assert not cap.startswith("gripper."), f"unexpected gripper capability {cap}"
+```
+
+- [ ] **Step 3: Run tests to verify they fail**
+
+```bash
+cd cli && PYTHONPATH=src python -m pytest tests/backends/test_realsense_backend_protocols.py tests/backends/test_realsense_capabilities_camera_only.py -v
+```
+
+Expected: FAIL — `ModuleNotFoundError: No module named 'robot_md.backends.realsense'`.
+
+- [ ] **Step 4: Create the package skeleton**
+
+Create `cli/src/robot_md/backends/realsense/__init__.py`:
+
+```python
+"""RealSense camera adapter — perception only, no motion."""
+
+from __future__ import annotations
+
+from robot_md.backends.base import (
+    CapabilityBackend,
+    ExecutionEvent,
+    ExecutionResult,
+    SceneSnapshot,
+)
+from robot_md.robot_spec import RobotSpec
+
+
+class RealsenseBackend(CapabilityBackend):
+    name = "realsense"
+    protocols = frozenset({"realsense"})
+    read_only_capabilities = frozenset({"perceive.rgb", "perceive.depth"})
+
+    def __init__(self) -> None:
+        self._pipeline = None
+
+    def open(self, spec: RobotSpec) -> None:
+        # Implemented in Task 10.
+        raise NotImplementedError
+
+    def close(self) -> None:
+        if self._pipeline is not None:
+            self._pipeline.stop()
+            self._pipeline = None
+
+    def capabilities(self) -> frozenset[str]:
+        return frozenset({
+            "perceive.rgb",
+            "perceive.depth",
+            "realsense.aligned_depth",
+        })
+
+    def execute(
+        self,
+        capability: str,
+        args: dict,
+        *,
+        dry_run: bool,
+        estop,
+    ) -> ExecutionResult:
+        from robot_md.backends.realsense.capabilities import dispatch
+        return dispatch(self, capability=capability, args=dict(args), dry_run=dry_run, estop=estop)
+
+    def scene_describe(self) -> SceneSnapshot:
+        # Implemented in Task 13.
+        return SceneSnapshot.empty()
+```
+
+Create `cli/src/robot_md/backends/realsense/capabilities.py`:
+
+```python
+"""RealSense capability dispatch — populated incrementally."""
+
+from __future__ import annotations
+
+from robot_md.backends.base import ExecutionResult
+
+
+def dispatch(backend, *, capability: str, args: dict, dry_run: bool, estop) -> ExecutionResult:
+    return ExecutionResult(
+        status="error",
+        trajectory=None,
+        events=[],
+        error={"reason": "not_implemented", "detail": f"capability {capability!r}"},
+    )
+```
+
+- [ ] **Step 5: Run tests to verify they pass**
+
+```bash
+cd cli && PYTHONPATH=src python -m pytest tests/backends/test_realsense_backend_protocols.py tests/backends/test_realsense_capabilities_camera_only.py -v
+```
+
+Expected: PASS (4/4).
+
+- [ ] **Step 6: Commit (Task 9)**
+
+```bash
+cd /home/craigm26/robot-md/.worktrees/sp3-sdk-adapter
+git add cli/src/robot_md/backends/realsense/__init__.py cli/src/robot_md/backends/realsense/capabilities.py cli/tests/backends/test_realsense_backend_protocols.py cli/tests/backends/test_realsense_capabilities_camera_only.py
+git commit -m "feat(sp3): RealsenseBackend skeleton + capability set"
+```
+
+---
+
+### Task 10: Implement `RealsenseBackend.open()` with mocked pipeline
+
+**Files:**
+- Modify: `cli/src/robot_md/backends/realsense/__init__.py` (real `open()` body)
+- Test: `cli/tests/backends/test_realsense_open_mocked.py`
+
+- [ ] **Step 1: Write the open-with-mocked-pyrealsense test**
+
+```python
+# cli/tests/backends/test_realsense_open_mocked.py
+from __future__ import annotations
+
+import sys
+import types
+from unittest.mock import MagicMock
+
+from robot_md.robot_spec import RobotSpec
+
+
+def _install_fake_pyrealsense2(monkeypatch) -> tuple[MagicMock, MagicMock]:
+    fake = types.ModuleType("pyrealsense2")
+    pipeline = MagicMock(name="rs.pipeline_instance")
+    pipeline_factory = MagicMock(name="rs.pipeline_factory", return_value=pipeline)
+    config = MagicMock(name="rs.config_instance")
+    config_factory = MagicMock(name="rs.config_factory", return_value=config)
+    fake.pipeline = pipeline_factory
+    fake.config = config_factory
+
+    class _Stream:
+        color = "color"
+        depth = "depth"
+
+    class _Format:
+        bgr8 = "bgr8"
+        z16 = "z16"
+
+    fake.stream = _Stream()
+    fake.format = _Format()
+    monkeypatch.setitem(sys.modules, "pyrealsense2", fake)
+    return pipeline, config
+
+
+def test_open_starts_pipeline_with_color_and_depth_streams(monkeypatch) -> None:
+    pipeline, config = _install_fake_pyrealsense2(monkeypatch)
+    from robot_md.backends.realsense import RealsenseBackend
+
+    spec = RobotSpec.empty(rrn="RRN-test")
+    b = RealsenseBackend()
+    b.open(spec)
+
+    pipeline.start.assert_called_once()
+    args, _ = pipeline.start.call_args
+    assert args[0] is config
+
+    enable_calls = config.enable_stream.call_args_list
+    enabled = {call.args[0] for call in enable_calls}
+    assert enabled == {"color", "depth"}
+
+
+def test_close_stops_pipeline(monkeypatch) -> None:
+    pipeline, _ = _install_fake_pyrealsense2(monkeypatch)
+    from robot_md.backends.realsense import RealsenseBackend
+
+    b = RealsenseBackend()
+    b.open(RobotSpec.empty(rrn="RRN-test"))
+    b.close()
+    pipeline.stop.assert_called_once()
+```
+
+- [ ] **Step 2: Run test (expect FAIL with NotImplementedError)**
+
+```bash
+cd cli && PYTHONPATH=src python -m pytest tests/backends/test_realsense_open_mocked.py -v
+```
+
+- [ ] **Step 3: Implement `open()`**
+
+Replace the stub `open()` in `cli/src/robot_md/backends/realsense/__init__.py`:
+
+```python
+    def open(self, spec: RobotSpec) -> None:
+        import pyrealsense2 as rs
+
+        self._pipeline = rs.pipeline()
+        config = rs.config()
+        config.enable_stream(rs.stream.color, 640, 480, rs.format.bgr8, 30)
+        config.enable_stream(rs.stream.depth, 640, 480, rs.format.z16, 30)
+        self._pipeline.start(config)
+```
+
+- [ ] **Step 4: Run test (expect PASS 2/2)**
+
+```bash
+cd cli && PYTHONPATH=src python -m pytest tests/backends/test_realsense_open_mocked.py -v
+```
+
+- [ ] **Step 5: Commit (Task 10)**
+
+```bash
+cd /home/craigm26/robot-md/.worktrees/sp3-sdk-adapter
+git add cli/src/robot_md/backends/realsense/__init__.py cli/tests/backends/test_realsense_open_mocked.py
+git commit -m "feat(sp3): RealsenseBackend.open()/.close() — pyrealsense2 pipeline"
+```
+
+---
+
+### Task 11: Add `perceive.rgb` capability handler
+
+**Files:**
+- Create: `cli/src/robot_md/backends/realsense/perception.py`
+- Modify: `cli/src/robot_md/backends/realsense/capabilities.py`
+- Test: `cli/tests/backends/test_realsense_perceive_rgb.py`
+
+- [ ] **Step 1: Write the test**
+
+```python
+# cli/tests/backends/test_realsense_perceive_rgb.py
+from __future__ import annotations
+
+from unittest.mock import MagicMock
+
+from robot_md.backends.realsense import RealsenseBackend
+
+
+def test_perceive_rgb_returns_frame_bytes() -> None:
+    color_frame = MagicMock()
+    color_frame.get_data.return_value = b"FAKE_RGB_BYTES"
+    frames = MagicMock()
+    frames.get_color_frame.return_value = color_frame
+    pipeline = MagicMock()
+    pipeline.wait_for_frames.return_value = frames
+
+    b = RealsenseBackend()
+    b._pipeline = pipeline
+    result = b.execute("perceive.rgb", {}, dry_run=False, estop=None)
+    assert result.status == "ok"
+    payload = result.events[-1].data
+    assert payload["frame_bytes"] == b"FAKE_RGB_BYTES"
+    assert payload["format"] == "bgr8"
+
+
+def test_perceive_rgb_dry_run_short_circuits() -> None:
+    b = RealsenseBackend()
+    b._pipeline = MagicMock()  # would raise if called
+    result = b.execute("perceive.rgb", {}, dry_run=True, estop=None)
+    assert result.status == "ok"
+    assert result.events[-1].kind == "dry_run"
+    b._pipeline.wait_for_frames.assert_not_called()
+```
+
+- [ ] **Step 2: Run test (expect FAIL with not_implemented)**
+
+```bash
+cd cli && PYTHONPATH=src python -m pytest tests/backends/test_realsense_perceive_rgb.py -v
+```
+
+- [ ] **Step 3: Add the handler**
+
+Create `cli/src/robot_md/backends/realsense/perception.py`:
+
+```python
+from __future__ import annotations
+
+from robot_md.backends.base import ExecutionEvent, ExecutionResult
+
+
+def perceive_rgb(backend, args: dict, *, dry_run: bool, estop) -> ExecutionResult:
+    if dry_run:
+        return ExecutionResult(
+            status="ok",
+            trajectory=None,
+            events=[ExecutionEvent(kind="dry_run", data={"capability": "perceive.rgb"})],
+            error=None,
+        )
+    frames = backend._pipeline.wait_for_frames(timeout_ms=1000)
+    color = frames.get_color_frame()
+    data = bytes(color.get_data()) if color is not None else b""
+    return ExecutionResult(
+        status="ok",
+        trajectory=None,
+        events=[ExecutionEvent(kind="frame", data={"frame_bytes": data, "format": "bgr8"})],
+        error=None,
+    )
+```
+
+Replace `cli/src/robot_md/backends/realsense/capabilities.py`:
+
+```python
+"""RealSense capability dispatch."""
+
+from __future__ import annotations
+
+from robot_md.backends.base import ExecutionResult
+from robot_md.backends.realsense.perception import perceive_rgb
+
+
+HANDLERS = {
+    "perceive.rgb": perceive_rgb,
+}
+
+
+def dispatch(backend, *, capability: str, args: dict, dry_run: bool, estop) -> ExecutionResult:
+    handler = HANDLERS.get(capability)
+    if handler is None:
+        return ExecutionResult(
+            status="error",
+            trajectory=None,
+            events=[],
+            error={"reason": "not_implemented", "detail": f"capability {capability!r}"},
+        )
+    return handler(backend, args, dry_run=dry_run, estop=estop)
+```
+
+- [ ] **Step 4: Run test (expect PASS 2/2)**
+
+```bash
+cd cli && PYTHONPATH=src python -m pytest tests/backends/test_realsense_perceive_rgb.py -v
+```
+
+- [ ] **Step 5: Commit (Task 11)**
+
+```bash
+cd /home/craigm26/robot-md/.worktrees/sp3-sdk-adapter
+git add cli/src/robot_md/backends/realsense/perception.py cli/src/robot_md/backends/realsense/capabilities.py cli/tests/backends/test_realsense_perceive_rgb.py
+git commit -m "feat(sp3): perceive.rgb handler in RealsenseBackend"
+```
+
+---
+
+### Task 12: Add `perceive.depth` handler
+
+**Files:**
+- Modify: `cli/src/robot_md/backends/realsense/perception.py`, `capabilities.py`
+- Test: `cli/tests/backends/test_realsense_perceive_depth.py`
+
+- [ ] **Step 1: Write the test**
+
+```python
+# cli/tests/backends/test_realsense_perceive_depth.py
+from __future__ import annotations
+
+from unittest.mock import MagicMock
+
+from robot_md.backends.realsense import RealsenseBackend
+
+
+def test_perceive_depth_returns_z16_bytes() -> None:
+    depth_frame = MagicMock()
+    depth_frame.get_data.return_value = b"FAKE_DEPTH_BYTES"
+    frames = MagicMock()
+    frames.get_depth_frame.return_value = depth_frame
+    pipeline = MagicMock()
+    pipeline.wait_for_frames.return_value = frames
+
+    b = RealsenseBackend()
+    b._pipeline = pipeline
+    result = b.execute("perceive.depth", {}, dry_run=False, estop=None)
+    assert result.status == "ok"
+    payload = result.events[-1].data
+    assert payload["frame_bytes"] == b"FAKE_DEPTH_BYTES"
+    assert payload["format"] == "z16"
+```
+
+- [ ] **Step 2: Run test (expect FAIL with not_implemented)**
+
+```bash
+cd cli && PYTHONPATH=src python -m pytest tests/backends/test_realsense_perceive_depth.py -v
+```
+
+- [ ] **Step 3: Append `perceive_depth` to perception.py**
+
+```python
+def perceive_depth(backend, args: dict, *, dry_run: bool, estop) -> ExecutionResult:
+    if dry_run:
+        return ExecutionResult(
+            status="ok",
+            trajectory=None,
+            events=[ExecutionEvent(kind="dry_run", data={"capability": "perceive.depth"})],
+            error=None,
+        )
+    frames = backend._pipeline.wait_for_frames(timeout_ms=1000)
+    depth = frames.get_depth_frame()
+    data = bytes(depth.get_data()) if depth is not None else b""
+    return ExecutionResult(
+        status="ok",
+        trajectory=None,
+        events=[ExecutionEvent(kind="frame", data={"frame_bytes": data, "format": "z16"})],
+        error=None,
+    )
+```
+
+Update `capabilities.py` HANDLERS:
+
+```python
+from robot_md.backends.realsense.perception import perceive_rgb, perceive_depth
+
+HANDLERS = {
+    "perceive.rgb": perceive_rgb,
+    "perceive.depth": perceive_depth,
+}
+```
+
+- [ ] **Step 4: Run test (expect PASS)**
+
+- [ ] **Step 5: Commit (Task 12)**
+
+```bash
+git add cli/src/robot_md/backends/realsense/perception.py cli/src/robot_md/backends/realsense/capabilities.py cli/tests/backends/test_realsense_perceive_depth.py
+git commit -m "feat(sp3): perceive.depth handler in RealsenseBackend"
+```
+
+---
+
+### Task 13: Implement `RealsenseBackend.scene_describe()`
+
+**Files:**
+- Modify: `cli/src/robot_md/backends/realsense/__init__.py`
+- Test: `cli/tests/backends/test_realsense_scene_describe_mocked.py`
+
+- [ ] **Step 1: Write the test**
+
+```python
+# cli/tests/backends/test_realsense_scene_describe_mocked.py
+from __future__ import annotations
+
+from unittest.mock import MagicMock
+
+from robot_md.backends.realsense import RealsenseBackend
+
+
+def test_scene_describe_returns_snapshot_with_color_bytes() -> None:
+    color_frame = MagicMock()
+    color_frame.get_data.return_value = b"COLOR_BYTES"
+    frames = MagicMock()
+    frames.get_color_frame.return_value = color_frame
+    pipeline = MagicMock()
+    pipeline.wait_for_frames.return_value = frames
+
+    b = RealsenseBackend()
+    b._pipeline = pipeline
+    snap = b.scene_describe()
+    assert snap.frame == b"COLOR_BYTES"
+    assert snap.detections == ()
+    assert snap.joint_state == {}
+
+
+def test_scene_describe_with_no_pipeline_returns_empty() -> None:
+    b = RealsenseBackend()
+    snap = b.scene_describe()
+    assert snap.frame is None
+```
+
+- [ ] **Step 2: Run tests (expect 1 PASS + 1 FAIL)**
+
+- [ ] **Step 3: Implement scene_describe**
+
+Replace stub in `__init__.py`:
+
+```python
+    def scene_describe(self) -> SceneSnapshot:
+        import time
+
+        if self._pipeline is None:
+            return SceneSnapshot.empty()
+        frames = self._pipeline.wait_for_frames(timeout_ms=1000)
+        color = frames.get_color_frame()
+        data = bytes(color.get_data()) if color is not None else None
+        return SceneSnapshot(frame=data, detections=(), joint_state={}, ts=time.time())
+```
+
+- [ ] **Step 4: Run test (expect PASS 2/2)**
+
+- [ ] **Step 5: Commit (Task 13)**
+
+```bash
+git add cli/src/robot_md/backends/realsense/__init__.py cli/tests/backends/test_realsense_scene_describe_mocked.py
+git commit -m "feat(sp3): RealsenseBackend.scene_describe()"
+```
+
+---
+
+### Task 14: `realsense.aligned_depth` vendor capability
+
+**Files:**
+- Modify: `cli/src/robot_md/backends/realsense/perception.py`, `capabilities.py`
+- Test: `cli/tests/backends/test_realsense_aligned_depth.py`
+
+- [ ] **Step 1: Write the test**
+
+```python
+# cli/tests/backends/test_realsense_aligned_depth.py
+from __future__ import annotations
+
+from unittest.mock import MagicMock
+
+from robot_md.backends.realsense import RealsenseBackend
+
+
+def test_aligned_depth_uses_align_processor() -> None:
+    aligned_depth = MagicMock()
+    aligned_depth.get_data.return_value = b"ALIGNED_DEPTH"
+    align_processor = MagicMock()
+    align_processor.process.return_value.get_depth_frame.return_value = aligned_depth
+    frames = MagicMock()
+    pipeline = MagicMock()
+    pipeline.wait_for_frames.return_value = frames
+
+    b = RealsenseBackend()
+    b._pipeline = pipeline
+    b._align_processor = align_processor
+    result = b.execute("realsense.aligned_depth", {}, dry_run=False, estop=None)
+    assert result.status == "ok"
+    payload = result.events[-1].data
+    assert payload["frame_bytes"] == b"ALIGNED_DEPTH"
+    assert payload["aligned_to"] == "color"
+    align_processor.process.assert_called_once_with(frames)
+```
+
+- [ ] **Step 2: Run test (expect FAIL with not_implemented)**
+
+- [ ] **Step 3: Append `realsense_aligned_depth` to perception.py**
+
+```python
+def realsense_aligned_depth(backend, args: dict, *, dry_run: bool, estop) -> ExecutionResult:
+    if dry_run:
+        return ExecutionResult(
+            status="ok",
+            trajectory=None,
+            events=[ExecutionEvent(kind="dry_run", data={"capability": "realsense.aligned_depth"})],
+            error=None,
+        )
+    align = _ensure_align(backend)
+    frames = backend._pipeline.wait_for_frames(timeout_ms=1000)
+    aligned_frames = align.process(frames)
+    aligned = aligned_frames.get_depth_frame()
+    data = bytes(aligned.get_data()) if aligned is not None else b""
+    return ExecutionResult(
+        status="ok",
+        trajectory=None,
+        events=[ExecutionEvent(kind="frame", data={"frame_bytes": data, "format": "z16", "aligned_to": "color"})],
+        error=None,
+    )
+
+
+def _ensure_align(backend):
+    if getattr(backend, "_align_processor", None) is None:
+        import pyrealsense2 as rs
+        backend._align_processor = rs.align(rs.stream.color)
+    return backend._align_processor
+```
+
+Update `capabilities.py`:
+
+```python
+from robot_md.backends.realsense.perception import perceive_rgb, perceive_depth, realsense_aligned_depth
+
+HANDLERS = {
+    "perceive.rgb": perceive_rgb,
+    "perceive.depth": perceive_depth,
+    "realsense.aligned_depth": realsense_aligned_depth,
+}
+```
+
+- [ ] **Step 4: Run test (expect PASS)**
+
+- [ ] **Step 5: Commit (Task 14)**
+
+```bash
+git add cli/src/robot_md/backends/realsense/perception.py cli/src/robot_md/backends/realsense/capabilities.py cli/tests/backends/test_realsense_aligned_depth.py
+git commit -m "feat(sp3): realsense.aligned_depth vendor capability"
+```
+
+---
+
+### Task 15: Lock the no-arm contract
+
+**Files:**
+- Test only: `cli/tests/backends/test_realsense_no_arm_capability.py`
+
+- [ ] **Step 1: Write the lock test**
+
+```python
+# cli/tests/backends/test_realsense_no_arm_capability.py
+from __future__ import annotations
+
+from robot_md.backends.realsense import RealsenseBackend
+
+
+def test_arm_pick_returns_not_implemented() -> None:
+    b = RealsenseBackend()
+    result = b.execute("arm.pick", {"target": "red_lego"}, dry_run=True, estop=None)
+    assert result.status == "error"
+    assert result.error["reason"] == "not_implemented"
+
+
+def test_gripper_open_returns_not_implemented() -> None:
+    b = RealsenseBackend()
+    result = b.execute("gripper.open", {}, dry_run=True, estop=None)
+    assert result.status == "error"
+    assert result.error["reason"] == "not_implemented"
+```
+
+- [ ] **Step 2: Run test (expect PASS — dispatch already returns not_implemented)**
+
+```bash
+cd cli && PYTHONPATH=src python -m pytest tests/backends/test_realsense_*.py -v
+```
+
+Expected: ALL RealSense tests PASS — Phase B locked.
+
+- [ ] **Step 3: Commit (Task 15)**
+
+```bash
+git add cli/tests/backends/test_realsense_no_arm_capability.py
+git commit -m "test(sp3): lock RealsenseBackend rejects arm.* / gripper.* calls"
+```
+
+---
+
+## Phase C — LeRobot backend (motion + camera)
+
+Heavier than RealSense. All `lerobot` SDK calls go through mocks so the test suite runs without the LeRobot package installed.
+
+### Task 16: Stub `LerobotBackend` class + class-attr tests
+
+**Files:**
+- Create: `cli/src/robot_md/backends/lerobot/__init__.py`, `cli/src/robot_md/backends/lerobot/capabilities.py`
+- Test: `cli/tests/backends/test_lerobot_backend_protocols.py`, `cli/tests/backends/test_lerobot_backend_capabilities_valid.py`
+
+- [ ] **Step 1: Write the protocols test**
+
+```python
+# cli/tests/backends/test_lerobot_backend_protocols.py
+from __future__ import annotations
+
+from robot_md.backends.lerobot import LerobotBackend
+
+
+def test_name_and_protocols() -> None:
+    b = LerobotBackend()
+    assert b.name == "lerobot"
+    assert b.protocols == frozenset({"feetech", "dynamixel"})
+
+
+def test_read_only_capabilities_marks_perception() -> None:
+    b = LerobotBackend()
+    assert b.read_only_capabilities == frozenset({"perceive.rgb", "perceive.depth"})
+```
+
+- [ ] **Step 2: Write the capabilities-pass-validator test**
+
+```python
+# cli/tests/backends/test_lerobot_backend_capabilities_valid.py
+from __future__ import annotations
+
+from robot_md.backends.lerobot import LerobotBackend
+from robot_md.backends.registry import _validate_capability_namespace
+
+
+def test_all_declared_capabilities_pass_tier_validator() -> None:
+    b = LerobotBackend()
+    _validate_capability_namespace("lerobot", b.capabilities())  # raises if any malformed
+
+
+def test_capabilities_set_contents() -> None:
+    b = LerobotBackend()
+    assert b.capabilities() == frozenset({
+        "arm.pick", "arm.place", "arm.home",
+        "perceive.rgb", "perceive.depth",
+        "gripper.open", "gripper.close",
+        "lerobot.teleop",
+    })
+```
+
+- [ ] **Step 3: Run tests to verify they fail**
+
+```bash
+cd cli && PYTHONPATH=src python -m pytest tests/backends/test_lerobot_backend_protocols.py tests/backends/test_lerobot_backend_capabilities_valid.py -v
+```
+
+Expected: FAIL — `ModuleNotFoundError: No module named 'robot_md.backends.lerobot'`.
+
+- [ ] **Step 4: Create the LeRobot package skeleton**
+
+Create `cli/src/robot_md/backends/lerobot/__init__.py`:
+
+```python
+"""LeRobot adapter — motion + camera, wraps HuggingFace LeRobot SDK."""
+
+from __future__ import annotations
+
+from robot_md.backends.base import (
+    CapabilityBackend,
+    ExecutionEvent,
+    ExecutionResult,
+    SceneSnapshot,
+)
+from robot_md.robot_spec import RobotSpec
+
+
+class LerobotBackend(CapabilityBackend):
+    name = "lerobot"
+    protocols = frozenset({"feetech", "dynamixel"})
+    read_only_capabilities = frozenset({"perceive.rgb", "perceive.depth"})
+
+    def __init__(self) -> None:
+        self._robot = None
+
+    def open(self, spec: RobotSpec) -> None:
+        # Implemented in Task 18.
+        raise NotImplementedError
+
+    def close(self) -> None:
+        if self._robot is not None:
+            try:
+                self._robot.disconnect()
+            except Exception:
+                pass
+            self._robot = None
+
+    def capabilities(self) -> frozenset[str]:
+        return frozenset({
+            "arm.pick", "arm.place", "arm.home",
+            "perceive.rgb", "perceive.depth",
+            "gripper.open", "gripper.close",
+            "lerobot.teleop",
+        })
+
+    def execute(
+        self,
+        capability: str,
+        args: dict,
+        *,
+        dry_run: bool,
+        estop,
+    ) -> ExecutionResult:
+        from robot_md.backends.lerobot.capabilities import dispatch
+        return dispatch(self, capability=capability, args=dict(args), dry_run=dry_run, estop=estop)
+
+    def scene_describe(self) -> SceneSnapshot:
+        return SceneSnapshot.empty()
+```
+
+Create `cli/src/robot_md/backends/lerobot/capabilities.py`:
+
+```python
+"""LeRobot capability dispatch — populated incrementally."""
+
+from __future__ import annotations
+
+from robot_md.backends.base import ExecutionResult
+
+
+def dispatch(backend, *, capability: str, args: dict, dry_run: bool, estop) -> ExecutionResult:
+    return ExecutionResult(
+        status="error",
+        trajectory=None,
+        events=[],
+        error={"reason": "not_implemented", "detail": f"capability {capability!r}"},
+    )
+```
+
+- [ ] **Step 5: Run tests (expect PASS 4/4)**
+
+```bash
+cd cli && PYTHONPATH=src python -m pytest tests/backends/test_lerobot_backend_protocols.py tests/backends/test_lerobot_backend_capabilities_valid.py -v
+```
+
+- [ ] **Step 6: Commit (Task 16)**
+
+```bash
+cd /home/craigm26/robot-md/.worktrees/sp3-sdk-adapter
+git add cli/src/robot_md/backends/lerobot/__init__.py cli/src/robot_md/backends/lerobot/capabilities.py cli/tests/backends/test_lerobot_backend_protocols.py cli/tests/backends/test_lerobot_backend_capabilities_valid.py
+git commit -m "feat(sp3): LerobotBackend skeleton + capability set"
+```
+
+---
+
+### Task 17: Implement `_build_lerobot_config(spec)` for SO-ARM101
+
+**Files:**
+- Create: `cli/src/robot_md/backends/lerobot/config.py`
+- Test: `cli/tests/backends/test_lerobot_build_config_so_arm101.py`
+
+- [ ] **Step 1: Write the config-mapping test**
+
+```python
+# cli/tests/backends/test_lerobot_build_config_so_arm101.py
+from __future__ import annotations
+
+from robot_md.backends.lerobot.config import build_lerobot_config
+from robot_md.robot_spec import RobotSpec, Driver
+
+
+def _so_arm101_spec() -> RobotSpec:
+    return RobotSpec(
+        rrn="RRN-test-so-arm101",
+        drivers=[
+            Driver(
+                id="arm_servos",
+                protocol="feetech",
+                backend="lerobot",
+                port="/dev/ttyACM0",
+                baud=1000000,
+                motors=[
+                    {"id": 1, "model": "sts3215", "joint": "shoulder_pan"},
+                    {"id": 2, "model": "sts3215", "joint": "shoulder_lift"},
+                    {"id": 3, "model": "sts3215", "joint": "elbow_flex"},
+                    {"id": 4, "model": "sts3215", "joint": "wrist_flex"},
+                    {"id": 5, "model": "sts3215", "joint": "wrist_roll"},
+                    {"id": 6, "model": "sts3215", "joint": "gripper"},
+                ],
+            ),
+        ],
+    )
+
+
+def test_build_config_extracts_six_motors() -> None:
+    spec = _so_arm101_spec()
+    cfg = build_lerobot_config(spec)
+    assert cfg["robot_type"] == "so_arm"
+    assert cfg["port"] == "/dev/ttyACM0"
+    assert cfg["baud"] == 1000000
+    assert len(cfg["motors"]) == 6
+    assert {m["joint"] for m in cfg["motors"]} == {
+        "shoulder_pan", "shoulder_lift", "elbow_flex",
+        "wrist_flex", "wrist_roll", "gripper",
+    }
+
+
+def test_build_config_missing_motors_raises_clean_error() -> None:
+    spec = RobotSpec(
+        rrn="RRN-test-bad",
+        drivers=[Driver(id="arm_servos", protocol="feetech", backend="lerobot", port="/dev/ttyACM0", baud=1000000, motors=[])],
+    )
+    import pytest
+    with pytest.raises(ValueError) as exc:
+        build_lerobot_config(spec)
+    assert "no motors" in str(exc.value).lower()
+```
+
+(Note: this test imports `Driver` from `robot_md.robot_spec`. If the existing dataclass doesn't accept these field names, adapt to whatever the live class signature actually is — grep `class Driver` in `robot_md/robot_spec.py` first.)
+
+- [ ] **Step 2: Run test to verify it fails**
+
+```bash
+cd cli && PYTHONPATH=src python -m pytest tests/backends/test_lerobot_build_config_so_arm101.py -v
+```
+
+Expected: FAIL — `ModuleNotFoundError: robot_md.backends.lerobot.config`.
+
+- [ ] **Step 3: Implement `build_lerobot_config`**
+
+Create `cli/src/robot_md/backends/lerobot/config.py`:
+
+```python
+from __future__ import annotations
+
+from robot_md.robot_spec import RobotSpec
+
+
+def build_lerobot_config(spec: RobotSpec) -> dict:
+    """Translate a RobotSpec into a LeRobot make_robot() config dict.
+
+    Pulls the first arm-shaped driver (protocol in {feetech, dynamixel}),
+    its port + baud, and its motor list. Raises ValueError if no driver
+    or no motors are declared.
+    """
+    arm_driver = next(
+        (d for d in spec.drivers if d.protocol in {"feetech", "dynamixel"}),
+        None,
+    )
+    if arm_driver is None:
+        raise ValueError("RobotSpec has no feetech/dynamixel arm driver")
+    if not arm_driver.motors:
+        raise ValueError(f"Driver {arm_driver.id!r} has no motors declared")
+    return {
+        "robot_type": "so_arm",  # default; override via vendor capability if needed
+        "port": arm_driver.port,
+        "baud": arm_driver.baud,
+        "motors": [
+            {"id": m["id"], "model": m["model"], "joint": m["joint"]}
+            for m in arm_driver.motors
+        ],
+    }
+```
+
+- [ ] **Step 4: Run test (expect PASS 2/2)**
+
+- [ ] **Step 5: Commit (Task 17)**
+
+```bash
+git add cli/src/robot_md/backends/lerobot/config.py cli/tests/backends/test_lerobot_build_config_so_arm101.py
+git commit -m "feat(sp3): _build_lerobot_config(spec) translates RobotSpec → LeRobot config dict"
+```
+
+---
+
+### Task 18: Implement `LerobotBackend.open()` with mocked `make_robot`
+
+**Files:**
+- Modify: `cli/src/robot_md/backends/lerobot/__init__.py` (real `open()`)
+- Test: `cli/tests/backends/test_lerobot_backend_open_mocked.py`
+
+- [ ] **Step 1: Write the open-with-mocked-make_robot test**
+
+```python
+# cli/tests/backends/test_lerobot_backend_open_mocked.py
+from __future__ import annotations
+
+import sys
+import types
+from unittest.mock import MagicMock
+
+from robot_md.backends.lerobot import LerobotBackend
+
+
+def _install_fake_lerobot(monkeypatch) -> tuple[MagicMock, MagicMock]:
+    """Stand up enough of the lerobot package tree so the lazy import
+    inside open() resolves cleanly without the real SDK installed."""
+    fake_robot = MagicMock(name="lerobot_robot_instance")
+    make_robot = MagicMock(name="make_robot", return_value=fake_robot)
+
+    factory_mod = types.ModuleType("lerobot.common.robot_devices.robots.factory")
+    factory_mod.make_robot = make_robot
+
+    common_mod = types.ModuleType("lerobot.common")
+    common_mod.robot_devices = types.ModuleType("lerobot.common.robot_devices")
+    common_mod.robot_devices.robots = types.ModuleType("lerobot.common.robot_devices.robots")
+    common_mod.robot_devices.robots.factory = factory_mod
+
+    root = types.ModuleType("lerobot")
+    root.common = common_mod
+
+    monkeypatch.setitem(sys.modules, "lerobot", root)
+    monkeypatch.setitem(sys.modules, "lerobot.common", common_mod)
+    monkeypatch.setitem(sys.modules, "lerobot.common.robot_devices", common_mod.robot_devices)
+    monkeypatch.setitem(sys.modules, "lerobot.common.robot_devices.robots", common_mod.robot_devices.robots)
+    monkeypatch.setitem(sys.modules, "lerobot.common.robot_devices.robots.factory", factory_mod)
+    return fake_robot, make_robot
+
+
+def _so_arm101_spec_for_open():
+    # Reuse Task 17's helper if practical; otherwise inline a minimal spec here.
+    from tests.backends.test_lerobot_build_config_so_arm101 import _so_arm101_spec  # noqa: PLC0415
+    return _so_arm101_spec()
+
+
+def test_open_calls_make_robot_then_connect(monkeypatch) -> None:
+    fake_robot, make_robot = _install_fake_lerobot(monkeypatch)
+    b = LerobotBackend()
+    b.open(_so_arm101_spec_for_open())
+
+    make_robot.assert_called_once()
+    cfg = make_robot.call_args[0][0]
+    assert cfg["port"] == "/dev/ttyACM0"
+    assert len(cfg["motors"]) == 6
+    fake_robot.connect.assert_called_once()
+    assert b._robot is fake_robot
+```
+
+- [ ] **Step 2: Run test (expect FAIL with NotImplementedError)**
+
+- [ ] **Step 3: Implement `open()`**
+
+Replace the stub `open()` in `cli/src/robot_md/backends/lerobot/__init__.py`:
+
+```python
+    def open(self, spec: RobotSpec) -> None:
+        from lerobot.common.robot_devices.robots.factory import make_robot
+        from robot_md.backends.lerobot.config import build_lerobot_config
+
+        cfg = build_lerobot_config(spec)
+        self._robot = make_robot(cfg)
+        self._robot.connect()
+```
+
+- [ ] **Step 4: Run test (expect PASS)**
+
+- [ ] **Step 5: Commit (Task 18)**
+
+```bash
+git add cli/src/robot_md/backends/lerobot/__init__.py cli/tests/backends/test_lerobot_backend_open_mocked.py
+git commit -m "feat(sp3): LerobotBackend.open() — make_robot + connect"
+```
+
+---
+
+### Task 19: `arm.pick` handler
+
+**Files:**
+- Create: `cli/src/robot_md/backends/lerobot/motion.py`
+- Modify: `cli/src/robot_md/backends/lerobot/capabilities.py`
+- Test: `cli/tests/backends/test_lerobot_execute_arm_pick_mocked.py`
+
+- [ ] **Step 1: Write the arm.pick test**
+
+```python
+# cli/tests/backends/test_lerobot_execute_arm_pick_mocked.py
+from __future__ import annotations
+
+from unittest.mock import MagicMock
+
+from robot_md.backends.lerobot import LerobotBackend
+
+
+def _backend_with_robot() -> tuple[LerobotBackend, MagicMock]:
+    b = LerobotBackend()
+    robot = MagicMock(name="lerobot_robot")
+    b._robot = robot
+    return b, robot
+
+
+def test_arm_pick_dry_run_emits_trajectory_no_writes() -> None:
+    b, robot = _backend_with_robot()
+    result = b.execute("arm.pick", {"target": "red_lego"}, dry_run=True, estop=None)
+    assert result.status == "ok"
+    assert result.trajectory is not None
+    robot.send_action.assert_not_called()
+
+
+def test_arm_pick_live_invokes_send_action() -> None:
+    b, robot = _backend_with_robot()
+    result = b.execute("arm.pick", {"target": "red_lego"}, dry_run=False, estop=None)
+    assert result.status == "ok"
+    robot.send_action.assert_called()
+    # The first send_action should target the approach pose.
+    first_call_args = robot.send_action.call_args_list[0].args[0]
+    assert "approach" in str(first_call_args).lower() or "joints" in first_call_args
+
+
+def test_arm_pick_missing_target_returns_error() -> None:
+    b, _ = _backend_with_robot()
+    result = b.execute("arm.pick", {}, dry_run=True, estop=None)
+    assert result.status == "error"
+    assert result.error["reason"] in {"missing_args", "schema_violation"}
+```
+
+- [ ] **Step 2: Run test (expect FAIL — not_implemented)**
+
+- [ ] **Step 3: Implement `arm.pick` handler**
+
+Create `cli/src/robot_md/backends/lerobot/motion.py`:
+
+```python
+"""LeRobot arm.* / gripper.* handlers — wraps the connected robot's
+send_action interface with simple per-capability action plans.
+
+These plans are intentionally generic: a real adapter would compute IK
+or invoke a learned policy. For SP3, the goal is to prove the dispatch
+plumbing — actual trajectory quality is out of scope.
+"""
+
+from __future__ import annotations
+
+from robot_md.backends.base import ExecutionEvent, ExecutionResult
+
+
+def _validate_pick_args(args: dict) -> ExecutionResult | None:
+    if "target" not in args:
+        return ExecutionResult(
+            status="error",
+            trajectory=None,
+            events=[],
+            error={"reason": "missing_args", "detail": "arm.pick requires 'target'"},
+        )
+    if not isinstance(args["target"], str):
+        return ExecutionResult(
+            status="error",
+            trajectory=None,
+            events=[],
+            error={"reason": "schema_violation", "detail": "'target' must be string"},
+        )
+    return None
+
+
+def arm_pick(backend, args: dict, *, dry_run: bool, estop) -> ExecutionResult:
+    bad = _validate_pick_args(args)
+    if bad is not None:
+        return bad
+    target = args["target"]
+    approach_height_mm = float(args.get("approach_height_mm", 50))
+    plan = [
+        {"phase": "approach", "joints": [0.0, -0.3, 0.6, 0.0, 0.0, 0.0], "approach_height_mm": approach_height_mm, "target": target},
+        {"phase": "descend", "joints": [0.0, -0.5, 0.4, 0.0, 0.0, 0.0]},
+        {"phase": "grasp",   "joints": [0.0, -0.5, 0.4, 0.0, 0.0, 0.6]},
+        {"phase": "lift",    "joints": [0.0, -0.3, 0.6, 0.0, 0.0, 0.6]},
+    ]
+    if dry_run:
+        return ExecutionResult(
+            status="ok",
+            trajectory=plan,
+            events=[ExecutionEvent(kind="dry_run", data={"capability": "arm.pick", "target": target})],
+            error=None,
+        )
+    for step in plan:
+        backend._robot.send_action(step)
+    return ExecutionResult(
+        status="ok",
+        trajectory=plan,
+        events=[ExecutionEvent(kind="motion_complete", data={"capability": "arm.pick", "target": target})],
+        error=None,
+    )
+```
+
+Update `capabilities.py`:
+
+```python
+from robot_md.backends.lerobot.motion import arm_pick
+
+
+HANDLERS = {
+    "arm.pick": arm_pick,
+}
+
+
+def dispatch(backend, *, capability: str, args: dict, dry_run: bool, estop) -> ExecutionResult:
+    handler = HANDLERS.get(capability)
+    if handler is None:
+        return ExecutionResult(
+            status="error",
+            trajectory=None,
+            events=[],
+            error={"reason": "not_implemented", "detail": f"capability {capability!r}"},
+        )
+    return handler(backend, args, dry_run=dry_run, estop=estop)
+```
+
+- [ ] **Step 4: Run test (expect PASS 3/3)**
+
+- [ ] **Step 5: Commit (Task 19)**
+
+```bash
+git add cli/src/robot_md/backends/lerobot/motion.py cli/src/robot_md/backends/lerobot/capabilities.py cli/tests/backends/test_lerobot_execute_arm_pick_mocked.py
+git commit -m "feat(sp3): arm.pick handler in LerobotBackend"
+```
+
+---
+
+### Task 20: `arm.place` and `arm.home` handlers
+
+**Files:**
+- Modify: `cli/src/robot_md/backends/lerobot/motion.py`, `capabilities.py`
+- Test: `cli/tests/backends/test_lerobot_arm_place_home.py`
+
+- [ ] **Step 1: Write the test**
+
+```python
+# cli/tests/backends/test_lerobot_arm_place_home.py
+from __future__ import annotations
+
+from unittest.mock import MagicMock
+
+from robot_md.backends.lerobot import LerobotBackend
+
+
+def _backend() -> tuple[LerobotBackend, MagicMock]:
+    b = LerobotBackend()
+    b._robot = MagicMock()
+    return b, b._robot
+
+
+def test_arm_place_dry_run_returns_trajectory() -> None:
+    b, robot = _backend()
+    result = b.execute("arm.place", {"destination": "drop_zone"}, dry_run=True, estop=None)
+    assert result.status == "ok"
+    assert result.trajectory is not None
+    robot.send_action.assert_not_called()
+
+
+def test_arm_place_missing_destination() -> None:
+    b, _ = _backend()
+    result = b.execute("arm.place", {}, dry_run=True, estop=None)
+    assert result.status == "error"
+
+
+def test_arm_home_no_args_succeeds() -> None:
+    b, robot = _backend()
+    result = b.execute("arm.home", {}, dry_run=False, estop=None)
+    assert result.status == "ok"
+    robot.send_action.assert_called()
+```
+
+- [ ] **Step 2: Run test (expect FAIL — not_implemented)**
+
+- [ ] **Step 3: Add `arm_place` and `arm_home` to motion.py**
+
+```python
+def arm_place(backend, args: dict, *, dry_run: bool, estop) -> ExecutionResult:
+    if "destination" not in args:
+        return ExecutionResult(
+            status="error",
+            trajectory=None,
+            events=[],
+            error={"reason": "missing_args", "detail": "arm.place requires 'destination'"},
+        )
+    plan = [
+        {"phase": "transport", "joints": [0.5, -0.3, 0.6, 0.0, 0.0, 0.6], "destination": args["destination"]},
+        {"phase": "release",   "joints": [0.5, -0.5, 0.4, 0.0, 0.0, 0.0]},
+        {"phase": "retract",   "joints": [0.0, -0.3, 0.6, 0.0, 0.0, 0.0]},
+    ]
+    if dry_run:
+        return ExecutionResult(
+            status="ok", trajectory=plan,
+            events=[ExecutionEvent(kind="dry_run", data={"capability": "arm.place"})],
+            error=None,
+        )
+    for step in plan:
+        backend._robot.send_action(step)
+    return ExecutionResult(
+        status="ok", trajectory=plan,
+        events=[ExecutionEvent(kind="motion_complete", data={"capability": "arm.place"})],
+        error=None,
+    )
+
+
+_HOME_JOINTS = [0.0, 0.0, 0.0, 0.0, 0.0, 0.0]
+
+
+def arm_home(backend, args: dict, *, dry_run: bool, estop) -> ExecutionResult:
+    plan = [{"phase": "home", "joints": _HOME_JOINTS}]
+    if dry_run:
+        return ExecutionResult(
+            status="ok", trajectory=plan,
+            events=[ExecutionEvent(kind="dry_run", data={"capability": "arm.home"})],
+            error=None,
+        )
+    backend._robot.send_action(plan[0])
+    return ExecutionResult(
+        status="ok", trajectory=plan,
+        events=[ExecutionEvent(kind="motion_complete", data={"capability": "arm.home"})],
+        error=None,
+    )
+```
+
+Update HANDLERS in `capabilities.py`:
+
+```python
+from robot_md.backends.lerobot.motion import arm_pick, arm_place, arm_home
+
+HANDLERS = {
+    "arm.pick": arm_pick,
+    "arm.place": arm_place,
+    "arm.home": arm_home,
+}
+```
+
+- [ ] **Step 4: Run test (expect PASS 3/3)**
+
+- [ ] **Step 5: Commit (Task 20)**
+
+```bash
+git add cli/src/robot_md/backends/lerobot/motion.py cli/src/robot_md/backends/lerobot/capabilities.py cli/tests/backends/test_lerobot_arm_place_home.py
+git commit -m "feat(sp3): arm.place + arm.home handlers in LerobotBackend"
+```
+
+---
+
+### Task 21: `gripper.open` and `gripper.close` handlers
+
+**Files:**
+- Modify: `cli/src/robot_md/backends/lerobot/motion.py`, `capabilities.py`
+- Test: `cli/tests/backends/test_lerobot_gripper.py`
+
+- [ ] **Step 1: Write the test**
+
+```python
+# cli/tests/backends/test_lerobot_gripper.py
+from __future__ import annotations
+
+from unittest.mock import MagicMock
+
+from robot_md.backends.lerobot import LerobotBackend
+
+
+def _backend() -> tuple[LerobotBackend, MagicMock]:
+    b = LerobotBackend()
+    b._robot = MagicMock()
+    return b, b._robot
+
+
+def test_gripper_open_sends_open_command() -> None:
+    b, robot = _backend()
+    result = b.execute("gripper.open", {}, dry_run=False, estop=None)
+    assert result.status == "ok"
+    robot.send_action.assert_called_once()
+    sent = robot.send_action.call_args.args[0]
+    assert sent.get("gripper") == "open"
+
+
+def test_gripper_close_sends_close_command() -> None:
+    b, robot = _backend()
+    result = b.execute("gripper.close", {}, dry_run=False, estop=None)
+    assert result.status == "ok"
+    sent = robot.send_action.call_args.args[0]
+    assert sent.get("gripper") == "close"
+```
+
+- [ ] **Step 2: Run test (expect FAIL — not_implemented)**
+
+- [ ] **Step 3: Add gripper handlers**
+
+```python
+def gripper_open(backend, args: dict, *, dry_run: bool, estop) -> ExecutionResult:
+    cmd = {"phase": "gripper.open", "gripper": "open"}
+    if dry_run:
+        return ExecutionResult(status="ok", trajectory=[cmd],
+                               events=[ExecutionEvent(kind="dry_run", data={"capability": "gripper.open"})],
+                               error=None)
+    backend._robot.send_action(cmd)
+    return ExecutionResult(status="ok", trajectory=[cmd],
+                           events=[ExecutionEvent(kind="motion_complete", data={"capability": "gripper.open"})],
+                           error=None)
+
+
+def gripper_close(backend, args: dict, *, dry_run: bool, estop) -> ExecutionResult:
+    cmd = {"phase": "gripper.close", "gripper": "close"}
+    if dry_run:
+        return ExecutionResult(status="ok", trajectory=[cmd],
+                               events=[ExecutionEvent(kind="dry_run", data={"capability": "gripper.close"})],
+                               error=None)
+    backend._robot.send_action(cmd)
+    return ExecutionResult(status="ok", trajectory=[cmd],
+                           events=[ExecutionEvent(kind="motion_complete", data={"capability": "gripper.close"})],
+                           error=None)
+```
+
+Add to HANDLERS:
+
+```python
+HANDLERS = {
+    "arm.pick": arm_pick,
+    "arm.place": arm_place,
+    "arm.home": arm_home,
+    "gripper.open": gripper_open,
+    "gripper.close": gripper_close,
+}
+```
+
+- [ ] **Step 4: Run test (expect PASS 2/2)**
+
+- [ ] **Step 5: Commit (Task 21)**
+
+```bash
+git add cli/src/robot_md/backends/lerobot/motion.py cli/src/robot_md/backends/lerobot/capabilities.py cli/tests/backends/test_lerobot_gripper.py
+git commit -m "feat(sp3): gripper.open + gripper.close handlers in LerobotBackend"
+```
+
+---
+
+### Task 22: `perceive.rgb` and `perceive.depth` via LeRobot's camera pipeline
+
+**Files:**
+- Create: `cli/src/robot_md/backends/lerobot/perception.py`
+- Modify: `cli/src/robot_md/backends/lerobot/capabilities.py`
+- Test: `cli/tests/backends/test_lerobot_perception.py`
+
+- [ ] **Step 1: Write the test**
+
+```python
+# cli/tests/backends/test_lerobot_perception.py
+from __future__ import annotations
+
+from unittest.mock import MagicMock
+
+from robot_md.backends.lerobot import LerobotBackend
+
+
+def test_perceive_rgb_pulls_from_robot_capture() -> None:
+    b = LerobotBackend()
+    robot = MagicMock()
+    robot.capture_observation.return_value = {
+        "observation.images.front": b"FRAME_RGB_BYTES",
+    }
+    b._robot = robot
+    result = b.execute("perceive.rgb", {}, dry_run=False, estop=None)
+    assert result.status == "ok"
+    payload = result.events[-1].data
+    assert payload["frame_bytes"] == b"FRAME_RGB_BYTES"
+
+
+def test_perceive_depth_returns_no_depth_when_camera_absent() -> None:
+    b = LerobotBackend()
+    robot = MagicMock()
+    robot.capture_observation.return_value = {
+        "observation.images.front": b"COLOR_ONLY",  # no depth key
+    }
+    b._robot = robot
+    result = b.execute("perceive.depth", {}, dry_run=False, estop=None)
+    assert result.status == "error"
+    assert result.error["reason"] == "no_depth_camera"
+```
+
+- [ ] **Step 2: Run test (expect FAIL — not_implemented)**
+
+- [ ] **Step 3: Implement perception handlers**
+
+Create `cli/src/robot_md/backends/lerobot/perception.py`:
+
+```python
+from __future__ import annotations
+
+from robot_md.backends.base import ExecutionEvent, ExecutionResult
+
+
+def _first_image_key(obs: dict, *prefixes: str) -> str | None:
+    for k in obs:
+        for p in prefixes:
+            if k.startswith(p):
+                return k
+    return None
+
+
+def perceive_rgb(backend, args: dict, *, dry_run: bool, estop) -> ExecutionResult:
+    if dry_run:
+        return ExecutionResult(status="ok", trajectory=None,
+                               events=[ExecutionEvent(kind="dry_run", data={"capability": "perceive.rgb"})],
+                               error=None)
+    obs = backend._robot.capture_observation()
+    key = _first_image_key(obs, "observation.images.")
+    if key is None:
+        return ExecutionResult(status="error", trajectory=None, events=[],
+                               error={"reason": "no_camera", "detail": "no observation.images.* in observation dict"})
+    return ExecutionResult(status="ok", trajectory=None,
+                           events=[ExecutionEvent(kind="frame", data={"frame_bytes": obs[key], "format": "bgr8", "source": key})],
+                           error=None)
+
+
+def perceive_depth(backend, args: dict, *, dry_run: bool, estop) -> ExecutionResult:
+    if dry_run:
+        return ExecutionResult(status="ok", trajectory=None,
+                               events=[ExecutionEvent(kind="dry_run", data={"capability": "perceive.depth"})],
+                               error=None)
+    obs = backend._robot.capture_observation()
+    key = _first_image_key(obs, "observation.depth.")
+    if key is None:
+        return ExecutionResult(status="error", trajectory=None, events=[],
+                               error={"reason": "no_depth_camera", "detail": "no observation.depth.* in observation dict"})
+    return ExecutionResult(status="ok", trajectory=None,
+                           events=[ExecutionEvent(kind="frame", data={"frame_bytes": obs[key], "format": "z16", "source": key})],
+                           error=None)
+```
+
+Update HANDLERS:
+
+```python
+from robot_md.backends.lerobot.perception import perceive_rgb, perceive_depth
+
+HANDLERS = {
+    "arm.pick": arm_pick,
+    "arm.place": arm_place,
+    "arm.home": arm_home,
+    "gripper.open": gripper_open,
+    "gripper.close": gripper_close,
+    "perceive.rgb": perceive_rgb,
+    "perceive.depth": perceive_depth,
+}
+```
+
+- [ ] **Step 4: Run test (expect PASS 2/2)**
+
+- [ ] **Step 5: Commit (Task 22)**
+
+```bash
+git add cli/src/robot_md/backends/lerobot/perception.py cli/src/robot_md/backends/lerobot/capabilities.py cli/tests/backends/test_lerobot_perception.py
+git commit -m "feat(sp3): perceive.rgb + perceive.depth via LeRobot capture_observation"
+```
+
+---
+
+### Task 23: `lerobot.teleop` vendor capability
+
+**Files:**
+- Modify: `cli/src/robot_md/backends/lerobot/motion.py`, `capabilities.py`
+- Test: `cli/tests/backends/test_lerobot_teleop.py`
+
+- [ ] **Step 1: Write the test**
+
+```python
+# cli/tests/backends/test_lerobot_teleop.py
+from __future__ import annotations
+
+from unittest.mock import MagicMock
+
+from robot_md.backends.lerobot import LerobotBackend
+
+
+def test_teleop_loop_streams_leader_to_follower() -> None:
+    b = LerobotBackend()
+    robot = MagicMock()
+    leader_states = [
+        {"joints": [0.1, 0.0, 0.0, 0.0, 0.0, 0.0]},
+        {"joints": [0.2, 0.0, 0.0, 0.0, 0.0, 0.0]},
+        None,  # sentinel — leader disconnected
+    ]
+    robot.read_leader_state.side_effect = leader_states
+    b._robot = robot
+    result = b.execute("lerobot.teleop", {"max_steps": 2}, dry_run=False, estop=None)
+    assert result.status == "ok"
+    assert robot.send_action.call_count == 2
+
+
+def test_teleop_dry_run_does_not_call_robot() -> None:
+    b = LerobotBackend()
+    b._robot = MagicMock()
+    result = b.execute("lerobot.teleop", {"max_steps": 5}, dry_run=True, estop=None)
+    assert result.status == "ok"
+    b._robot.send_action.assert_not_called()
+```
+
+- [ ] **Step 2: Run test (expect FAIL — not_implemented)**
+
+- [ ] **Step 3: Add `lerobot_teleop` to motion.py**
+
+```python
+def lerobot_teleop(backend, args: dict, *, dry_run: bool, estop) -> ExecutionResult:
+    max_steps = int(args.get("max_steps", 100))
+    if dry_run:
+        return ExecutionResult(status="ok", trajectory=None,
+                               events=[ExecutionEvent(kind="dry_run",
+                                                       data={"capability": "lerobot.teleop", "max_steps": max_steps})],
+                               error=None)
+    streamed = 0
+    for _ in range(max_steps):
+        state = backend._robot.read_leader_state()
+        if state is None:
+            break
+        backend._robot.send_action(state)
+        streamed += 1
+    return ExecutionResult(status="ok", trajectory=None,
+                           events=[ExecutionEvent(kind="teleop_complete", data={"steps": streamed})],
+                           error=None)
+```
+
+Add to HANDLERS in `capabilities.py`:
+
+```python
+from robot_md.backends.lerobot.motion import (
+    arm_pick, arm_place, arm_home, gripper_open, gripper_close, lerobot_teleop,
+)
+
+HANDLERS = {
+    "arm.pick": arm_pick,
+    "arm.place": arm_place,
+    "arm.home": arm_home,
+    "gripper.open": gripper_open,
+    "gripper.close": gripper_close,
+    "perceive.rgb": perceive_rgb,
+    "perceive.depth": perceive_depth,
+    "lerobot.teleop": lerobot_teleop,
+}
+```
+
+- [ ] **Step 4: Run test (expect PASS 2/2)**
+
+- [ ] **Step 5: Commit (Task 23)**
+
+```bash
+git add cli/src/robot_md/backends/lerobot/motion.py cli/src/robot_md/backends/lerobot/capabilities.py cli/tests/backends/test_lerobot_teleop.py
+git commit -m "feat(sp3): lerobot.teleop vendor capability"
+```
+
+---
+
+### Task 24: Lock the not-implemented contract + dry-run trajectory contract
+
+**Files:**
+- Test only: `cli/tests/backends/test_lerobot_execute_unknown_capability.py`, `cli/tests/backends/test_lerobot_dry_run.py`, `cli/tests/backends/test_lerobot_capabilities_schema_compliance.py`
+
+- [ ] **Step 1: Write the unknown-capability test**
+
+```python
+# cli/tests/backends/test_lerobot_execute_unknown_capability.py
+from __future__ import annotations
+
+from unittest.mock import MagicMock
+
+from robot_md.backends.lerobot import LerobotBackend
+
+
+def test_unknown_capability_returns_not_implemented() -> None:
+    b = LerobotBackend()
+    b._robot = MagicMock()
+    result = b.execute("arm.dance", {}, dry_run=True, estop=None)
+    assert result.status == "error"
+    assert result.error["reason"] == "not_implemented"
+```
+
+- [ ] **Step 2: Write the dry-run trajectory test**
+
+```python
+# cli/tests/backends/test_lerobot_dry_run.py
+from __future__ import annotations
+
+from unittest.mock import MagicMock
+
+from robot_md.backends.lerobot import LerobotBackend
+
+
+def test_dry_run_arm_pick_populates_trajectory_and_skips_writes() -> None:
+    b = LerobotBackend()
+    robot = MagicMock()
+    b._robot = robot
+    result = b.execute("arm.pick", {"target": "red_lego"}, dry_run=True, estop=None)
+    assert result.status == "ok"
+    assert isinstance(result.trajectory, list)
+    assert len(result.trajectory) >= 2  # at least approach + descend
+    robot.send_action.assert_not_called()
+```
+
+- [ ] **Step 3: Write the schema-compliance test**
+
+```python
+# cli/tests/backends/test_lerobot_capabilities_schema_compliance.py
+from __future__ import annotations
+
+import json
+from pathlib import Path
+
+import jsonschema
+
+from robot_md.backends.lerobot import LerobotBackend
+
+
+_SCHEMA_PATH = Path(__file__).parents[2] / "src" / "robot_md" / "schemas" / "capabilities.json"
+
+
+def test_minimal_valid_args_per_core_capability_pass_validation() -> None:
+    schema = json.loads(_SCHEMA_PATH.read_text())
+    defs = schema["definitions"]
+    minimal_args = {
+        "arm.pick": {"target": "red_lego"},
+        "arm.place": {"destination": "drop_zone"},
+        "arm.home": {},
+        "perceive.rgb": {},
+        "perceive.depth": {},
+        "gripper.open": {},
+        "gripper.close": {},
+    }
+    backend_caps = LerobotBackend().capabilities()
+    for cap in backend_caps:
+        if cap not in defs:
+            continue  # vendor capability — not in capabilities.json
+        jsonschema.validate(minimal_args[cap], defs[cap])
+```
+
+- [ ] **Step 4: Run all three tests (expect PASS — all driven by behavior already implemented)**
+
+```bash
+cd cli && PYTHONPATH=src python -m pytest tests/backends/test_lerobot_execute_unknown_capability.py tests/backends/test_lerobot_dry_run.py tests/backends/test_lerobot_capabilities_schema_compliance.py -v
+```
+
+Expected: all PASS.
+
+- [ ] **Step 5: Run the entire LeRobot test suite to lock the phase**
+
+```bash
+cd cli && PYTHONPATH=src python -m pytest tests/backends/test_lerobot_*.py -v
+```
+
+Expected: all PASS.
+
+- [ ] **Step 6: Commit (Task 24)**
+
+```bash
+git add cli/tests/backends/test_lerobot_execute_unknown_capability.py cli/tests/backends/test_lerobot_dry_run.py cli/tests/backends/test_lerobot_capabilities_schema_compliance.py
+git commit -m "test(sp3): lock LerobotBackend dispatch + dry-run + schema-compliance contracts"
+```
+
+---
+
+## Phase D — Wiring (pyproject + entry-points + presets)
+
+This is when the new backends become live in the registry. Until Tasks 25-27, the LeRobot and RealSense adapters exist as code but are NOT discoverable via `entry_points(group="robot_md.backends")`.
+
+### Task 25: Add `[hardware]`, `[lerobot]`, `[realsense]` extras to `cli/pyproject.toml`
+
+**Files:**
+- Modify: `cli/pyproject.toml`
+- Test: install + import smoke (manual + CI surface).
+
+Pin set comes from `docs/superpowers/specs/2026-04-27-sp1-5-simplification-revisions.md` Revision 3.
+
+- [ ] **Step 1: Inspect existing optional-dependencies block**
+
+```bash
+grep -n -A 20 "\[project.optional-dependencies\]" cli/pyproject.toml | head -40
+```
+
+- [ ] **Step 2: Add the three extras**
+
+Edit `cli/pyproject.toml`. Inside the `[project.optional-dependencies]` table, add (preserving any existing extras like `dev`, `test`):
+
+```toml
+[project.optional-dependencies]
+# ... existing extras preserved ...
+
+# SP3: meta-extra pulling all common backends (per simplification-revisions Rev 3).
+hardware = [
+    "lerobot>=0.5,<0.8",
+    "pyrealsense2>=2.55",
+    "depthai>=2.24",
+    "feetech-servo-sdk>=1.0",
+    "pyserial>=3.5",
+    "opencv-python>=4.8",
+]
+# SP3: granular per-backend extras (advanced / minimal installs).
+lerobot = [
+    "lerobot>=0.5,<0.8",
+    "pyserial>=3.5",
+]
+realsense = [
+    "pyrealsense2>=2.55",
+]
+```
+
+- [ ] **Step 3: Verify the dependency surface installs cleanly (smoke)**
+
+```bash
+cd /home/craigm26/robot-md/.worktrees/sp3-sdk-adapter
+python -m venv /tmp/sp3-extras-smoke && source /tmp/sp3-extras-smoke/bin/activate
+pip install -e 'cli[realsense]'
+python -c "import pyrealsense2; print('ok')"
+deactivate && rm -rf /tmp/sp3-extras-smoke
+```
+
+Expected: `ok`. The `lerobot` extra also installs but pulls PyTorch (~1.5 GB) — skip in this smoke unless verifying on a beefy machine.
+
+- [ ] **Step 4: Run the existing test suite to confirm no regression from the toml edits**
+
+```bash
+cd cli && PYTHONPATH=src python -m pytest tests/ -q --ignore=tests/integration --ignore=tests/spatial_eval -x
+```
+
+Expected: all PASS.
+
+- [ ] **Step 5: Commit (Task 25)**
+
+```bash
+cd /home/craigm26/robot-md/.worktrees/sp3-sdk-adapter
+git add cli/pyproject.toml
+git commit -m "$(cat <<'EOF'
+feat(sp3): add [hardware] meta-extra + [lerobot] / [realsense] granular extras
+
+Per simplification-revisions Rev 3: [hardware] is the default install
+hint across all docs; granular extras stay for advanced/minimal installs.
+
+Pin set: lerobot>=0.5,<0.8 + pyrealsense2>=2.55 + depthai>=2.24 +
+feetech-servo-sdk>=1.0 + pyserial>=3.5 + opencv-python>=4.8.
+
+Entry-point declarations follow in Task 26.
+
+Co-Authored-By: Claude Opus 4.7 (1M context) <noreply@anthropic.com>
+EOF
+)"
+```
+
+---
+
+### Task 26: Add `lerobot` and `realsense` entry-point declarations
+
+**Files:**
+- Modify: `cli/pyproject.toml`
+- Test: `cli/tests/backends/test_entry_points_register_sp3_backends.py`
+
+- [ ] **Step 1: Write the entry-point registration test**
+
+```python
+# cli/tests/backends/test_entry_points_register_sp3_backends.py
+from __future__ import annotations
+
+from importlib.metadata import entry_points
+
+
+def test_lerobot_and_realsense_entry_points_registered() -> None:
+    eps = entry_points(group="robot_md.backends")
+    names = {ep.name for ep in eps}
+    assert "feetech_depthai" in names  # baseline
+    assert "lerobot" in names
+    assert "realsense" in names
+```
+
+- [ ] **Step 2: Run test (expect FAIL — names missing)**
+
+```bash
+cd cli && PYTHONPATH=src python -m pytest tests/backends/test_entry_points_register_sp3_backends.py -v
+```
+
+- [ ] **Step 3: Add the entry-point declarations**
+
+Edit `cli/pyproject.toml`. Find the `[project.entry-points."robot_md.backends"]` block (existing `feetech_depthai = ...` line) and add:
+
+```toml
+[project.entry-points."robot_md.backends"]
+feetech_depthai = "robot_md.backends.feetech_depthai:FeetechDepthaiBackend"
+lerobot         = "robot_md.backends.lerobot:LerobotBackend"
+realsense       = "robot_md.backends.realsense:RealsenseBackend"
+```
+
+- [ ] **Step 4: Reinstall in editable mode so entry-point metadata refreshes**
+
+```bash
+cd /home/craigm26/robot-md/.worktrees/sp3-sdk-adapter/cli
+pip install -e .
+```
+
+Expected: clean install. (Verify with `pip show robot-md` if needed.)
+
+- [ ] **Step 5: Run the entry-point test**
+
+```bash
+cd cli && PYTHONPATH=src python -m pytest tests/backends/test_entry_points_register_sp3_backends.py -v
+```
+
+Expected: PASS.
+
+- [ ] **Step 6: Smoke `robot-md describe-capabilities` end-to-end**
+
+```bash
+cd /home/craigm26/robot-md/.worktrees/sp3-sdk-adapter
+PYTHONPATH=cli/src python -m robot_md describe-capabilities
+```
+
+Expected output: now shows three sections (`feetech_depthai`, `lerobot`, `realsense`), each with their capabilities.
+
+- [ ] **Step 7: Commit (Task 26)**
+
+```bash
+git add cli/pyproject.toml cli/tests/backends/test_entry_points_register_sp3_backends.py
+git commit -m "$(cat <<'EOF'
+feat(sp3): register lerobot + realsense backends via entry-points
+
+Backends are now discoverable via importlib.metadata.entry_points
+(group="robot_md.backends"). robot-md describe-capabilities surfaces
+all three. Tier validator runs on each at discovery time; both pass
+(arm.* / perceive.* / gripper.* are core; lerobot.teleop and
+realsense.aligned_depth are vendor-shaped).
+
+Co-Authored-By: Claude Opus 4.7 (1M context) <noreply@anthropic.com>
+EOF
+)"
+```
+
+---
+
+### Task 27: Update SO-ARM presets to declare `preferred_backend: lerobot`
+
+**Files:**
+- Modify: `cli/src/robot_md/presets/so_arm101.yaml`, `so_arm101_leader.yaml`, `koch_arm.yaml`, `aloha2.yaml`
+- Test: `cli/tests/backends/test_presets_preferred_backend_lerobot.py`
+
+- [ ] **Step 1: Inspect one preset to confirm shape**
+
+```bash
+cat cli/src/robot_md/presets/so_arm101.yaml
+```
+
+Note the structure (`drivers:` list with `id`, `protocol`, etc.). The new field goes inside the arm-servos driver entry.
+
+- [ ] **Step 2: Write the preferred-backend test**
+
+```python
+# cli/tests/backends/test_presets_preferred_backend_lerobot.py
+from __future__ import annotations
+
+from pathlib import Path
+
+import yaml
+
+
+_PRESETS_DIR = Path(__file__).parents[2] / "src" / "robot_md" / "presets"
+
+
+def _load(preset: str) -> dict:
+    return yaml.safe_load((_PRESETS_DIR / preset).read_text())
+
+
+def _arm_driver_of(data: dict) -> dict:
+    for drv in data.get("drivers", []):
+        if drv.get("protocol") in {"feetech", "dynamixel"}:
+            return drv
+    raise AssertionError(f"no arm driver in preset: {data}")
+
+
+def test_so_arm_presets_prefer_lerobot() -> None:
+    for preset in ("so_arm101.yaml", "so_arm101_leader.yaml", "koch_arm.yaml", "aloha2.yaml"):
+        data = _load(preset)
+        arm = _arm_driver_of(data)
+        assert arm.get("preferred_backend") == "lerobot", (
+            f"{preset} arm driver missing or wrong preferred_backend (got {arm.get('preferred_backend')!r})"
+        )
+```
+
+- [ ] **Step 3: Run test (expect FAIL — field missing)**
+
+```bash
+cd cli && PYTHONPATH=src python -m pytest tests/backends/test_presets_preferred_backend_lerobot.py -v
+```
+
+- [ ] **Step 4: Edit each preset**
+
+For each of `so_arm101.yaml`, `so_arm101_leader.yaml`, `koch_arm.yaml`, `aloha2.yaml`: locate the arm-servos driver entry (the one with `protocol: feetech` or `protocol: dynamixel`) and add `preferred_backend: lerobot` as a sibling key.
+
+Example (so_arm101.yaml):
+
+```yaml
+drivers:
+  - id: arm_servos
+    protocol: feetech
+    preferred_backend: lerobot          # NEW
+    port: /dev/ttyACM0
+    baud: 1000000
+    motors:
+      # ... existing motor list ...
+```
+
+Per simplification-revisions Revision 6: this field is **preset-internal only** — it MUST NOT appear in the `manifest` ROBOT.md schema written by `init`. Verify the manifest writer doesn't accidentally copy it through (the existing test in SP2 should catch this; if not, this is a follow-up).
+
+- [ ] **Step 5: Run the preset test (expect PASS)**
+
+- [ ] **Step 6: Run the full test suite to catch any preset-loader regressions**
+
+```bash
+cd cli && PYTHONPATH=src python -m pytest tests/ -q --ignore=tests/integration --ignore=tests/spatial_eval -x
+```
+
+Expected: all PASS.
+
+- [ ] **Step 7: Commit (Task 27)**
+
+```bash
+git add cli/src/robot_md/presets/so_arm101.yaml cli/src/robot_md/presets/so_arm101_leader.yaml cli/src/robot_md/presets/koch_arm.yaml cli/src/robot_md/presets/aloha2.yaml cli/tests/backends/test_presets_preferred_backend_lerobot.py
+git commit -m "$(cat <<'EOF'
+feat(sp3): SO-ARM presets prefer lerobot backend
+
+so_arm101 / so_arm101_leader / koch_arm / aloha2 arm drivers now declare
+preferred_backend: lerobot. SP2's try_resolve picks this hint when
+multiple backends could drive the protocol (lerobot wins over
+feetech_depthai when both installed).
+
+preferred_backend is preset-internal per simplification-revisions Rev 6;
+NOT copied to the operator-visible manifest.
+
+Co-Authored-By: Claude Opus 4.7 (1M context) <noreply@anthropic.com>
+EOF
+)"
+```
+
+---
+
+## Phase E — Authoring guide + backend template
+
+### Task 28: Write `docs/authoring-a-backend.md`
+
+**Files:**
+- Create: `docs/authoring-a-backend.md`
+- Test: deferred to Task 30 (extracted code-block compile check).
+
+- [ ] **Step 1: Draft the 8-section guide**
+
+Create `docs/authoring-a-backend.md` with the structure from SP3 spec § 7. Target ~2000 words. Each section MUST contain only working code (Task 30 will compile-check every Python block).
+
+```markdown
+# Authoring a robot-md backend
+
+This guide walks through writing a new `robot-md` backend — an adapter
+that lets `robot-md` drive your robot's hardware via your vendor SDK,
+exposed through `CapabilityBackend` and registered via Python
+entry-points.
+
+## 1. What is a backend?
+
+A backend is a Python class implementing the `CapabilityBackend` ABC
+(`from robot_md.backends import CapabilityBackend`). At runtime the
+operator's manifest (`ROBOT.md`) names a backend per driver; the
+runtime resolves the name to your class via `entry_points(group="robot_md.backends")`,
+instantiates it, and calls `open(spec)` followed by `execute(capability, args)`.
+
+The relationship:
+
+```
+ROBOT.md → BackendRegistry.resolve(spec) → your_backend_instance
+                                              ↓
+                                          execute("arm.pick", {...})
+                                              ↓
+                                          your_dispatch_table["arm.pick"]
+```
+
+## 2. The 30-minute path: copy the template
+
+The fastest start is `examples/backend-template/`. Copy it, rename, edit:
+
+(see Task 29 — the template has its own README.)
+
+## 3. Implementing CapabilityBackend
+
+Five required methods plus one optional:
+
+```python
+from robot_md.backends import CapabilityBackend, ExecutionResult
+
+class MyBackend(CapabilityBackend):
+    name = "my_vendor"
+    protocols = frozenset({"my_protocol"})
+    read_only_capabilities = frozenset({"perceive.rgb"})
+
+    def open(self, spec):
+        # connect to hardware
+        ...
+
+    def close(self):
+        # disconnect
+        ...
+
+    def capabilities(self):
+        return frozenset({"arm.pick", "my_vendor.special"})
+
+    def execute(self, capability, args, *, dry_run, estop):
+        # dispatch to handler
+        ...
+
+    # optional override — default impl walks capabilities.json
+    # def describe_capabilities(self):
+    #     ...
+```
+
+## 4. Capability namespacing
+
+Use **core prefixes** (`arm.*`, `nav.*`, `perceive.*`, `gripper.*`,
+`safety.*`) when your capability matches a standard one defined in
+`cli/src/robot_md/schemas/capabilities.json`. Use **vendor namespacing**
+(`<vendor>.<capability>`) for anything your SDK exposes that doesn't
+fit a core prefix.
+
+The tier validator at registration enforces this:
+
+- core: must start with one of the prefixes above.
+- vendor: must match `^[a-z][a-z0-9_]*\.[a-z][a-z0-9_.]*$`.
+
+Backends with malformed names are skipped at discovery — your adapter
+won't load if you accidentally typo `Arm.Pick`.
+
+## 5. Testing without hardware
+
+Mock the SDK. The pattern from `feetech_depthai`:
+
+```python
+from unittest.mock import MagicMock
+from my_backend import MyBackend
+
+
+def test_open_calls_connect():
+    b = MyBackend()
+    b._sdk = MagicMock()  # short-circuit lazy import
+    b.open(some_spec)
+    b._sdk.connect.assert_called_once()
+```
+
+For SDKs that import slow C extensions, install a fake module via
+`sys.modules` before instantiating:
+
+```python
+import sys, types
+fake = types.ModuleType("my_vendor_sdk")
+fake.connect = lambda port: object()
+sys.modules["my_vendor_sdk"] = fake
+```
+
+## 6. Packaging + entry-point declaration
+
+In your package's `pyproject.toml`:
+
+```toml
+[project.entry-points."robot_md.backends"]
+my_vendor = "my_backend:MyBackend"
+```
+
+After `pip install -e .`, `robot-md describe-capabilities` will list your backend.
+
+## 7. Contributing first-party vs publishing third-party
+
+| Path | Where source lives | Reviewed by | Trust |
+|------|-------------------|-------------|-------|
+| First-party | `cli/src/robot_md/backends/<vendor>/` | `robot-md` maintainers | Audited |
+| Third-party | Your own PyPI package `robot-md-backend-<vendor>` | You | Operator's risk |
+
+Operators distinguish via `pip show <pkg>` and the publisher metadata.
+
+## 8. Versioning + ABC stability
+
+The `CapabilityBackend` ABC follows additive evolution:
+- New optional methods land with concrete defaults; existing adapters keep
+  working without changes.
+- Breaking changes get a major-version bump on `robot-md` plus a 6-month
+  deprecation window.
+- `capabilities()` and the four originally-abstract methods (`open`,
+  `close`, `execute`, `capabilities`) are stable.
+```
+
+(The above is condensed for the plan — write it out to ~2000 words in the actual doc with more examples, diagnostics tips, etc.)
+
+- [ ] **Step 2: Save and visually inspect**
+
+Run a syntax-only Markdown lint if the project has one (`pre-commit run -a` or similar). Fix any heading-hierarchy or list-indent issues.
+
+- [ ] **Step 3: Commit (Task 28)**
+
+```bash
+git add docs/authoring-a-backend.md
+git commit -m "docs(sp3): authoring-a-backend guide"
+```
+
+---
+
+### Task 29: Backend template scaffold under `examples/backend-template/`
+
+**Files:**
+- Create: `examples/backend-template/README.md`, `pyproject.toml`, `src/my_backend/__init__.py`, `src/my_backend/capabilities.py`, `src/my_backend/motion.py`, `tests/test_my_backend.py`
+- Test: `cli/tests/backends/test_backend_template_scaffolds.py`, `test_backend_template_tests_pass.py`, `test_backend_template_validates_namespace.py`
+
+- [ ] **Step 1: Write the scaffold-and-install test**
+
+```python
+# cli/tests/backends/test_backend_template_scaffolds.py
+from __future__ import annotations
+
+import shutil
+import subprocess
+import sys
+from pathlib import Path
+
+
+_TEMPLATE_ROOT = Path(__file__).parents[3] / "examples" / "backend-template"
+
+
+def test_template_files_exist() -> None:
+    expected = [
+        _TEMPLATE_ROOT / "README.md",
+        _TEMPLATE_ROOT / "pyproject.toml",
+        _TEMPLATE_ROOT / "src" / "my_backend" / "__init__.py",
+        _TEMPLATE_ROOT / "src" / "my_backend" / "capabilities.py",
+        _TEMPLATE_ROOT / "src" / "my_backend" / "motion.py",
+        _TEMPLATE_ROOT / "tests" / "test_my_backend.py",
+    ]
+    for path in expected:
+        assert path.exists(), f"template missing {path}"
+
+
+def test_template_pip_installs_into_temp_env(tmp_path: Path) -> None:
+    """Copy template to tmp, pip-install in editable mode, verify the
+    entry-point appears in the installed metadata."""
+    dest = tmp_path / "backend"
+    shutil.copytree(_TEMPLATE_ROOT, dest)
+
+    result = subprocess.run(
+        [sys.executable, "-m", "pip", "install", "-e", str(dest), "--quiet"],
+        capture_output=True, text=True,
+    )
+    assert result.returncode == 0, result.stderr
+
+    # Verify entry-point registered. (Use a subprocess so we don't pollute
+    # the parent's importlib.metadata cache.)
+    check = subprocess.run(
+        [sys.executable, "-c", "from importlib.metadata import entry_points; print({ep.name for ep in entry_points(group='robot_md.backends')})"],
+        capture_output=True, text=True,
+    )
+    assert "my_backend" in check.stdout, check.stdout
+```
+
+- [ ] **Step 2: Write the template-tests-pass and validates-namespace tests**
+
+```python
+# cli/tests/backends/test_backend_template_tests_pass.py
+from __future__ import annotations
+
+import subprocess
+import sys
+from pathlib import Path
+
+_TEMPLATE_ROOT = Path(__file__).parents[3] / "examples" / "backend-template"
+
+
+def test_template_pytests_pass() -> None:
+    result = subprocess.run(
+        [sys.executable, "-m", "pytest", str(_TEMPLATE_ROOT / "tests"), "-q"],
+        capture_output=True, text=True, cwd=_TEMPLATE_ROOT,
+    )
+    # NotImplementedError stubs are xfail; suite as a whole returns 0 when
+    # all pass + any xfail are handled cleanly.
+    assert result.returncode == 0, result.stdout + result.stderr
+```
+
+```python
+# cli/tests/backends/test_backend_template_validates_namespace.py
+from __future__ import annotations
+
+from pathlib import Path
+import importlib.util
+
+
+_INIT = Path(__file__).parents[3] / "examples" / "backend-template" / "src" / "my_backend" / "__init__.py"
+
+
+def test_template_capabilities_pass_tier_validator() -> None:
+    spec = importlib.util.spec_from_file_location("template_my_backend", _INIT)
+    mod = importlib.util.module_from_spec(spec)
+    spec.loader.exec_module(mod)
+    backend = mod.MyBackend()
+    from robot_md.backends.registry import _validate_capability_namespace
+    _validate_capability_namespace("my_backend", backend.capabilities())
+```
+
+- [ ] **Step 3: Run tests (expect FAIL — files don't exist yet)**
+
+- [ ] **Step 4: Create template files**
+
+`examples/backend-template/README.md`:
+
+```markdown
+# robot-md backend template — 5-step bring-up
+
+1. `cp -r examples/backend-template ~/robot-md-backend-myvendor`
+2. `cd ~/robot-md-backend-myvendor`
+3. Edit `pyproject.toml` — change `name`, the entry-point key (`my_backend`), and the maintainer.
+4. Edit `src/my_backend/__init__.py` — set `name`, `protocols`, fill in `open()`, `close()`, `execute()`.
+5. `pip install -e . && pytest`
+
+Then verify your backend appears: `robot-md describe-capabilities`.
+
+See `docs/authoring-a-backend.md` for full guidance.
+```
+
+`examples/backend-template/pyproject.toml`:
+
+```toml
+[project]
+name = "robot-md-backend-template"
+version = "0.0.1"
+requires-python = ">=3.10"
+dependencies = ["robot-md"]
+
+[build-system]
+requires = ["hatchling"]
+build-backend = "hatchling.build"
+
+[tool.hatch.build.targets.wheel]
+packages = ["src/my_backend"]
+
+[project.entry-points."robot_md.backends"]
+my_backend = "my_backend:MyBackend"
+```
+
+`examples/backend-template/src/my_backend/__init__.py`:
+
+```python
+"""Template backend — copy, rename, edit, install, test."""
+
+from __future__ import annotations
+
+from robot_md.backends import CapabilityBackend, ExecutionResult
+
+
+class MyBackend(CapabilityBackend):
+    name = "my_backend"
+    protocols = frozenset({"my_protocol"})
+    read_only_capabilities = frozenset()
+
+    def open(self, spec) -> None:
+        # TODO: connect to your hardware here.
+        raise NotImplementedError
+
+    def close(self) -> None:
+        # TODO: disconnect.
+        pass
+
+    def capabilities(self) -> frozenset[str]:
+        return frozenset({"arm.pick", "my_backend.example"})
+
+    def execute(self, capability: str, args: dict, *, dry_run: bool, estop) -> ExecutionResult:
+        from my_backend.capabilities import dispatch
+        return dispatch(self, capability=capability, args=dict(args), dry_run=dry_run, estop=estop)
+```
+
+`examples/backend-template/src/my_backend/capabilities.py`:
+
+```python
+from __future__ import annotations
+
+from robot_md.backends import ExecutionResult
+from my_backend.motion import arm_pick, my_backend_example
+
+
+HANDLERS = {
+    "arm.pick": arm_pick,
+    "my_backend.example": my_backend_example,
+}
+
+
+def dispatch(backend, *, capability: str, args: dict, dry_run: bool, estop) -> ExecutionResult:
+    handler = HANDLERS.get(capability)
+    if handler is None:
+        return ExecutionResult(status="error", trajectory=None, events=[],
+                               error={"reason": "not_implemented", "detail": f"capability {capability!r}"})
+    return handler(backend, args, dry_run=dry_run, estop=estop)
+```
+
+`examples/backend-template/src/my_backend/motion.py`:
+
+```python
+from __future__ import annotations
+
+from robot_md.backends import ExecutionEvent, ExecutionResult
+
+
+def arm_pick(backend, args, *, dry_run, estop) -> ExecutionResult:
+    # TODO: replace with real motion using your SDK.
+    raise NotImplementedError("arm.pick not yet implemented")
+
+
+def my_backend_example(backend, args, *, dry_run, estop) -> ExecutionResult:
+    # TODO: implement your vendor capability.
+    raise NotImplementedError("my_backend.example not yet implemented")
+```
+
+`examples/backend-template/tests/test_my_backend.py`:
+
+```python
+from __future__ import annotations
+
+import pytest
+
+from my_backend import MyBackend
+
+
+def test_class_attrs() -> None:
+    b = MyBackend()
+    assert b.name == "my_backend"
+    assert "my_protocol" in b.protocols
+
+
+def test_capabilities_pass_tier_validator() -> None:
+    from robot_md.backends.registry import _validate_capability_namespace
+    _validate_capability_namespace("my_backend", MyBackend().capabilities())
+
+
+@pytest.mark.xfail(strict=True, reason="template stub — implement before shipping")
+def test_arm_pick_executes() -> None:
+    b = MyBackend()
+    result = b.execute("arm.pick", {"target": "x"}, dry_run=True, estop=None)
+    assert result.status == "ok"
+```
+
+- [ ] **Step 5: Run tests (expect PASS)**
+
+```bash
+cd cli && PYTHONPATH=src python -m pytest tests/backends/test_backend_template_*.py -v
+```
+
+Expected: all PASS — scaffolds exist, install works, namespace validator accepts the template's capabilities, template tests pass with the `xfail` for the stub motion handler.
+
+- [ ] **Step 6: Commit (Task 29)**
+
+```bash
+git add examples/backend-template/ cli/tests/backends/test_backend_template_scaffolds.py cli/tests/backends/test_backend_template_tests_pass.py cli/tests/backends/test_backend_template_validates_namespace.py
+git commit -m "$(cat <<'EOF'
+feat(sp3): examples/backend-template — copy-paste backend skeleton
+
+5-step bring-up (cp + rename + edit + install + test) targeting under
+60 seconds end-to-end. Skeleton's __init__.py raises NotImplementedError
+at each abstract method with TODO comments; the stub handler in the
+template's tests is xfail-strict so the suite is green out of the box
+yet flips green-to-fail the moment the implementer wires the real
+handler.
+
+Three CI tests pin the template's invariants: scaffold present,
+`pip install -e .` registers the entry-point, capabilities pass the
+tier validator.
+
+Co-Authored-By: Claude Opus 4.7 (1M context) <noreply@anthropic.com>
+EOF
+)"
+```
+
+---
+
+### Task 30: Code-block-extraction test for `docs/authoring-a-backend.md`
+
+**Files:**
+- Create: `cli/tests/docs/test_docs_authoring_examples_executable.py`
+
+- [ ] **Step 1: Write the compile-check test**
+
+```python
+# cli/tests/docs/test_docs_authoring_examples_executable.py
+from __future__ import annotations
+
+import re
+from pathlib import Path
+
+
+_DOC = Path(__file__).parents[3] / "docs" / "authoring-a-backend.md"
+_PY_BLOCK_RE = re.compile(r"```python\n(.*?)```", re.DOTALL)
+
+
+def test_every_python_code_block_compiles() -> None:
+    blocks = _PY_BLOCK_RE.findall(_DOC.read_text())
+    assert blocks, "no ```python code blocks found in authoring guide"
+    for i, block in enumerate(blocks):
+        # Skip blocks marked as illustrative-only with `# pseudo:` first line.
+        if block.lstrip().startswith("# pseudo:"):
+            continue
+        try:
+            compile(block, f"<authoring-a-backend.md block {i}>", "exec")
+        except SyntaxError as e:
+            raise AssertionError(f"block {i} has syntax errors: {e}\n{block}") from e
+```
+
+- [ ] **Step 2: Run test (expect PASS — Task 28's blocks are all valid)**
+
+```bash
+cd cli && PYTHONPATH=src python -m pytest tests/docs/test_docs_authoring_examples_executable.py -v
+```
+
+If a block fails to compile, fix the doc until the test passes (or mark the offending block with `# pseudo:` if it's deliberately illustrative).
+
+- [ ] **Step 3: Commit (Task 30)**
+
+```bash
+git add cli/tests/docs/test_docs_authoring_examples_executable.py
+git commit -m "test(sp3): every python block in authoring-a-backend.md compiles"
+```
+
+---
+
+## Phase F — Integration tests, schema sync, hardware-test stubs
+
+These tasks stitch SP3 into SP1's `init` flow + SP2's `try_resolve` and lock the runtime dispatch contract.
+
+### Task 31: Integration: `init` resolves SO-ARM101 to lerobot when both backends installed
+
+**Files:**
+- Create: `cli/tests/integration/test_init_sp3_lerobot_resolves.py`
+
+- [ ] **Step 1: Inspect SP1/SP2 init test patterns**
+
+```bash
+ls cli/tests/integration/ | head -20
+grep -l "preferred_backend\|try_resolve" cli/tests/integration/*.py 2>/dev/null
+```
+
+Reuse whatever fixtures the existing init integration tests have (e.g., `tmp_path` + a controlled entry-point monkey-patch).
+
+- [ ] **Step 2: Write the test**
+
+```python
+# cli/tests/integration/test_init_sp3_lerobot_resolves.py
+from __future__ import annotations
+
+from pathlib import Path
+from unittest.mock import MagicMock, patch
+
+import pytest
+
+from robot_md.backends.lerobot import LerobotBackend
+from robot_md.backends.feetech_depthai import FeetechDepthaiBackend
+
+
+def _fake_entry_points(group: str):
+    assert group == "robot_md.backends"
+    le_ep = MagicMock(); le_ep.name = "lerobot"; le_ep.load.return_value = LerobotBackend
+    fd_ep = MagicMock(); fd_ep.name = "feetech_depthai"; fd_ep.load.return_value = FeetechDepthaiBackend
+    return [le_ep, fd_ep]
+
+
+@pytest.mark.skipif(
+    not Path("/dev/ttyACM0").exists(),
+    reason="serial autodetect path requires /dev or strong mocking — keep this test skip-safe",
+)
+def test_init_sp3_lerobot_resolves_so_arm101_with_preset_hint(tmp_path: Path) -> None:
+    """When both lerobot and feetech_depthai are registered AND the SO-ARM101
+    preset declares preferred_backend: lerobot, init's try_resolve picks lerobot."""
+    # ... follow existing init-integration fixture conventions:
+    #     1. patch entry_points to return both backends
+    #     2. patch autodetect to return SO-ARM101 candidate
+    #     3. invoke init in tmp_path with --yes
+    #     4. read the written ROBOT.md
+    #     5. assert drivers[0].backend == "lerobot"
+    with patch("robot_md.backends.registry.entry_points", _fake_entry_points):
+        # The actual init invocation depends on the project's existing
+        # integration test scaffolding (see test_init_e2e_*.py for shape).
+        # Outline:
+        from robot_md.cli.init import init_command  # adjust import to the real symbol
+        manifest_path = tmp_path / "ROBOT.md"
+        init_command(target=tmp_path, preset_name="so_arm101", yes=True)
+        text = manifest_path.read_text()
+        # Manifest should declare backend: lerobot for the arm driver.
+        assert "backend: lerobot" in text
+        # And per simplification-revisions Rev 6, NOT preferred_backend:
+        assert "preferred_backend:" not in text
+```
+
+(Note: the imports + invocation pattern depend on the existing init scaffolding. If `init_command` isn't the real symbol, replace with whatever Typer command runner the existing integration tests use — typically `from typer.testing import CliRunner`. Adapt before running.)
+
+- [ ] **Step 3: Run test, fix imports/patch targets until it passes**
+
+```bash
+cd cli && PYTHONPATH=src python -m pytest tests/integration/test_init_sp3_lerobot_resolves.py -v
+```
+
+Expected: PASS once init flow is correctly invoked + entry-points patched.
+
+- [ ] **Step 4: Commit (Task 31)**
+
+```bash
+git add cli/tests/integration/test_init_sp3_lerobot_resolves.py
+git commit -m "test(sp3): init resolves SO-ARM101 + preset hint → lerobot"
+```
+
+---
+
+### Task 32: Integration: RealSense-only rig → LOW tier with camera pre-filled
+
+**Files:**
+- Create: `cli/tests/integration/test_init_sp3_realsense_camera_only.py`
+
+- [ ] **Step 1: Write the test**
+
+```python
+# cli/tests/integration/test_init_sp3_realsense_camera_only.py
+from __future__ import annotations
+
+from pathlib import Path
+from unittest.mock import MagicMock, patch
+
+import pytest
+
+from robot_md.backends.realsense import RealsenseBackend
+
+
+def _fake_entry_points(group: str):
+    assert group == "robot_md.backends"
+    rs_ep = MagicMock(); rs_ep.name = "realsense"; rs_ep.load.return_value = RealsenseBackend
+    return [rs_ep]
+
+
+@pytest.mark.skipif(True, reason="needs autodetect mock harness; left as stub for SP3 implementation")
+def test_realsense_only_rig_writes_low_tier_manifest_with_camera_prefilled(tmp_path: Path) -> None:
+    """No arm preset matches; only a RealSense D435 detected. init writes a
+    LOW-tier manifest with drivers[0] = realsense camera driver pre-filled
+    + physics.cameras[0] = realsense_d435 placeholder."""
+    with patch("robot_md.backends.registry.entry_points", _fake_entry_points):
+        # Outline (depends on autodetect mock fixtures):
+        # 1. patch autodetect to return: no arm bus, RealSense D435.
+        # 2. invoke init with --yes in tmp_path.
+        # 3. read manifest:
+        #    - drivers contains a vision driver with backend: realsense
+        #    - physics.cameras[0] exists with realsense_d435 hint
+        #    - TODO markers on metadata.manufacturer / physics.dof
+        # 4. assert all of the above.
+        pass  # see SP1's init.py + autodetect mock harness for the fixture shape
+```
+
+(This integration test is left as a runnable stub — the SP3 implementation must replace the `pass` body with real assertions once the autodetect fixture surface is understood by the implementer. The `skipif(True)` marker prevents false greens; remove once filled in.)
+
+- [ ] **Step 2: Run (expect SKIP)**
+
+```bash
+cd cli && PYTHONPATH=src python -m pytest tests/integration/test_init_sp3_realsense_camera_only.py -v
+```
+
+Expected: SKIPPED — the implementer should remove the `skipif(True)` and fill in the body during this task's execution.
+
+- [ ] **Step 3: Implement the test body**
+
+Drive the existing autodetect harness to return only a RealSense D435 (no arm bus). Confirm the manifest:
+
+- has `drivers:` with one entry, `protocol: realsense`, `backend: realsense`
+- has `physics.cameras[0]` pre-filled with the RealSense D435 hint
+- has TODO markers on `metadata.manufacturer` and `physics.dof`
+
+If the existing autodetect path doesn't yet support the no-arm/camera-only case, this task absorbs that small extension.
+
+- [ ] **Step 4: Run test (expect PASS)**
+
+- [ ] **Step 5: Commit (Task 32)**
+
+```bash
+git add cli/tests/integration/test_init_sp3_realsense_camera_only.py
+git commit -m "test(sp3): RealSense-only rig → LOW tier manifest with camera pre-filled"
+```
+
+---
+
+### Task 33: Integration: runtime dispatches to the explicit `backend:` field
+
+**Files:**
+- Create: `cli/tests/integration/test_runtime_dispatches_to_correct_backend.py`, `cli/tests/integration/test_runtime_two_backends_same_protocol_explicit_wins.py`
+
+- [ ] **Step 1: Write the dispatch test**
+
+```python
+# cli/tests/integration/test_runtime_dispatches_to_correct_backend.py
+from __future__ import annotations
+
+from unittest.mock import MagicMock, patch
+
+from robot_md.backends.lerobot import LerobotBackend
+from robot_md.backends.realsense import RealsenseBackend
+from robot_md.backends.registry import BackendRegistry
+from robot_md.robot_spec import RobotSpec, Driver
+
+
+def test_explicit_backend_field_wins() -> None:
+    spec = RobotSpec(
+        rrn="RRN-test",
+        drivers=[Driver(id="arm_servos", protocol="feetech", backend="lerobot",
+                        port="/dev/ttyACM0", baud=1000000, motors=[{"id": 1, "model": "sts3215", "joint": "shoulder_pan"}])],
+    )
+    reg = BackendRegistry(backends=[LerobotBackend(), RealsenseBackend()])
+    resolved = reg.resolve(spec)
+    assert isinstance(resolved["arm_servos"], LerobotBackend)
+
+
+def test_no_explicit_backend_alphabetical_first_wins() -> None:
+    spec = RobotSpec(
+        rrn="RRN-test",
+        drivers=[Driver(id="arm_servos", protocol="feetech", backend=None,
+                        port="/dev/ttyACM0", baud=1000000, motors=[])],
+    )
+    # Both lerobot and feetech_depthai claim "feetech"; alphabetical → feetech_depthai.
+    from robot_md.backends.feetech_depthai import FeetechDepthaiBackend
+    reg = BackendRegistry(backends=[LerobotBackend(), FeetechDepthaiBackend()])
+    resolved = reg.resolve(spec)
+    # Note: BackendRegistry.resolve sorts by .name; "feetech_depthai" < "lerobot".
+    assert resolved["arm_servos"].name == "feetech_depthai"
+```
+
+```python
+# cli/tests/integration/test_runtime_two_backends_same_protocol_explicit_wins.py
+from __future__ import annotations
+
+from robot_md.backends.lerobot import LerobotBackend
+from robot_md.backends.feetech_depthai import FeetechDepthaiBackend
+from robot_md.backends.registry import BackendRegistry
+from robot_md.robot_spec import RobotSpec, Driver
+
+
+def test_explicit_feetech_depthai_overrides_alphabetical() -> None:
+    spec = RobotSpec(
+        rrn="RRN-test",
+        drivers=[Driver(id="arm_servos", protocol="feetech", backend="feetech_depthai",
+                        port="/dev/ttyACM0", baud=1000000, motors=[])],
+    )
+    reg = BackendRegistry(backends=[LerobotBackend(), FeetechDepthaiBackend()])
+    resolved = reg.resolve(spec)
+    assert resolved["arm_servos"].name == "feetech_depthai"
+```
+
+- [ ] **Step 2: Run tests (expect PASS — `BackendRegistry.resolve` already implements this)**
+
+```bash
+cd cli && PYTHONPATH=src python -m pytest tests/integration/test_runtime_dispatches_to_correct_backend.py tests/integration/test_runtime_two_backends_same_protocol_explicit_wins.py -v
+```
+
+Expected: PASS (3/3).
+
+- [ ] **Step 3: Commit (Task 33)**
+
+```bash
+git add cli/tests/integration/test_runtime_dispatches_to_correct_backend.py cli/tests/integration/test_runtime_two_backends_same_protocol_explicit_wins.py
+git commit -m "test(sp3): lock runtime backend resolution — explicit wins, alphabetical fallback"
+```
+
+---
+
+### Task 34: Schema sync — TS bundle mirror of `capabilities.json`
+
+**Files:**
+- Modify: existing schema-sync script (whichever exists — `scripts/sync-schema.mjs` or `cli/scripts/sync-schema.py` per the SP6 plan's pattern)
+- Test: `cli/tests/backends/test_capabilities_schema_sync_ts.py`
+
+- [ ] **Step 1: Find the existing schema-sync mechanism**
+
+```bash
+ls scripts/ cli/scripts/ 2>/dev/null
+grep -rn "schema.json\|sync-schema\|robot.schema" Makefile package.json site/package.json 2>/dev/null | head -10
+```
+
+The SP6 plan's T1 / T34 set the precedent that `schema/v1/robot.schema.json` is canonical with byte-identical mirrors elsewhere. SP3's `capabilities.json` follows the same pattern.
+
+- [ ] **Step 2: Decide canonical path**
+
+Canonical: `cli/src/robot_md/schemas/capabilities.json` (Python-side). Mirror destinations (one or both, depending on what already exists):
+
+- `schema/v1/capabilities.json` (top-level canonical mirror, if `schema/` directory exists per SP6 precedent).
+- `site/static/schemas/capabilities.json` (web mirror, if `site/` exists).
+
+- [ ] **Step 3: Write the byte-identical-mirror test**
+
+```python
+# cli/tests/backends/test_capabilities_schema_sync_ts.py
+from __future__ import annotations
+
+import hashlib
+from pathlib import Path
+
+import pytest
+
+
+_REPO_ROOT = Path(__file__).parents[3]
+_CANONICAL = _REPO_ROOT / "cli" / "src" / "robot_md" / "schemas" / "capabilities.json"
+
+
+def _sha256(p: Path) -> str:
+    return hashlib.sha256(p.read_bytes()).hexdigest()
+
+
+def test_schema_v1_mirror_matches_canonical() -> None:
+    mirror = _REPO_ROOT / "schema" / "v1" / "capabilities.json"
+    if not mirror.exists():
+        pytest.skip("schema/v1/capabilities.json mirror not configured for this repo")
+    assert _sha256(_CANONICAL) == _sha256(mirror), (
+        f"capabilities.json drift: canonical {_sha256(_CANONICAL)} vs mirror {_sha256(mirror)}; "
+        f"run scripts/sync-schema to refresh."
+    )
+
+
+def test_site_mirror_matches_canonical() -> None:
+    mirror = _REPO_ROOT / "site" / "static" / "schemas" / "capabilities.json"
+    if not mirror.exists():
+        pytest.skip("site/static/schemas/capabilities.json mirror not configured for this repo")
+    assert _sha256(_CANONICAL) == _sha256(mirror)
+```
+
+- [ ] **Step 4: Update the sync script + run it**
+
+Find the existing sync script (one is expected to exist from SP6/RCAN work). Add `capabilities.json` to its file list. Run it:
+
+```bash
+# Whatever the existing invocation is — examples:
+node scripts/sync-schema.mjs
+# or
+python cli/scripts/sync-schema.py
+```
+
+Expected: produces `schema/v1/capabilities.json` and/or `site/.../capabilities.json` byte-identical to canonical.
+
+- [ ] **Step 5: Run the test (expect PASS or SKIP, no FAIL)**
+
+```bash
+cd cli && PYTHONPATH=src python -m pytest tests/backends/test_capabilities_schema_sync_ts.py -v
+```
+
+- [ ] **Step 6: Commit (Task 34)**
+
+```bash
+git add cli/src/robot_md/schemas/capabilities.json schema/v1/capabilities.json site/static/schemas/capabilities.json scripts/sync-schema.* cli/tests/backends/test_capabilities_schema_sync_ts.py
+git commit -m "$(cat <<'EOF'
+chore(sp3): mirror capabilities.json to schema/v1 + site/
+
+Canonical lives at cli/src/robot_md/schemas/capabilities.json. Mirrors
+are byte-identical, refreshed via the existing schema sync script. Test
+locks the byte-equivalence so CI catches drift.
+
+Co-Authored-By: Claude Opus 4.7 (1M context) <noreply@anthropic.com>
+EOF
+)"
+```
+
+(If the repo has only one of the two mirror locations, the test's other branch SKIPs cleanly — the commit can omit the missing path.)
+
+---
+
+### Task 35: Hardware-test stubs (skipped in CI; runnable on bob)
+
+**Files:**
+- Create: `cli/tests/hardware/test_sp3_lerobot_so_arm101_pick.py`, `cli/tests/hardware/test_sp3_realsense_d435_perceive.py`
+- Manual smoke: `cli/tests/manual/sp3_adapter_smoke.md`
+
+- [ ] **Step 1: Write the LeRobot hardware test stub**
+
+```python
+# cli/tests/hardware/test_sp3_lerobot_so_arm101_pick.py
+from __future__ import annotations
+
+import pytest
+
+
+pytestmark = pytest.mark.hardware
+
+
+def test_lerobot_arm_pick_red_lego_on_bob() -> None:
+    """End-to-end: LeRobot adapter drives bob's SO-ARM101 to pick the red lego.
+
+    Compares roughly to feetech_depthai's trajectory shape (does NOT require
+    bit-identical paths — different SDKs).
+    """
+    from robot_md.backends.lerobot import LerobotBackend
+    from robot_md.robot_spec import RobotSpec
+    # Load bob's actual ROBOT.md.
+    spec = RobotSpec.load_from("/home/craigm26/bob/ROBOT.md")
+    backend = LerobotBackend()
+    backend.open(spec)
+    try:
+        result = backend.execute("arm.pick", {"target": "red_lego"}, dry_run=False, estop=None)
+        assert result.status == "ok"
+        assert result.trajectory is not None
+        assert len(result.trajectory) >= 2
+    finally:
+        backend.close()
+```
+
+- [ ] **Step 2: Write the RealSense hardware test stub**
+
+```python
+# cli/tests/hardware/test_sp3_realsense_d435_perceive.py
+from __future__ import annotations
+
+import pytest
+
+
+pytestmark = pytest.mark.hardware
+
+
+def test_realsense_d435_perceive_rgb_returns_nonempty_frame() -> None:
+    from robot_md.backends.realsense import RealsenseBackend
+    from robot_md.robot_spec import RobotSpec
+
+    spec = RobotSpec.empty(rrn="RRN-realsense-only")
+    backend = RealsenseBackend()
+    backend.open(spec)
+    try:
+        result = backend.execute("perceive.rgb", {}, dry_run=False, estop=None)
+        assert result.status == "ok"
+        payload = result.events[-1].data
+        assert len(payload["frame_bytes"]) > 0
+    finally:
+        backend.close()
+
+
+def test_realsense_d435_perceive_depth_returns_nonempty_frame() -> None:
+    from robot_md.backends.realsense import RealsenseBackend
+    from robot_md.robot_spec import RobotSpec
+
+    spec = RobotSpec.empty(rrn="RRN-realsense-only")
+    backend = RealsenseBackend()
+    backend.open(spec)
+    try:
+        result = backend.execute("perceive.depth", {}, dry_run=False, estop=None)
+        assert result.status == "ok"
+        payload = result.events[-1].data
+        assert len(payload["frame_bytes"]) > 0
+    finally:
+        backend.close()
+```
+
+- [ ] **Step 3: Verify they're skipped in default CI run**
+
+```bash
+cd cli && PYTHONPATH=src python -m pytest tests/hardware/test_sp3_*.py -v
+```
+
+Expected: SKIPPED (because `@pytest.mark.hardware` and the conftest skips this marker unless `--run-hardware` or equivalent is passed; verify against `cli/tests/conftest.py`).
+
+- [ ] **Step 4: Write the manual smoke checklist**
+
+Create `cli/tests/manual/sp3_adapter_smoke.md`:
+
+```markdown
+# SP3 adapter smoke — manual checks on bob
+
+Run on the Pi5 with bob's ROBOT.md present in cwd.
+
+1. **LeRobot adapter on bob:** install + init + drive
+   ```
+   pip uninstall -y robot-md  # cleanup any prior local install
+   pip install -e 'cli[lerobot]'
+   robot-md init --yes
+   ```
+   Confirm `ROBOT.md`'s arm driver has `backend: lerobot`. Run `claude` and ask
+   "find the red lego" — verify motion via the LeRobot path.
+
+2. **Two adapters installed, preset hint disambiguates:**
+   ```
+   pip install -e 'cli[hardware]'   # both lerobot + feetech-depthai installed
+   robot-md init bob
+   ```
+   Init's closing line should mention preset hint → lerobot. Manifest gets
+   `backend: lerobot` (NOT preferred_backend — see Rev 6).
+
+3. **RealSense camera-only rig:** plug a D435, no arm.
+   ```
+   robot-md init scanrig --yes
+   ```
+   Manifest is LOW tier with `physics.cameras[0]` pre-filled and no arm
+   driver. TODO markers on `metadata.manufacturer` and `physics.dof`.
+
+4. **Template author flow:**
+   ```
+   cp -r examples/backend-template ~/foo
+   cd ~/foo && pip install -e . && pytest
+   ```
+   Entry-point registered, template tests pass with stub xfail.
+
+5. **describe-capabilities CLI:**
+   ```
+   robot-md describe-capabilities
+   robot-md describe-capabilities --json | jq '. | length'
+   ```
+   Shows three sections; JSON output has length 3.
+
+Each step's pass/fail goes in the commit message of the PR landing this plan.
+```
+
+- [ ] **Step 5: Commit (Task 35)**
+
+```bash
+git add cli/tests/hardware/test_sp3_lerobot_so_arm101_pick.py cli/tests/hardware/test_sp3_realsense_d435_perceive.py cli/tests/manual/sp3_adapter_smoke.md
+git commit -m "$(cat <<'EOF'
+test(sp3): hardware stubs (@pytest.mark.hardware) + manual smoke checklist
+
+LeRobot SO-ARM101 pick + RealSense D435 perceive — skipped in CI per
+existing conftest hardware-marker policy; runnable on bob via the
+project's hardware-suite invocation.
+
+Manual smoke covers the five operator-visible flows: lerobot install +
+init, two-backends-installed preset disambiguation, RealSense-only LOW
+tier, backend-template copy + install, and the describe-capabilities CLI.
+
+Co-Authored-By: Claude Opus 4.7 (1M context) <noreply@anthropic.com>
+EOF
+)"
+```
+
+---
+
+## Implementation Order Summary
+
+```
+Phase A — capability metadata foundation
+  1. capabilities.json (core schema)
+  2. capability tier validator
+  3. wire validator into discover_backends()
+  4. Capability dataclass + derive_namespace
+  5. describe_capabilities() default impl
+  6. BackendRegistry.iter_classes()
+  7. enumerate_capabilities(registry) walker
+  8. robot-md describe-capabilities CLI
+
+Phase B — RealSense backend (camera-only)
+  9. RealsenseBackend class skeleton
+ 10. open() with mocked pyrealsense2 pipeline
+ 11. perceive.rgb handler
+ 12. perceive.depth handler
+ 13. scene_describe()
+ 14. realsense.aligned_depth vendor cap
+ 15. lock no-arm contract
+
+Phase C — LeRobot backend (motion + camera)
+ 16. LerobotBackend skeleton + class-attr tests
+ 17. _build_lerobot_config(spec) for SO-ARM101
+ 18. open() with mocked make_robot
+ 19. arm.pick handler
+ 20. arm.place + arm.home handlers
+ 21. gripper.open + gripper.close handlers
+ 22. perceive.rgb + perceive.depth via capture_observation
+ 23. lerobot.teleop vendor cap
+ 24. lock unknown-cap + dry-run + schema-compliance contracts
+
+Phase D — wiring
+ 25. [hardware] / [lerobot] / [realsense] extras
+ 26. entry-point declarations for new backends
+ 27. SO-ARM presets prefer lerobot
+
+Phase E — authoring guide + template
+ 28. docs/authoring-a-backend.md
+ 29. examples/backend-template/ scaffold
+ 30. compile-check every Python block in the guide
+
+Phase F — integration + schema sync + hardware
+ 31. integration: init resolves SO-ARM101 → lerobot
+ 32. integration: RealSense-only rig → LOW tier
+ 33. integration: runtime backend dispatch
+ 34. schema sync (capabilities.json mirrors)
+ 35. hardware-test stubs + manual smoke checklist
+```
+
+---
+
+## Success Criteria
+
+SP3 is done when:
+
+- [ ] All 35 tasks are merged.
+- [ ] Test count: ~50+ unit tests across `cli/tests/backends/`, ~5 integration tests, 3 hardware tests (skipped in CI).
+- [ ] `robot-md describe-capabilities` lists all three backends + their capability metadata, both human-readable and `--json`.
+- [ ] `pip install 'cli[hardware]'` installs cleanly on Linux + macOS.
+- [ ] `feetech_depthai` ships green — no edits to its source; all its capabilities (core arm.* and vendor vision./status.) flow through the new tier validator and `describe_capabilities()` default unchanged.
+- [ ] Manual smoke checklist (`cli/tests/manual/sp3_adapter_smoke.md`) passes 5/5 on bob.
+- [ ] Hardware tests pass on bob (LeRobot SO-ARM101 pick + RealSense D435 perceive).
+- [ ] Demo dry-run: a stock SO-100 with `pip install 'robot-md[hardware]'` + `robot-md init` + `claude` → "find a red lego" → motion via LeRobot. End-to-end with no RRF-specific config.
+
+---
+
+## Notes for the implementer
+
+- **TDD discipline:** every code-producing task has its tests written FIRST and run-and-failed BEFORE the implementation. Don't skip the failure-verification step — it's how you know the test actually exercises the code path.
+- **`feetech_depthai` declares vision.describe + status.report** — these don't match `CORE_CAPABILITY_PREFIXES`. Both pass the vendor regex (look like `<vendor>.<name>`), so the validator accepts them. **Do not "fix" the prefix list** — it's RRF-canonical for core only.
+- **Mock the SDKs.** The `lerobot` and `pyrealsense2` packages are heavy / platform-specific. All tests in Phases B/C use `sys.modules` monkey-patching or `MagicMock` fixtures. Real-SDK paths run only in the hardware suite (Task 35).
+- **Per simplification-revisions Rev 6:** `preferred_backend` is preset-internal; never copied to operator-visible `ROBOT.md`. SP2's manifest writer should already drop it; if Task 31's integration test fails because the manifest has `preferred_backend:`, file a follow-up to fix the writer (don't paper over it in this plan).
+- **Each task ends with a commit.** Plan execution is incremental — at any point an external reviewer should be able to look at HEAD and understand what just landed.
+
+

--- a/docs/superpowers/specs/2026-04-26-sp3-sdk-adapter-pattern-design.md
+++ b/docs/superpowers/specs/2026-04-26-sp3-sdk-adapter-pattern-design.md
@@ -6,6 +6,13 @@
 
 > **REVISION 2026-04-27:** Several sections superseded by `2026-04-27-sp1-5-simplification-revisions.md` — Revision 3 specifically applies to SP3. Notably: add a `[hardware]` meta-extra that pulls all common backends in one install; granular `[lerobot]`/`[realsense]`/`[feetech-depthai]` extras stay for advanced/minimal installs.
 
+> **ADDENDUM 2026-04-27 — Capability Metadata.** SP3 also adds a transport-agnostic `Capability` dataclass + optional `describe_capabilities()` ABC method + module-level `enumerate_capabilities(registry)` walker. See [§ Capability Metadata Addendum](#capability-metadata-addendum-2026-04-27) below. This addendum is orthogonal to Revision 3 (`[hardware]` meta-extra) — both apply.
+
+> **See also:** companion specs to SP3 (not numbered in the SP1-5 sequence):
+> - `2026-04-27-sp-hp-hotplug-daemon-design.md` — runtime device hot-plug detection + manifest auto-merge.
+> - `2026-04-27-sp-an-announce-confirm-design.md` — operator-facing surfaces (audio/screen + Claude chat) for hot-plug events.
+> Both consume the metadata APIs introduced in this addendum.
+
 ## Problem
 
 `robot-md` has the `CapabilityBackend` ABC, the `robot_md.backends` entry-point group, and one reference implementation (`feetech_depthai`, ~1150 LoC). The runtime architecture is sound. What's missing is a *story* for how vendors (HuggingFace, Intel, Trossen, Pollen, etc.) ship their SDKs as `robot-md`-compatible backends — and how operators discover and install them. Today, owning a SO-100 with stock LeRobot tooling means there's no way to point Claude at it through `robot-md`. The runtime works, but the ecosystem doesn't yet.
@@ -580,6 +587,135 @@ SP3 is done when:
 - [ ] Authoring guide reviewed by one external robotics engineer; feedback incorporated.
 - [ ] Backend template scaffolds in <60 seconds end-to-end (`cp` + `pip install -e .` + `pytest`).
 - [ ] Demo dry-run: `pip install robot-md[lerobot]; robot-md init so100; claude; "find a red lego"` end-to-end on a stock SO-100 (no RRF-specific config).
+
+## Capability Metadata Addendum (2026-04-27)
+
+This addendum extends SP3 with a transport-agnostic capability metadata layer so future surfaces (the SP-HP hot-plug daemon, the SP-AN announce/confirm flow, and an eventual `robot-md-http` OpenAPI bridge) can introspect the capability catalog without each rewriting it. The original `capabilities() -> frozenset[str]` ABC method is **preserved unchanged** for backward compatibility; existing `feetech_depthai` ships green with no edits.
+
+### Why now
+
+Three downstream consumers need the same data:
+
+1. **MCP server tool registration** (today). Walks `BackendRegistry`, builds tool schemas. Currently has to look up arg shapes in `capabilities.json` itself.
+2. **SP-HP hot-plug daemon**. When a device hot-plug event resolves, the daemon needs to surface to operators "this backend would expose these capabilities" without instantiating the backend.
+3. **Future `robot-md-http` OpenAPI bridge**. The HTTP server needs the same metadata to generate an OpenAPI spec — same source of truth, no parallel definition.
+
+Without this addendum, each downstream rebuilds the lookup. With it, all three call one helper.
+
+### New public API
+
+#### `Capability` dataclass
+
+```python
+# cli/src/robot_md/backends/capability.py (NEW)
+# Re-exported from cli/src/robot_md/backends/__init__.py for stable import path.
+
+from __future__ import annotations
+from dataclasses import dataclass
+from typing import Literal
+
+@dataclass(frozen=True)
+class Capability:
+    name: str                        # e.g. "arm.pick", "lerobot.teleop"
+    namespace: Literal["core", "vendor"]
+    arg_schema: dict | None          # JSON-Schema fragment from capabilities.json, or None
+    description: str                 # short human-readable; "" if none available
+```
+
+`namespace` is derived from the prefix: `"core"` if `name` starts with one of `CORE_CAPABILITY_PREFIXES`; `"vendor"` if it matches the `<vendor>.<name>` pattern.
+
+#### `describe_capabilities()` — new optional ABC method
+
+Added to `CapabilityBackend` with a **concrete default implementation** (NOT abstract). Adapters MAY override.
+
+```python
+class CapabilityBackend(ABC):
+    # ... existing abstract methods unchanged ...
+
+    def describe_capabilities(self) -> list[Capability]:
+        """Return rich metadata for each capability this backend declares.
+
+        Default: walk self.capabilities(), look each up in
+        cli/src/robot_md/schemas/capabilities.json for arg_schema +
+        description; vendor capabilities not in the schema get
+        arg_schema=None, description="".
+
+        Adapters MAY override to provide richer vendor metadata
+        (e.g., lerobot.teleop description, dynamixel.indirect_address
+        arg shapes).
+        """
+        from robot_md.backends._capability_default import describe_default
+        return describe_default(self.name, self.capabilities())
+```
+
+#### `enumerate_capabilities(registry)` — module-level walker
+
+```python
+# cli/src/robot_md/backends/__init__.py
+
+def enumerate_capabilities(
+    registry: BackendRegistry,
+) -> list[tuple[str, Capability]]:
+    """Walk all registered backends, return (backend_name, Capability) pairs.
+
+    Used by:
+      - MCP server tool registration (build tool schemas)
+      - SP-HP daemon (preview backend's capabilities at hot-plug time)
+      - robot-md-http OpenAPI generator (future)
+    """
+    out: list[tuple[str, Capability]] = []
+    for backend_name, backend_cls in registry.iter_classes():
+        instance = backend_cls()
+        for cap in instance.describe_capabilities():
+            out.append((backend_name, cap))
+    return out
+```
+
+`registry.iter_classes()` is added to `BackendRegistry` (returns `(name, cls)` pairs without `open()`-ing instances). Existing `resolve()` path is untouched.
+
+### Default-impl behavior — explicit cases
+
+| Capability case | `arg_schema` | `description` |
+|---|---|---|
+| Core (`arm.pick` etc.) listed in `capabilities.json` | the schema fragment | schema's `description` field if present, else `""` |
+| Core capability NOT in `capabilities.json` (drift) | `None` | `""` — and tier validator already warns about this |
+| Vendor capability (`lerobot.teleop`) not in `capabilities.json` | `None` | `""` — adapter author overrides `describe_capabilities()` to fill in |
+| Vendor capability where adapter overrides | adapter's value | adapter's value |
+
+Vendor capabilities are deliberately NOT required to be in `capabilities.json` (which is RRF-canonical for core only). Vendors fill in their own arg shapes via override.
+
+### Backward compatibility
+
+| Existing code | Behavior with addendum |
+|---|---|
+| `feetech_depthai`'s `capabilities()` returning `frozenset[str]` | Unchanged. `describe_capabilities()` default returns `Capability` objects with arg_schemas pulled from `capabilities.json`. |
+| Third-party adapter that has not opted in | Same. Default `describe_capabilities()` works. |
+| MCP server's existing tool registration code path | Migrates to `enumerate_capabilities()`; output shape compatible (backend_name, name, arg_schema). |
+
+Net code addition: ~120 LoC across `base.py`, `__init__.py`, `_capability_default.py`, plus tests.
+
+### Files affected by the addendum
+
+- `cli/src/robot_md/backends/base.py` — add `Capability` dataclass + `describe_capabilities()` default method.
+- `cli/src/robot_md/backends/__init__.py` — re-export `Capability` + `enumerate_capabilities`; expose `BackendRegistry.iter_classes()`.
+- `cli/src/robot_md/backends/_capability_default.py` (NEW) — `describe_default(backend_name, caps)` helper that loads `capabilities.json` + builds `Capability` objects.
+- `cli/src/robot_md/mcp/server.py` (or wherever tools are registered) — migrate to `enumerate_capabilities()`. No behavior change, single source of truth.
+- `cli/tests/backends/test_capability_metadata.py` (NEW) — unit tests:
+  - `test_describe_default_core_with_schema` — `arm.pick` → arg_schema present.
+  - `test_describe_default_vendor_no_schema` — `lerobot.teleop` → arg_schema=None.
+  - `test_describe_default_namespace_derived` — `arm.*` → "core"; `lerobot.*` → "vendor".
+  - `test_enumerate_capabilities_walks_registry` — two backends → all pairs returned.
+  - `test_describe_capabilities_override_wins` — adapter's override overrides default.
+  - `test_existing_capabilities_method_unchanged` — `feetech_depthai.capabilities()` still returns same frozenset.
+- `cli/tests/integration/test_mcp_tool_registration_uses_enumerate.py` (NEW) — integration test that MCP server tool list matches `enumerate_capabilities()` output.
+
+### Net effect on SP3 success criteria
+
+Addendum adds: "✓ `enumerate_capabilities()` returns the same data MCP server uses for tool registration; `describe_capabilities()` default works for all in-tree backends without override."
+
+Estimated size: SP3 grows ~10–15% over the original spec — small price to avoid the same refactor when the future HTTP bridge lands.
+
+---
 
 ## Sub-project Relationships
 

--- a/docs/superpowers/specs/2026-04-27-sp-an-announce-confirm-design.md
+++ b/docs/superpowers/specs/2026-04-27-sp-an-announce-confirm-design.md
@@ -14,45 +14,42 @@ SP-AN is the operator-facing layer on top of SP-HP — the announce + confirm su
 
 ## Scope
 
-**In scope:**
+**In scope (v1):**
 - **Claude-chat surface.** Whenever a Claude session is active (MCP server connected), pending events surface in two ways:
   - Proactive: on session connect or on socket-nudge, Claude is informed via the existing `notifications/tools/list_changed` plus a new `notifications/resources/updated` for the queue resource. Claude's `using-robot-md` skill text instructs it to call `hotplug_review` and surface pending events to the operator inline.
   - Reactive: operator can ask "any new hardware?" → Claude calls `hotplug_review`.
-- **Audio onboarding announcement** for HIGH-tier auto-binds. When the daemon writes a `bind` resolution, the MCP server (next session connect) reads the audit-log entry and surfaces the bind to Claude with a "tell the operator" hint. Audio is rendered by Claude's existing voice surface (when the operator is in voice mode); falls back to text otherwise. **No separate TTS engine is shipped by SP-AN** — we ride on Claude's voice mode.
-- **Pendant screen surface** (when the operator's robot-md-pendant is attached AND a Claude session is active). The pendant subscribes via MCP notifications routed through Claude. Pending events appear on the pendant's status panel; the pendant's existing buttons drive `hotplug_confirm`.
-- **State model: pending → resolved (`bind | reject | expired`).** Both surfaces (Claude + pendant) read the same queue and both can act on it. The daemon (SP-HP) is the **single writer**. First surface to call `hotplug_confirm` wins; the other shows "(resolved on pendant)" or "(resolved by Claude)" on next refresh.
-- **One new MCP server-side resource:** `robot-md://hotplug/pending` (URI). Subscribers get `notifications/resources/updated` on socket nudge or queue change.
-- **Skill-text additions** to `using-robot-md.SKILL.md`: instructions for Claude on how to surface pending events without being asked, including the "audio first, screen if available" hierarchy.
+- **Audio onboarding announcement** for HIGH-tier auto-binds. When the daemon writes a `bind` resolution, the MCP server (next session connect or socket-nudge) reads the audit-log entry and surfaces the bind to Claude with a "tell the operator" hint. Audio is rendered by Claude's existing voice surface (when the operator is in voice mode); falls back to text otherwise. **No separate TTS engine is shipped by SP-AN** — we ride on Claude's voice mode.
+- **State model: `pending → resolved (bind | reject | expired)`.** v1 has a single operator-acting surface (Claude); the daemon (SP-HP) is the **single writer** of the queue; the resolution-race semantics are still implemented end-to-end so the queue contract is correct from day one. (Future surfaces — pendant, web UI — slot in without queue-shape changes.)
+- **One new MCP server-side resource:** `robot-md://hotplug/pending` (URI). Subscribers get `notifications/resources/updated` on socket-nudge or queue change.
+- **Skill-text additions** to `using-robot-md.SKILL.md`: instructions for Claude on how to surface pending events without being asked, including the audio-first / text-fallback hierarchy and the resolution flow.
 
-**Out of scope** (v1 limitations or follow-ups):
-- **Pendant subscription without an active Claude session.** Pendant subscribes via MCP notifications routed through Claude's session. No Claude session = pendant doesn't see live events. Events still queue (SP-HP) and surface on next Claude connect. Future work: pendant hosts its own socket subscriber. **Called out as a known v1 limitation in this spec; not fixed.**
+**Out of scope (deferred to SP-AN v2):**
+- **Pendant screen surface.** Originally co-scoped with v1, **deferred** because the pendant repo (`robot-md-pendant`) is in early bring-up — there's no MCP-client subscriber on `pendantd`, the `pendant-mcp` server itself is only introduced by the separate `2026-04-25-voice-host-audio-design.md` spec, and pendant hardware bring-up is blocked on the stuck BOOT button. v2 SP-AN will add a pendant-mcp tool (`pendant_set_pending_panel`) + a pending-events panel in pendantd's renderer + the explicit dependency on pendant-mcp landing.
 - **Standalone TTS / SP-AN-owned audio engine.** Audio rides on Claude's voice mode.
-- **Multi-pendant rigs.** Single pendant assumed.
 - **Cross-host event sync.** Inherited from SP-HP's out-of-scope list.
 - **Persistent operator preferences for tier-based prompting.** v1 uses SP-HP's tier policy as-is. Future: per-RRN "always confirm even on HIGH" preference.
+- **Manifest unbind tool.** A reject-after-HIGH-tier-auto-bind logs intent only; manifest hand-edit remains the operator's path. v2 will add `hotplug_unbind` complementing `hotplug_confirm` once driver-dependency + safety semantics are designed.
+- **Web UI surface.** Out of scope.
 
 ## Design
 
 ### Architecture
 
-Three operator-facing surfaces, all subscribers of SP-HP's queue + manifest. SP-AN ships as additions to existing components — not a new long-running process.
+Two operator-facing surfaces in v1, both driven by the MCP server. SP-AN ships as additions to existing components — not a new long-running process.
 
 1. **Claude chat surface** (lives in the MCP server + skill text). Claude is informed of pending events via two MCP primitives: `notifications/tools/list_changed` (already wired in SP-HP for newly bound capabilities) and a new `notifications/resources/updated` for the `robot-md://hotplug/pending` resource. Claude's skill text tells it what to do on each.
-2. **Audio announcement surface** (skill text only, no new code). When the MCP server detects a recent `hotplug_bind` audit-log entry on session connect (or via the socket nudge), it informs Claude via the same resource update. Skill text instructs Claude to announce the bind to the operator using its current modality (voice if active, text otherwise).
-3. **Pendant screen surface** (lives in the pendant's existing renderer). The pendant already polls the MCP session for status via the existing `pendant_status` tool. SP-AN extends `pendant_status` to include `pending_hotplug_events`. The pendant's display routine adds a "Pending hardware" panel + a "Confirm / Reject" button mapping.
+2. **Audio announcement surface** (skill text only, no new code). When the MCP server detects a recent `hotplug_bind` audit-log entry on session connect (or via the socket-nudge), it informs Claude via the same resource update. Skill text instructs Claude to announce the bind to the operator using its current modality (voice if active, text otherwise).
 
-Net new code is small (~200 LoC across server + pendant). Most SP-AN value is in the skill text + the resource subscription.
+Net new code is small (~120 LoC in the MCP server, plus skill-text additions). Most SP-AN value is in the skill text + the resource subscription.
 
 #### Channel-availability matrix
 
-| Channel state | Claude session active | Pendant attached | Visible event surfaces |
-|---|---|---|---|
-| Both available | yes | yes | Claude chat (proactive announce) + pendant screen |
-| Claude only | yes | no | Claude chat only |
-| Pendant only | no | yes | **none in v1** (limitation) |
-| Neither | no | no | Events queue durably (SP-HP); surface on next connect |
+| Claude session active | Visible event surface |
+|---|---|
+| yes | Claude chat (proactive announce on tier=HIGH; reactive review on operator ask) |
+| no | Events queue durably (SP-HP); surface on next Claude connect |
 
-The "Pendant only, no Claude" cell is the v1 limitation. The pendant doesn't have an independent socket subscriber yet.
+The "no Claude session" case is what makes SP-HP's durable queue load-bearing — events aren't lost; they wait.
 
 ### Components
 
@@ -67,8 +64,8 @@ URI = "robot-md://hotplug/pending"
 def hotplug_pending_resource(ctx) -> Resource:
     """Read-only view over the pending hot-plug events.
 
-    Subscribers receive notifications/resources/updated on socket nudge
-    or file-poll detected change.
+    Subscribers receive notifications/resources/updated on socket-nudge
+    or file-poll-detected change.
     """
     pending = read_pending_from_queue()  # uses SP-HP's queue.py
     return Resource(
@@ -82,7 +79,7 @@ Why a resource rather than a tool: resources support subscription and `notificat
 
 #### 2. Skill-text additions to `using-robot-md.SKILL.md`
 
-Three new sections (per the Revision 7 canonical-source rule, edited only in `~/robot-md-mcp/skills/using-robot-md/SKILL.md`):
+Three new sections (per the SP1 simplification-revisions Revision 7 canonical-source rule, edited only in `~/robot-md-mcp/skills/using-robot-md/SKILL.md`):
 
 ```markdown
 ## Reacting to hot-plug events
@@ -114,53 +111,17 @@ If the operator is in voice mode, **announce by voice first**, then mirror
 the same text to the chat. If the operator is in text mode, write to the
 chat only.
 
-If a pendant is attached (visible via `pendant_status`), the pendant will
-ALSO show the pending event independently. Don't assume the operator
-needs you to read aloud what they can already see; do mention "you can
-also confirm on the pendant."
-
 ## Resolved-elsewhere handling
 
 If you call `hotplug_confirm` and get back `already_resolved`, the
-operator confirmed it on the pendant first. Tell them you saw it
-("Got it — I see {decision} happened on the pendant.") and move on.
+operator confirmed it via another path (e.g., `robot-md hotplug confirm`
+from a terminal, or — in the future — a pendant). Tell them you saw it
+("Got it — I see {decision} happened from the terminal.") and move on.
 ```
 
 The skill text is a contract: it's how Claude turns the resource update into the announce-confirm flow.
 
-#### 3. Pendant: `pending_hotplug_events` panel
-
-```python
-# pendant repo: pendant/src/views/status.py (extend existing)
-
-def render_status(state: PendantState) -> Frame:
-    panels = [...]
-    if state.pending_hotplug_events:
-        panels.append(_render_pending_panel(state.pending_hotplug_events))
-    return Frame(panels=panels)
-
-def _render_pending_panel(events: list[PendingEventSummary]) -> Panel:
-    top = events[0]  # one-at-a-time UX; queue depth shown as "+N more"
-    return Panel(
-        title=f"NEW HARDWARE ({len(events)} pending)" if len(events) > 1
-              else "NEW HARDWARE",
-        body=[
-            f"{top.preset_name or top.transport} on {top.port}",
-            f"Tier: {top.tier}",
-            f"Bind as {top.bind_proposal.backend_name}? (button A)",
-            "Reject (button B)  •  Skip to next (button C)",
-        ],
-    )
-```
-
-Pendant's existing button-handler wires:
-- A → `mcp_call("hotplug_confirm", {event_id, decision: "bind"})`
-- B → `mcp_call("hotplug_confirm", {event_id, decision: "reject"})`
-- C → cycle to next event in `pending_hotplug_events`
-
-The pendant **does not** subscribe to the daemon's socket directly in v1 — it relies on the MCP session's `pending_hotplug_events` value being refreshed by the server (which is itself a subscriber of the socket nudge / file-poll). One transport hop adds ≤2 s of latency, acceptable for v1.
-
-#### 4. Audio announce — no new code, just skill-text
+#### 3. Audio announce — no new code, just skill-text
 
 Audio rides on Claude's voice mode entirely. SP-AN does NOT ship a TTS engine, an audio device manager, or a separate speech subsystem. The "audio onboarding moment" is the operator being in voice mode + Claude reading the announce text. If Claude is in text mode, the same announcement appears in chat.
 
@@ -202,17 +163,14 @@ Operator: "Undo."                    →  Claude calls
                                         driver?"
 ```
 
-#### MEDIUM-tier event: text-mode operator with pendant
+#### MEDIUM-tier event: text-mode operator
 
 ```
 (Generic feetech bus chip plug.     →  Daemon classifies tier=MEDIUM.
- Operator in text mode. Pendant         queue.append_pending(...)
- attached.)                             socket nudge.
+ Operator in text mode.)                queue.append_pending(...)
+                                        socket nudge.
 
 (MCP server)                        →  Resource update emitted.
-                                        Pendant's next pendant_status call
-                                        gets pending_hotplug_events
-                                        populated.
 
 (Claude, text mode)                 →  Skill text: surface the pending
                                         event in chat:
@@ -223,23 +181,21 @@ Operator: "Undo."                    →  Claude calls
                                              likely)
                                           2. koch_arm + lerobot
                                           3. so_arm101 + feetech_depthai
-                                        Or reject. The pendant is also
-                                        showing this. Which?"
+                                        Or reject. Which?"
 
-(Operator presses pendant button A) →  Pendant calls hotplug_confirm.
-                                        Daemon merges manifest.
-                                        Resolution=bind appended.
-                                        socket nudge.
+Operator: "Bind it as so_arm101."   →  Claude calls
+                                        hotplug_confirm(event_id, "bind",
+                                                        choice_index=0).
+                                        Daemon merges manifest, appends
+                                        resolution=bind to queue, appends
+                                        hotplug_bind to audit.
+                                        socket nudge → MCP reloads spec.
 
-(MCP server next refresh)           →  Resource updated. Claude sees
-                                        already_resolved on its next
-                                        check.
-                                        Claude (next message):
-                                        "Got it — I see the pendant just
-                                        bound it as so_arm101 + lerobot."
+(Claude, next message)              →  "Done — bound. The manifest now
+                                        has the new driver."
 ```
 
-#### LOW-tier: voice-mode operator, no pendant, unknown hardware
+#### LOW-tier: voice-mode operator, unknown hardware
 
 ```
 (Unknown VID:PID, no preset match.) →  Daemon: tier=LOW, queue.append.
@@ -261,51 +217,25 @@ Operator: "Try it."                 →  Claude triggers SP4's
                                         event doesn't keep nagging.
 ```
 
-#### Resolved-elsewhere race
+#### Resolved-elsewhere (terminal CLI)
 
 ```
-(Both Claude and pendant see the    →  Both call hotplug_confirm.
- same MEDIUM event.)                    Daemon serializes via socket
-                                        listener fcntl lock.
-
-(Pendant gets there first.)         →  Daemon writes resolution=bind,
-                                        by="pendant".
+(Operator runs `robot-md hotplug    →  CLI calls back to daemon over the
+ confirm <event_id> --bind` from a      socket; daemon serializes via
+ terminal while a Claude session        fcntl lock; writes resolution=bind,
+ is also open.)                         by="cli".
                                         socket nudge.
 
-(Claude's call arrives second.)     →  Daemon: already_resolved.
-                                        Returns {ok: false,
-                                                 reason: "already_resolved",
-                                                 by: "pendant"}.
-
-(Claude, text or voice)             →  Skill text: "Looks like the
-                                        pendant just confirmed it as
-                                        so_arm101 + lerobot. Done."
+(Claude session learns)             →  Resource update fires; Claude's
+                                        next call to hotplug_review shows
+                                        no pending (or fewer pending).
+                                        On next operator interaction:
+                                        "I see you confirmed the
+                                        SO-ARM101 from the terminal.
+                                        Done."
 ```
 
-#### v1 limitation: no Claude session, pendant only
-
-```
-(No Claude session running.         →  SP-HP daemon queues events.
- Pendant attached, idle.)               No socket subscriber → MCP server
-                                        is the only would-be subscriber,
-                                        and it's not running.
-
-                                        Pendant has no path to see the
-                                        event in v1.
-                                        Pendant's status panel shows
-                                        normal status; pending events
-                                        are invisible until a Claude
-                                        session opens.
-
-(Operator opens Claude later.)      →  MCP server connects, drains
-                                        queue, gets all pending events,
-                                        surfaces them. Pendant's next
-                                        pendant_status call now shows
-                                        them too.
-```
-
-This is the explicit v1 limitation. Future work: pendant gains an
-independent socket subscriber.
+This race-handling exists in v1 even though the only other channel today is the CLI. The contract is correct from day one; pendant in v2 plugs into the same resolution path.
 
 ### Error Handling
 
@@ -314,35 +244,32 @@ independent socket subscriber.
 | Failure | Where caught | Operator sees |
 |---|---|---|
 | `notifications/resources/updated` not delivered (Claude session dropped mid-write) | MCP server next reconnect | On reconnect, MCP server emits a fresh resource update for any pending events; Claude surfaces them on next message. |
-| Pendant's `pendant_status` call fails | Pendant existing handler | Pendant retries; existing pendant offline/online icon flips. SP-AN doesn't add new failure UI. |
 | Operator's "undo" arrives after the 30 s window | Claude skill text | Claude still passes through `hotplug_confirm({decision:"reject"})`; daemon appends the rejection record (manifest stays bound; audit trail captures intent). Claude tells the operator "the manifest is already bound; want me to help unbind by hand?" |
 | Audio announcement attempted but operator is muted | Claude voice mode | Falls through to text rendering (Claude's existing behavior). Skill text doesn't need special handling. |
-| `hotplug_confirm` call from Claude/pendant returns `already_resolved` | Each surface | Both surfaces show "(resolved on \<other surface\>)" on next refresh — no error to operator. |
+| `hotplug_confirm` call from Claude returns `already_resolved` | Claude skill text | Claude says "(resolved on \<other surface\>)" on next message. No error to operator. |
 
 #### (b) Pass-through
 
 | Failure | Surface |
 |---|---|
 | Claude voice mode failure (TTS audio device unavailable) | Existing Claude behavior — falls back to text. SP-AN does nothing extra. |
-| Pendant disconnects mid-confirm | Pendant's existing reconnect logic handles. The daemon's resolution record is the source of truth. |
 | Daemon down at the time of operator confirmation | `hotplug_confirm` call from MCP server fails with `daemon_unreachable`. Claude tells the operator to start the daemon (`robot-md hotplug-daemon start`). |
 
 #### (c) Edge cases — defensive handling
 
 | Edge case | Defense |
 |---|---|
-| Operator confirms via pendant, then says "undo" to Claude | Daemon already wrote `resolved: bind`. Claude responds "the pendant already bound it; the manifest now has the driver. Want me to help unbind by hand?" — no quiet retry. |
 | Two pending events at once, voice mode | Skill text instructs Claude to handle them sequentially: announce the highest-tier first; queue the rest as "I have N more pending." |
 | Operator dismisses an event by saying "later" | Claude takes no action (no `hotplug_confirm` called). The pending record stays in the queue until the TTL elapses (SP-HP's 7-day default). |
-| Pendant shows stale events (subscription lag) | Pendant's `pendant_status` call returns the latest server-side snapshot on each tick; staleness window ≤2 s. Acceptable. |
-| Skill text drift between robot-md-mcp and CLI copies | Revision 7 sync script + CI check (existing in SP1). SP-AN editor edits the canonical copy; sync handles propagation. |
+| Operator confirms via terminal mid-session, then says "undo" to Claude | Daemon already wrote `resolved: bind`. Claude responds "the terminal already bound it; the manifest now has the driver. Want me to help unbind by hand?" — no quiet retry. |
+| Skill text drift between robot-md-mcp and CLI copies | SP1 simplification-revisions Revision 7 sync script + CI check (existing). SP-AN editor edits the canonical copy; sync handles propagation. |
 
 #### Explicit non-goals
 
 - **Background TTS engine.** Voice rides on Claude's existing voice mode.
 - **Operator preferences UI** (e.g., "always confirm even on HIGH"). v1 uses SP-HP's tier policy. Custom preferences land as a follow-up.
-- **Multi-channel arbitration beyond pendant + Claude.** Other surfaces (web UI, OS notifications) deferred.
-- **Manifest unbind tool.** Reject after a HIGH-tier auto-bind logs intent only; manifest hand-edit remains the operator's path. Future work: `hotplug_unbind` tool that mirrors `hotplug_confirm` but for removal.
+- **Multi-channel arbitration beyond Claude + CLI in v1.** Pendant + web UI deferred.
+- **Manifest unbind tool.** Reject after a HIGH-tier auto-bind logs intent only; manifest hand-edit remains the operator's path. v2 work.
 
 ### Testing
 
@@ -351,7 +278,7 @@ independent socket subscriber.
 | Test | Verifies |
 |---|---|
 | `test_hotplug_pending_resource_lists_pending.py` (NEW) | Resource read returns all pending events; resolved events excluded. |
-| `test_hotplug_pending_resource_emits_updated_on_nudge.py` (NEW) | Daemon socket nudge → MCP server emits `notifications/resources/updated` for the URI. |
+| `test_hotplug_pending_resource_emits_updated_on_nudge.py` (NEW) | Daemon socket-nudge → MCP server emits `notifications/resources/updated` for the URI. |
 | `test_hotplug_pending_resource_emits_updated_on_file_poll.py` (NEW) | File-poll path (no socket) → same notification within 2 s of queue change. |
 | `test_hotplug_pending_resource_subscribers_only_get_changes.py` (NEW) | Two clients subscribed; one client gets `updated` for the change it caused (no infinite loops). |
 
@@ -363,50 +290,39 @@ independent socket subscriber.
 | `test_skill_undo_within_window_calls_reject.py` (NEW) | Same as above; operator says "undo" within 30 s → Claude calls `hotplug_confirm("reject")`. |
 | `test_skill_undo_after_window_warns_manifest_bound.py` (NEW) | Operator says "undo" 60 s later → Claude still calls reject AND tells operator manifest stays bound. |
 | `test_skill_medium_tier_surfaces_alternatives.py` (NEW) | MEDIUM event → Claude's response lists top-3 alternatives + asks operator. |
-| `test_skill_resolved_elsewhere_acknowledges.py` (NEW) | `hotplug_confirm` returns `already_resolved` → Claude says "I see {decision} happened on {by}". |
-
-#### Pendant integration
-
-| Test | Verifies |
-|---|---|
-| `test_pendant_status_includes_pending_events.py` (NEW) | Mock daemon with 2 pending events → pendant's `pendant_status` payload includes them. |
-| `test_pendant_button_a_calls_confirm_bind.py` (NEW) | Press A → mocked MCP call invokes `hotplug_confirm({decision:"bind"})`. |
-| `test_pendant_button_b_calls_confirm_reject.py` (NEW) | Press B → invokes `hotplug_confirm({decision:"reject"})`. |
-| `test_pendant_button_c_cycles_events.py` (NEW) | With 2 pending → C → display advances to event 2. |
-| `test_pendant_panel_omitted_when_no_pending.py` (NEW) | Empty queue → panel not rendered. |
+| `test_skill_resolved_elsewhere_acknowledges.py` (NEW) | `hotplug_confirm` returns `already_resolved` → Claude says "I see {decision} happened from {by}". |
 
 #### Manual smoke checklist — `cli/tests/manual/span_smoke.md`
 
 1. **Voice-mode HIGH-tier auto-bind.** Replug SO-ARM101 on bob with operator in Claude voice mode; verify Claude's first audio response is the announce string within 5 s of the plug click.
 2. **Voice-mode undo within window.** Same as #1; operator says "undo" within 30 s; verify rejection record appears in queue.
 3. **Voice-mode undo after window.** Same as #1; operator says "undo" 60 s later; verify Claude warns manifest is bound.
-4. **Text-mode MEDIUM with pendant.** Plug generic feetech bus; verify Claude chat surfaces alternatives + pendant shows the pending panel; press pendant button A; verify Claude acknowledges in next message ("the pendant just bound it...").
-5. **No-Claude-session pendant invisibility.** With no Claude session running, plug a device. Verify pendant does NOT show the pending event (v1 limitation behaving as documented).
-6. **Resolved-elsewhere race.** Two Claude sessions + pendant all see the same MEDIUM event; one acts; verify the others get `already_resolved` and acknowledge cleanly.
+4. **Text-mode MEDIUM event.** Plug generic feetech bus; verify Claude chat surfaces alternatives; operator picks one; verify manifest updates.
+5. **No-Claude-session durability.** With no Claude session running, plug a device. Verify queue grows. Open Claude later; verify event surfaces on connect.
+6. **Resolved-elsewhere via terminal CLI.** Have a Claude session open; in another shell run `robot-md hotplug confirm <id> --bind`; verify Claude's next interaction acknowledges cleanly.
 
 #### Coverage gaps acknowledged
 
 - Voice-mode tests are the hardest to automate. Skill-text tests use a sandboxed harness; real voice-mode behavior tested by hand.
-- Pendant tests assume the existing pendant codebase compiles and runs; SP-AN doesn't include pendant-runtime CI changes beyond the new panel test.
 - `notifications/resources/updated` is a relatively new MCP feature; client-side rendering varies. Skill text targets the MCP-spec-compliant path; non-Claude clients may not surface resource updates.
 
-## Open Questions
+## Decisions deferred / future work
 
 1. **Undo window length.** 30 s default. Long enough to react after a voice announce; short enough to not silently linger. Roll back to 15 s if operators report the manifest "feels editable for too long."
-2. **Manifest unbind tool.** Should v1 include a `hotplug_unbind` complement to handle the reject-after-HIGH case cleanly? **Decision: defer to v2** — the v1 path (Claude offers to help hand-edit) is acceptable for the demo, and the unbind semantics deserve their own design pass (driver dependencies, safety).
-3. **Pendant independent subscriber.** The v1 limitation (pendant requires Claude session) is the most-likely future complaint. Tracked as the SP-AN v2 headline item.
+2. **Pendant screen surface (SP-AN v2).** Defer until pendant-mcp lands (per `2026-04-25-voice-host-audio-design.md`) AND pendant hardware bring-up unblocks. v2 will add a pendant-mcp tool (`pendant_set_pending_panel`) + a pending-events panel in pendantd's renderer; the queue's resolution-race contract is already implemented in v1, so pendant slots in without queue-shape changes.
+3. **Manifest unbind tool (`hotplug_unbind`).** v2 work after driver-dependency + safety semantics are designed. v1 path: Claude offers to help hand-edit ROBOT.md.
+4. **Independent pendant subscriber (no Claude session).** Future SP-AN v2+ work — pendantd hosts its own socket subscriber to the daemon. Removes the "no Claude session = pendant blind" limitation entirely.
 
 ## Success Criteria
 
-SP-AN is done when:
+SP-AN v1 is done when:
 
-- [ ] `robot-md://hotplug/pending` resource implemented + tested; resource updates fire on nudge and on file-poll.
+- [ ] `robot-md://hotplug/pending` resource implemented + tested; resource updates fire on socket-nudge and on file-poll.
 - [ ] Skill-text additions land in the canonical `using-robot-md.SKILL.md`; sync script propagates.
-- [ ] Pendant gains the pending-events panel + button bindings; existing pendant tests still pass.
-- [ ] All unit + integration tests pass (resource subscription + skill harness + pendant render).
+- [ ] All unit + integration tests pass (resource subscription + skill harness).
 - [ ] Manual smoke checklist passes 6/6 on bob with the SO-ARM101 + a generic feetech bus chip.
 - [ ] Demo dry-run: operator in voice mode, no display attached; replug SO-ARM101; Claude announces the bind audibly within 5 s; operator says "looks good"; conversation continues. **This is the headline auto-onboard moment.**
-- [ ] v1 limitation (pendant requires Claude session) documented in `using-robot-md.SKILL.md` and in `cli/docs/hotplug-limitations.md`.
+- [ ] v2 pendant integration is documented as future work in `using-robot-md.SKILL.md` and in `cli/docs/hotplug-roadmap.md`.
 
 ## Sub-project Relationships
 
@@ -414,4 +330,5 @@ SP-AN is done when:
 - **SP3 → SP-AN.** SP-AN's "what tools just appeared" surfacing uses SP3's `enumerate_capabilities()` to enrich the announce with "you can now use {tool list}."
 - **SP-AN ↔ SP1.** SP-AN's resource + skill-text additions land in the existing SP1 MCP server. No SP1 architecture changes.
 - **SP-AN ↔ SP4.** SP-AN's LOW-tier path can offer to trigger SP4's `author-backend`. SP-AN itself does not own that flow.
-- **SP-AN delivers the auto-onboard demo moment.** Combined with SP-HP, the headline pitch beat: *robot reboots, no display, audio onboarding, Claude announces "Found a SO-ARM101, binding it. Say 'undo' to reject" — operator nods, conversation continues.* SP-AN is the mouth of the system; SP-HP is the eyes.
+- **SP-AN v1 delivers the auto-onboard demo moment via Claude.** Combined with SP-HP, the headline pitch beat: *robot reboots, no display, audio onboarding, Claude announces "Found a SO-ARM101, binding it. Say 'undo' to reject" — operator nods, conversation continues.* SP-AN is the mouth of the system; SP-HP is the eyes.
+- **SP-AN v2 → robot-md-pendant.** When the pendant hardware ships and pendant-mcp lands, v2 SP-AN extends the same queue-contract to a third surface (pendant screen). No v1 queue-shape changes required.

--- a/docs/superpowers/specs/2026-04-27-sp-an-announce-confirm-design.md
+++ b/docs/superpowers/specs/2026-04-27-sp-an-announce-confirm-design.md
@@ -1,0 +1,417 @@
+# SP-AN — Hot-Plug Announce + Confirm Surfaces
+
+**Date:** 2026-04-27
+**Status:** Design — pending implementation plan
+**Sub-project:** Companion to SP3 (not numbered in the SP1-5 sequence)
+**Depends on:** SP-HP (`2026-04-27-sp-hp-hotplug-daemon-design.md`) — provides the event queue, manifest merge API, and MCP-server tools.
+**Companion to:** SP3 (`2026-04-26-sp3-sdk-adapter-pattern-design.md`).
+
+## Problem
+
+SP-HP produces a durable queue of hot-plug events. Without SP-AN, the operator has to *check* the queue manually (`robot-md hotplug review` from a terminal). That works, but it's the wrong shape for the headline demo: *the robot rebooted, you didn't open a terminal, you have no display, just audio in/out, and Claude says "Found a SO-ARM101 — should I bind it?"*
+
+SP-AN is the operator-facing layer on top of SP-HP — the announce + confirm surfaces that turn a queued event into a moment the operator perceives and can act on, with their hands free.
+
+## Scope
+
+**In scope:**
+- **Claude-chat surface.** Whenever a Claude session is active (MCP server connected), pending events surface in two ways:
+  - Proactive: on session connect or on socket-nudge, Claude is informed via the existing `notifications/tools/list_changed` plus a new `notifications/resources/updated` for the queue resource. Claude's `using-robot-md` skill text instructs it to call `hotplug_review` and surface pending events to the operator inline.
+  - Reactive: operator can ask "any new hardware?" → Claude calls `hotplug_review`.
+- **Audio onboarding announcement** for HIGH-tier auto-binds. When the daemon writes a `bind` resolution, the MCP server (next session connect) reads the audit-log entry and surfaces the bind to Claude with a "tell the operator" hint. Audio is rendered by Claude's existing voice surface (when the operator is in voice mode); falls back to text otherwise. **No separate TTS engine is shipped by SP-AN** — we ride on Claude's voice mode.
+- **Pendant screen surface** (when the operator's robot-md-pendant is attached AND a Claude session is active). The pendant subscribes via MCP notifications routed through Claude. Pending events appear on the pendant's status panel; the pendant's existing buttons drive `hotplug_confirm`.
+- **State model: pending → resolved (`bind | reject | expired`).** Both surfaces (Claude + pendant) read the same queue and both can act on it. The daemon (SP-HP) is the **single writer**. First surface to call `hotplug_confirm` wins; the other shows "(resolved on pendant)" or "(resolved by Claude)" on next refresh.
+- **One new MCP server-side resource:** `robot-md://hotplug/pending` (URI). Subscribers get `notifications/resources/updated` on socket nudge or queue change.
+- **Skill-text additions** to `using-robot-md.SKILL.md`: instructions for Claude on how to surface pending events without being asked, including the "audio first, screen if available" hierarchy.
+
+**Out of scope** (v1 limitations or follow-ups):
+- **Pendant subscription without an active Claude session.** Pendant subscribes via MCP notifications routed through Claude's session. No Claude session = pendant doesn't see live events. Events still queue (SP-HP) and surface on next Claude connect. Future work: pendant hosts its own socket subscriber. **Called out as a known v1 limitation in this spec; not fixed.**
+- **Standalone TTS / SP-AN-owned audio engine.** Audio rides on Claude's voice mode.
+- **Multi-pendant rigs.** Single pendant assumed.
+- **Cross-host event sync.** Inherited from SP-HP's out-of-scope list.
+- **Persistent operator preferences for tier-based prompting.** v1 uses SP-HP's tier policy as-is. Future: per-RRN "always confirm even on HIGH" preference.
+
+## Design
+
+### Architecture
+
+Three operator-facing surfaces, all subscribers of SP-HP's queue + manifest. SP-AN ships as additions to existing components — not a new long-running process.
+
+1. **Claude chat surface** (lives in the MCP server + skill text). Claude is informed of pending events via two MCP primitives: `notifications/tools/list_changed` (already wired in SP-HP for newly bound capabilities) and a new `notifications/resources/updated` for the `robot-md://hotplug/pending` resource. Claude's skill text tells it what to do on each.
+2. **Audio announcement surface** (skill text only, no new code). When the MCP server detects a recent `hotplug_bind` audit-log entry on session connect (or via the socket nudge), it informs Claude via the same resource update. Skill text instructs Claude to announce the bind to the operator using its current modality (voice if active, text otherwise).
+3. **Pendant screen surface** (lives in the pendant's existing renderer). The pendant already polls the MCP session for status via the existing `pendant_status` tool. SP-AN extends `pendant_status` to include `pending_hotplug_events`. The pendant's display routine adds a "Pending hardware" panel + a "Confirm / Reject" button mapping.
+
+Net new code is small (~200 LoC across server + pendant). Most SP-AN value is in the skill text + the resource subscription.
+
+#### Channel-availability matrix
+
+| Channel state | Claude session active | Pendant attached | Visible event surfaces |
+|---|---|---|---|
+| Both available | yes | yes | Claude chat (proactive announce) + pendant screen |
+| Claude only | yes | no | Claude chat only |
+| Pendant only | no | yes | **none in v1** (limitation) |
+| Neither | no | no | Events queue durably (SP-HP); surface on next connect |
+
+The "Pendant only, no Claude" cell is the v1 limitation. The pendant doesn't have an independent socket subscriber yet.
+
+### Components
+
+#### 1. MCP server: `robot-md://hotplug/pending` resource
+
+```python
+# cli/src/robot_md/mcp/resources/hotplug_pending.py (NEW)
+
+URI = "robot-md://hotplug/pending"
+
+@mcp_server.resource(URI)
+def hotplug_pending_resource(ctx) -> Resource:
+    """Read-only view over the pending hot-plug events.
+
+    Subscribers receive notifications/resources/updated on socket nudge
+    or file-poll detected change.
+    """
+    pending = read_pending_from_queue()  # uses SP-HP's queue.py
+    return Resource(
+        uri=URI,
+        mimeType="application/json",
+        text=json.dumps({"pending": [p.to_summary() for p in pending]}),
+    )
+```
+
+Why a resource rather than a tool: resources support subscription and `notifications/resources/updated`, which is the right primitive for "Claude should know about new pending events without being asked."
+
+#### 2. Skill-text additions to `using-robot-md.SKILL.md`
+
+Three new sections (per the Revision 7 canonical-source rule, edited only in `~/robot-md-mcp/skills/using-robot-md/SKILL.md`):
+
+```markdown
+## Reacting to hot-plug events
+
+The MCP server emits `notifications/resources/updated` for
+`robot-md://hotplug/pending` whenever new hardware is detected.
+
+When you receive that notification:
+
+1. Call `hotplug_review`.
+2. For HIGH-tier events that already resolved (`bind`):
+   - **Announce to the operator** — say or write:
+     "Found a {preset_name} on {port}. I bound it as the {driver_id} driver
+      using the {backend_name} backend. Say 'undo' to reject."
+   - If the operator says undo / reject within 30 s of the announce,
+     call `hotplug_confirm({event_id}, "reject")`. The daemon will append
+     a rejection record; the manifest stays bound but the audit trail
+     captures the operator's intent. (Manifest unbinding is out of scope
+     for v1 — call this out and offer to help edit ROBOT.md by hand.)
+3. For MEDIUM/LOW-tier pending events:
+   - Surface the event with its alternatives.
+   - Ask the operator: "Want me to bind this as {top_candidate}, pick
+     a different option, or reject?"
+   - Call `hotplug_confirm` with their answer.
+
+## Modality hierarchy
+
+If the operator is in voice mode, **announce by voice first**, then mirror
+the same text to the chat. If the operator is in text mode, write to the
+chat only.
+
+If a pendant is attached (visible via `pendant_status`), the pendant will
+ALSO show the pending event independently. Don't assume the operator
+needs you to read aloud what they can already see; do mention "you can
+also confirm on the pendant."
+
+## Resolved-elsewhere handling
+
+If you call `hotplug_confirm` and get back `already_resolved`, the
+operator confirmed it on the pendant first. Tell them you saw it
+("Got it — I see {decision} happened on the pendant.") and move on.
+```
+
+The skill text is a contract: it's how Claude turns the resource update into the announce-confirm flow.
+
+#### 3. Pendant: `pending_hotplug_events` panel
+
+```python
+# pendant repo: pendant/src/views/status.py (extend existing)
+
+def render_status(state: PendantState) -> Frame:
+    panels = [...]
+    if state.pending_hotplug_events:
+        panels.append(_render_pending_panel(state.pending_hotplug_events))
+    return Frame(panels=panels)
+
+def _render_pending_panel(events: list[PendingEventSummary]) -> Panel:
+    top = events[0]  # one-at-a-time UX; queue depth shown as "+N more"
+    return Panel(
+        title=f"NEW HARDWARE ({len(events)} pending)" if len(events) > 1
+              else "NEW HARDWARE",
+        body=[
+            f"{top.preset_name or top.transport} on {top.port}",
+            f"Tier: {top.tier}",
+            f"Bind as {top.bind_proposal.backend_name}? (button A)",
+            "Reject (button B)  •  Skip to next (button C)",
+        ],
+    )
+```
+
+Pendant's existing button-handler wires:
+- A → `mcp_call("hotplug_confirm", {event_id, decision: "bind"})`
+- B → `mcp_call("hotplug_confirm", {event_id, decision: "reject"})`
+- C → cycle to next event in `pending_hotplug_events`
+
+The pendant **does not** subscribe to the daemon's socket directly in v1 — it relies on the MCP session's `pending_hotplug_events` value being refreshed by the server (which is itself a subscriber of the socket nudge / file-poll). One transport hop adds ≤2 s of latency, acceptable for v1.
+
+#### 4. Audio announce — no new code, just skill-text
+
+Audio rides on Claude's voice mode entirely. SP-AN does NOT ship a TTS engine, an audio device manager, or a separate speech subsystem. The "audio onboarding moment" is the operator being in voice mode + Claude reading the announce text. If Claude is in text mode, the same announcement appears in chat.
+
+This keeps SP-AN's surface area small and avoids parallel infrastructure.
+
+### Data Flow
+
+#### HIGH-tier auto-bind: voice-mode operator (the headline beat)
+
+```
+(Operator in voice mode with        →  SP-HP daemon classifies device:
+ Claude. Robot reboots, USB plug        tier=HIGH, unambiguous.
+ click on bob.)                         manifest.merge() succeeds.
+                                        audit.append(hotplug_bind, ...)
+                                        socket.nudge_subscribers()
+
+(MCP server, socket subscriber)     →  Reads queue, sees new bind record.
+                                        Emits notifications/resources/updated
+                                        for robot-md://hotplug/pending AND
+                                        notifications/tools/list_changed
+                                        (because new tools exist via the
+                                        new driver's capabilities).
+
+(Claude, voice mode)                →  Skill text triggers: announce by
+                                        voice — "Found an SO-ARM101 on
+                                        /dev/ttyACM0. I bound it as
+                                        arm_servos using lerobot. Say
+                                        'undo' to reject."
+
+Operator: "Looks good."             →  Claude continues normally.
+
+(or)
+Operator: "Undo."                    →  Claude calls
+                                        hotplug_confirm(event_id, "reject").
+                                        Daemon appends rejection record.
+                                        Claude: "Rejected. The manifest
+                                        stays bound for now — want me to
+                                        help edit ROBOT.md to remove the
+                                        driver?"
+```
+
+#### MEDIUM-tier event: text-mode operator with pendant
+
+```
+(Generic feetech bus chip plug.     →  Daemon classifies tier=MEDIUM.
+ Operator in text mode. Pendant         queue.append_pending(...)
+ attached.)                             socket nudge.
+
+(MCP server)                        →  Resource update emitted.
+                                        Pendant's next pendant_status call
+                                        gets pending_hotplug_events
+                                        populated.
+
+(Claude, text mode)                 →  Skill text: surface the pending
+                                        event in chat:
+                                        "New hardware detected on
+                                        /dev/ttyACM0 (generic feetech).
+                                        Three preset matches:
+                                          1. so_arm101 + lerobot (most
+                                             likely)
+                                          2. koch_arm + lerobot
+                                          3. so_arm101 + feetech_depthai
+                                        Or reject. The pendant is also
+                                        showing this. Which?"
+
+(Operator presses pendant button A) →  Pendant calls hotplug_confirm.
+                                        Daemon merges manifest.
+                                        Resolution=bind appended.
+                                        socket nudge.
+
+(MCP server next refresh)           →  Resource updated. Claude sees
+                                        already_resolved on its next
+                                        check.
+                                        Claude (next message):
+                                        "Got it — I see the pendant just
+                                        bound it as so_arm101 + lerobot."
+```
+
+#### LOW-tier: voice-mode operator, no pendant, unknown hardware
+
+```
+(Unknown VID:PID, no preset match.) →  Daemon: tier=LOW, queue.append.
+                                        socket nudge.
+
+(Claude, voice mode)                →  Skill text: announce by voice —
+                                        "I see new hardware on
+                                        /dev/ttyACM0, but I don't
+                                        recognize it. It looks like a
+                                        feetech bus device. Want me to
+                                        try to write a backend for it?
+                                        (That'll start a guided setup.)
+                                        Or skip for now."
+
+Operator: "Try it."                 →  Claude triggers SP4's
+                                        author-backend flow.
+                                        SP-HP queue gets a resolution
+                                        of "deferred_to_sp4" so the
+                                        event doesn't keep nagging.
+```
+
+#### Resolved-elsewhere race
+
+```
+(Both Claude and pendant see the    →  Both call hotplug_confirm.
+ same MEDIUM event.)                    Daemon serializes via socket
+                                        listener fcntl lock.
+
+(Pendant gets there first.)         →  Daemon writes resolution=bind,
+                                        by="pendant".
+                                        socket nudge.
+
+(Claude's call arrives second.)     →  Daemon: already_resolved.
+                                        Returns {ok: false,
+                                                 reason: "already_resolved",
+                                                 by: "pendant"}.
+
+(Claude, text or voice)             →  Skill text: "Looks like the
+                                        pendant just confirmed it as
+                                        so_arm101 + lerobot. Done."
+```
+
+#### v1 limitation: no Claude session, pendant only
+
+```
+(No Claude session running.         →  SP-HP daemon queues events.
+ Pendant attached, idle.)               No socket subscriber → MCP server
+                                        is the only would-be subscriber,
+                                        and it's not running.
+
+                                        Pendant has no path to see the
+                                        event in v1.
+                                        Pendant's status panel shows
+                                        normal status; pending events
+                                        are invisible until a Claude
+                                        session opens.
+
+(Operator opens Claude later.)      →  MCP server connects, drains
+                                        queue, gets all pending events,
+                                        surfaces them. Pendant's next
+                                        pendant_status call now shows
+                                        them too.
+```
+
+This is the explicit v1 limitation. Future work: pendant gains an
+independent socket subscriber.
+
+### Error Handling
+
+#### (a) Caught — structured handling
+
+| Failure | Where caught | Operator sees |
+|---|---|---|
+| `notifications/resources/updated` not delivered (Claude session dropped mid-write) | MCP server next reconnect | On reconnect, MCP server emits a fresh resource update for any pending events; Claude surfaces them on next message. |
+| Pendant's `pendant_status` call fails | Pendant existing handler | Pendant retries; existing pendant offline/online icon flips. SP-AN doesn't add new failure UI. |
+| Operator's "undo" arrives after the 30 s window | Claude skill text | Claude still passes through `hotplug_confirm({decision:"reject"})`; daemon appends the rejection record (manifest stays bound; audit trail captures intent). Claude tells the operator "the manifest is already bound; want me to help unbind by hand?" |
+| Audio announcement attempted but operator is muted | Claude voice mode | Falls through to text rendering (Claude's existing behavior). Skill text doesn't need special handling. |
+| `hotplug_confirm` call from Claude/pendant returns `already_resolved` | Each surface | Both surfaces show "(resolved on \<other surface\>)" on next refresh — no error to operator. |
+
+#### (b) Pass-through
+
+| Failure | Surface |
+|---|---|
+| Claude voice mode failure (TTS audio device unavailable) | Existing Claude behavior — falls back to text. SP-AN does nothing extra. |
+| Pendant disconnects mid-confirm | Pendant's existing reconnect logic handles. The daemon's resolution record is the source of truth. |
+| Daemon down at the time of operator confirmation | `hotplug_confirm` call from MCP server fails with `daemon_unreachable`. Claude tells the operator to start the daemon (`robot-md hotplug-daemon start`). |
+
+#### (c) Edge cases — defensive handling
+
+| Edge case | Defense |
+|---|---|
+| Operator confirms via pendant, then says "undo" to Claude | Daemon already wrote `resolved: bind`. Claude responds "the pendant already bound it; the manifest now has the driver. Want me to help unbind by hand?" — no quiet retry. |
+| Two pending events at once, voice mode | Skill text instructs Claude to handle them sequentially: announce the highest-tier first; queue the rest as "I have N more pending." |
+| Operator dismisses an event by saying "later" | Claude takes no action (no `hotplug_confirm` called). The pending record stays in the queue until the TTL elapses (SP-HP's 7-day default). |
+| Pendant shows stale events (subscription lag) | Pendant's `pendant_status` call returns the latest server-side snapshot on each tick; staleness window ≤2 s. Acceptable. |
+| Skill text drift between robot-md-mcp and CLI copies | Revision 7 sync script + CI check (existing in SP1). SP-AN editor edits the canonical copy; sync handles propagation. |
+
+#### Explicit non-goals
+
+- **Background TTS engine.** Voice rides on Claude's existing voice mode.
+- **Operator preferences UI** (e.g., "always confirm even on HIGH"). v1 uses SP-HP's tier policy. Custom preferences land as a follow-up.
+- **Multi-channel arbitration beyond pendant + Claude.** Other surfaces (web UI, OS notifications) deferred.
+- **Manifest unbind tool.** Reject after a HIGH-tier auto-bind logs intent only; manifest hand-edit remains the operator's path. Future work: `hotplug_unbind` tool that mirrors `hotplug_confirm` but for removal.
+
+### Testing
+
+#### Resource subscription
+
+| Test | Verifies |
+|---|---|
+| `test_hotplug_pending_resource_lists_pending.py` (NEW) | Resource read returns all pending events; resolved events excluded. |
+| `test_hotplug_pending_resource_emits_updated_on_nudge.py` (NEW) | Daemon socket nudge → MCP server emits `notifications/resources/updated` for the URI. |
+| `test_hotplug_pending_resource_emits_updated_on_file_poll.py` (NEW) | File-poll path (no socket) → same notification within 2 s of queue change. |
+| `test_hotplug_pending_resource_subscribers_only_get_changes.py` (NEW) | Two clients subscribed; one client gets `updated` for the change it caused (no infinite loops). |
+
+#### Skill-text behavior (sandboxed Claude harness)
+
+| Test | Verifies |
+|---|---|
+| `test_skill_announce_high_tier_in_voice_mode.py` (NEW) | Mock voice-mode session + HIGH bind audit entry → Claude's first response is the announce string. |
+| `test_skill_undo_within_window_calls_reject.py` (NEW) | Same as above; operator says "undo" within 30 s → Claude calls `hotplug_confirm("reject")`. |
+| `test_skill_undo_after_window_warns_manifest_bound.py` (NEW) | Operator says "undo" 60 s later → Claude still calls reject AND tells operator manifest stays bound. |
+| `test_skill_medium_tier_surfaces_alternatives.py` (NEW) | MEDIUM event → Claude's response lists top-3 alternatives + asks operator. |
+| `test_skill_resolved_elsewhere_acknowledges.py` (NEW) | `hotplug_confirm` returns `already_resolved` → Claude says "I see {decision} happened on {by}". |
+
+#### Pendant integration
+
+| Test | Verifies |
+|---|---|
+| `test_pendant_status_includes_pending_events.py` (NEW) | Mock daemon with 2 pending events → pendant's `pendant_status` payload includes them. |
+| `test_pendant_button_a_calls_confirm_bind.py` (NEW) | Press A → mocked MCP call invokes `hotplug_confirm({decision:"bind"})`. |
+| `test_pendant_button_b_calls_confirm_reject.py` (NEW) | Press B → invokes `hotplug_confirm({decision:"reject"})`. |
+| `test_pendant_button_c_cycles_events.py` (NEW) | With 2 pending → C → display advances to event 2. |
+| `test_pendant_panel_omitted_when_no_pending.py` (NEW) | Empty queue → panel not rendered. |
+
+#### Manual smoke checklist — `cli/tests/manual/span_smoke.md`
+
+1. **Voice-mode HIGH-tier auto-bind.** Replug SO-ARM101 on bob with operator in Claude voice mode; verify Claude's first audio response is the announce string within 5 s of the plug click.
+2. **Voice-mode undo within window.** Same as #1; operator says "undo" within 30 s; verify rejection record appears in queue.
+3. **Voice-mode undo after window.** Same as #1; operator says "undo" 60 s later; verify Claude warns manifest is bound.
+4. **Text-mode MEDIUM with pendant.** Plug generic feetech bus; verify Claude chat surfaces alternatives + pendant shows the pending panel; press pendant button A; verify Claude acknowledges in next message ("the pendant just bound it...").
+5. **No-Claude-session pendant invisibility.** With no Claude session running, plug a device. Verify pendant does NOT show the pending event (v1 limitation behaving as documented).
+6. **Resolved-elsewhere race.** Two Claude sessions + pendant all see the same MEDIUM event; one acts; verify the others get `already_resolved` and acknowledge cleanly.
+
+#### Coverage gaps acknowledged
+
+- Voice-mode tests are the hardest to automate. Skill-text tests use a sandboxed harness; real voice-mode behavior tested by hand.
+- Pendant tests assume the existing pendant codebase compiles and runs; SP-AN doesn't include pendant-runtime CI changes beyond the new panel test.
+- `notifications/resources/updated` is a relatively new MCP feature; client-side rendering varies. Skill text targets the MCP-spec-compliant path; non-Claude clients may not surface resource updates.
+
+## Open Questions
+
+1. **Undo window length.** 30 s default. Long enough to react after a voice announce; short enough to not silently linger. Roll back to 15 s if operators report the manifest "feels editable for too long."
+2. **Manifest unbind tool.** Should v1 include a `hotplug_unbind` complement to handle the reject-after-HIGH case cleanly? **Decision: defer to v2** — the v1 path (Claude offers to help hand-edit) is acceptable for the demo, and the unbind semantics deserve their own design pass (driver dependencies, safety).
+3. **Pendant independent subscriber.** The v1 limitation (pendant requires Claude session) is the most-likely future complaint. Tracked as the SP-AN v2 headline item.
+
+## Success Criteria
+
+SP-AN is done when:
+
+- [ ] `robot-md://hotplug/pending` resource implemented + tested; resource updates fire on nudge and on file-poll.
+- [ ] Skill-text additions land in the canonical `using-robot-md.SKILL.md`; sync script propagates.
+- [ ] Pendant gains the pending-events panel + button bindings; existing pendant tests still pass.
+- [ ] All unit + integration tests pass (resource subscription + skill harness + pendant render).
+- [ ] Manual smoke checklist passes 6/6 on bob with the SO-ARM101 + a generic feetech bus chip.
+- [ ] Demo dry-run: operator in voice mode, no display attached; replug SO-ARM101; Claude announces the bind audibly within 5 s; operator says "looks good"; conversation continues. **This is the headline auto-onboard moment.**
+- [ ] v1 limitation (pendant requires Claude session) documented in `using-robot-md.SKILL.md` and in `cli/docs/hotplug-limitations.md`.
+
+## Sub-project Relationships
+
+- **SP-HP → SP-AN.** SP-HP's queue + manifest merge + audit log are the foundation. SP-AN is read-only on SP-HP's writes (except via `hotplug_confirm`, which SP-HP defines).
+- **SP3 → SP-AN.** SP-AN's "what tools just appeared" surfacing uses SP3's `enumerate_capabilities()` to enrich the announce with "you can now use {tool list}."
+- **SP-AN ↔ SP1.** SP-AN's resource + skill-text additions land in the existing SP1 MCP server. No SP1 architecture changes.
+- **SP-AN ↔ SP4.** SP-AN's LOW-tier path can offer to trigger SP4's `author-backend`. SP-AN itself does not own that flow.
+- **SP-AN delivers the auto-onboard demo moment.** Combined with SP-HP, the headline pitch beat: *robot reboots, no display, audio onboarding, Claude announces "Found a SO-ARM101, binding it. Say 'undo' to reject" — operator nods, conversation continues.* SP-AN is the mouth of the system; SP-HP is the eyes.

--- a/docs/superpowers/specs/2026-04-27-sp-hp-hotplug-daemon-design.md
+++ b/docs/superpowers/specs/2026-04-27-sp-hp-hotplug-daemon-design.md
@@ -1,0 +1,536 @@
+# SP-HP — Runtime Hot-Plug Detection Daemon
+
+**Date:** 2026-04-27
+**Status:** Design — pending implementation plan
+**Sub-project:** Companion to SP3 (not numbered in the SP1-5 sequence)
+**Depends on:** SP3 capability-metadata addendum (`Capability`, `describe_capabilities`, `enumerate_capabilities`)
+**Paired with:** `2026-04-27-sp-an-announce-confirm-design.md` (operator-facing surfaces)
+
+## Problem
+
+Once SP3 ships, an operator with `robot-md` installed can plug in any vendor's arm and *if they re-run* `robot-md init`, autodetect picks up the change. The "headless auto-onboard" demo moment — *robot reboots, no screen, just audio I/O, and Claude's like "I see a new arm, want me to bind it?"* — does NOT work today. Two specific gaps:
+
+1. **No runtime device watcher.** `robot-md init` only runs when the operator invokes it.
+2. **No durable event surface.** Even if `init` ran on every boot, there's no place to queue "I detected an arm, but I need confirmation" so an operator (via Claude or pendant) can answer it later.
+
+For the Anthropic acquisition demo, the auto-onboard moment is a strong reveal — *it just works the way you'd want a robot to work*. Without SP-HP, that moment requires manual operator intervention (re-run init), which weakens the demo.
+
+## Scope
+
+**In scope:**
+- A persistent OS-level service (`robot-md hotplug-daemon`) that watches for USB / serial device hot-plug events, matches them to presets + backends, and emits a durable, hash-chained event stream.
+- Cross-platform device detection from v1: Linux (`pyudev`, real-time, <50 ms), macOS (`ioreg` polling + `pyserial.tools.list_ports`, 1–2 s), Windows (`pywin32` `WM_DEVICECHANGE` + polling fallback, 1–2 s).
+- Tier-based confirmation policy: HIGH → auto-bind manifest + emit announce event; MEDIUM/LOW → queue `awaiting_confirm` event, no manifest write.
+- Durable event queue at `~/.robot-md/hotplug-events.jsonl`, hash-chained for audit.
+- Hash-chained per-RRN audit log at `~/.robot-md/audit/<rrn>.jsonl` capturing every bind/queue/reject decision.
+- Hybrid daemon ↔ MCP-server communication: files for durable state, optional Linux-only Unix socket at `/run/user/$UID/robot-md-hotplug.sock` for low-latency wake-up nudges. Graceful fallback to file-poll if the socket is unavailable.
+- MCP server changes: inotify watch on `ROBOT.md` + manifest reload + `notifications/tools/list_changed` emission; socket subscriber on connect; two new tools (`hotplug_review`, `hotplug_confirm`).
+- CLI: `robot-md hotplug-daemon start|stop|status`, `robot-md hotplug review`, `robot-md hotplug confirm`, `robot-md hotplug install-service` (writes systemd user unit on Linux, launchd plist on macOS, scheduled task on Windows).
+
+**Out of scope** (called out as v1 limitations or follow-ups):
+- **Hot-unplug (device removal) graceful handling** — daemon emits a `device_removed` audit-log entry but does NOT auto-unbind the manifest. Removed-then-replugged behaves like a fresh hot-plug.
+- **Multi-host robot rigs.** Single host assumed; cross-host event sync is out of scope.
+- **Automatic driver download from a registry.** The matching backend's pip extra must already be installed; if no backend matches the device's protocol, the event lands as LOW with a `missing_backend_extra` hint.
+- **Backend hot-uninstall mid-session.** Manifest stays bound to the named backend even if `pip uninstall` removed the entry-point. Runtime fails with a clean error on next call.
+- **Pendant subscription without an active Claude session.** The pendant subscribes via MCP notifications; no Claude session = pendant doesn't see live events. Events still queue and surface on next Claude connect. Future work: pendant hosts its own socket subscriber. (Tracked in SP-AN.)
+
+## Design
+
+### Architecture
+
+Six in-process components plus the OS service wrapper:
+
+1. **`cli/src/robot_md/hotplug/daemon.py`** — Long-running event loop. Composes the cross-platform watcher + matcher + queue writer. Owns the socket listener.
+2. **`cli/src/robot_md/hotplug/{linux,macos,windows}.py`** — Per-platform implementations of a single `watch_devices()` interface. All emit the same `DeviceEvent` shape.
+3. **`cli/src/robot_md/hotplug/matcher.py`** — Given a `DeviceEvent`, walks installed presets + `BackendRegistry` to compute a tier (HIGH/MEDIUM/LOW) and a candidate `bind_proposal`.
+4. **`cli/src/robot_md/hotplug/queue.py`** — Hash-chained append-only writer for `~/.robot-md/hotplug-events.jsonl`. Resolution operations (`bind`, `reject`, `expired`) append a new chained record; original `pending` is never edited.
+5. **`cli/src/robot_md/hotplug/audit.py`** — Hash-chained per-RRN audit logger. Mirrors RRF's audit-trail conventions.
+6. **`cli/src/robot_md/hotplug/manifest.py`** — Manifest merge logic. Validates BEFORE writing; refuses non-validating writes and queues a `merge_failed` event instead.
+
+OS service wrappers (created by `robot-md hotplug install-service`):
+- `~/.config/systemd/user/robot-md-hotplug.service` (Linux)
+- `~/Library/LaunchAgents/dev.robotmd.hotplug.plist` (macOS)
+- Scheduled Task via `pywin32` install helper (Windows)
+
+The MCP server (`robot-md mcp`) is **not** a peer of the daemon — it's a subscriber. Specifically:
+
+- The daemon is the single writer of `hotplug-events.jsonl` and the audit log. (Concurrency: even if two daemons race-started, only one binds the socket; the other fails fast with `EADDRINUSE` and exits with a clear error.)
+- The MCP server reads-only the queue + watches the manifest. No writes from the MCP server side.
+- Why split? Per-session lifecycle is the wrong shape for hot-plug — the daemon must outlive any one Claude session. Embedding the daemon inside the MCP server would tie hot-plug detection to "an operator has Claude open right now."
+
+**Design principles preserved:**
+- Backend resolution via SP3 entry-points + `try_resolve` — daemon reuses, doesn't re-implement.
+- Manifest schema validation gates every write. No "best-effort write then fix later."
+- Audit log is append-only and hash-chained — same shape as RRF's compliance trail.
+
+### Components
+
+#### 1. `hotplug/daemon.py` — service entry point
+
+```python
+# robot_md/hotplug/daemon.py
+
+import asyncio, signal
+from robot_md.hotplug import linux, macos, windows
+from robot_md.hotplug.matcher import classify
+from robot_md.hotplug.queue import EventQueue
+from robot_md.hotplug.audit import AuditLog
+
+PLATFORM_WATCHERS = {"linux": linux.watch_devices,
+                     "darwin": macos.watch_devices,
+                     "win32": windows.watch_devices}
+
+async def run(rrn: str | None) -> int:
+    queue = EventQueue.open()
+    audit = AuditLog.open(rrn=rrn)
+    socket_listener = _maybe_open_socket()  # Linux-only; None elsewhere
+
+    watcher = PLATFORM_WATCHERS[sys.platform]
+    async for evt in watcher():
+        decision = classify(evt)
+        record = queue.append_pending(evt, decision)
+        audit.append("hotplug_event", record)
+        if decision.tier == "HIGH" and decision.unambiguous:
+            outcome = manifest.merge(decision.bind_proposal)
+            queue.append_resolution(record.id, outcome)
+            audit.append("hotplug_bind", outcome)
+            if socket_listener: socket_listener.nudge_subscribers()
+        else:
+            if socket_listener: socket_listener.nudge_subscribers()
+    return 0
+```
+
+**Why structured:** every hot-plug becomes a queue record. Resolution is a separate appended record referencing the original — never an in-place edit. This is what makes the queue hash-chainable.
+
+#### 2. Per-platform `watch_devices()`
+
+```python
+# robot_md/hotplug/linux.py
+async def watch_devices() -> AsyncIterator[DeviceEvent]:
+    """pyudev real-time monitor. <50ms latency."""
+    import pyudev
+    ctx = pyudev.Context()
+    monitor = pyudev.Monitor.from_netlink(ctx)
+    monitor.filter_by(subsystem="usb")
+    monitor.filter_by(subsystem="tty")
+    monitor.start()
+    for action, device in monitor:
+        if action == "add":
+            yield DeviceEvent.from_pyudev(device)
+
+# robot_md/hotplug/macos.py
+async def watch_devices() -> AsyncIterator[DeviceEvent]:
+    """ioreg + pyserial polling. 1-2s latency."""
+    seen = set()
+    while True:
+        await asyncio.sleep(1.5)
+        current = _enumerate_macos()  # parses `ioreg -p IOUSB -l` + list_ports.comports()
+        for evt in (current - seen):
+            yield evt
+        seen = current
+
+# robot_md/hotplug/windows.py
+async def watch_devices() -> AsyncIterator[DeviceEvent]:
+    """WM_DEVICECHANGE message pump + polling fallback. 1-2s latency."""
+    # See Implementation Notes for details on win32 message-loop integration.
+    ...
+```
+
+Single shape:
+
+```python
+@dataclass(frozen=True)
+class DeviceEvent:
+    kind: Literal["usb_added", "tty_added"]
+    vid: str | None              # e.g. "1a86"
+    pid: str | None              # e.g. "7523"
+    serial: str | None           # device serial number, if exposed
+    path: str                    # /dev/ttyACM0, /dev/cu.usbmodem*, COM3
+    transport: Literal["feetech", "dynamixel", "realsense", "uvc", "unknown"]
+    raw_metadata: dict[str, Any] # platform-specific extras
+    detected_at: str             # ISO-8601 UTC
+```
+
+`transport` is heuristically derived from VID:PID lookup table + tty class hints. "unknown" lands in LOW tier.
+
+#### 3. `matcher.py` — tier classification
+
+```python
+# robot_md/hotplug/matcher.py
+
+@dataclass(frozen=True)
+class BindProposal:
+    rrn: str | None              # if a manifest already exists in cwd
+    driver_id_suggestion: str    # e.g. "arm_servos"
+    backend_name: str            # resolved entry-point name
+    preset_name: str | None      # e.g. "so_arm101"
+    capability_preview: list[Capability]   # via SP3 enumerate_capabilities()
+    inferred_fields: dict        # protocol, port, baud, etc.
+
+@dataclass(frozen=True)
+class Decision:
+    tier: Literal["HIGH", "MEDIUM", "LOW"]
+    unambiguous: bool
+    bind_proposal: BindProposal | None
+    alternatives: list[BindProposal]
+    reasons: list[str]           # human-readable; surfaced to operator
+
+def classify(evt: DeviceEvent) -> Decision:
+    """Match a hot-plug event to preset + backend.
+
+    Tier criteria:
+      HIGH:   VID:PID:serial triple matches a preset that declares this exact
+              hardware AND exactly one matching backend installed. Auto-bind.
+      MEDIUM: VID:PID matches a preset family OR multiple eligible
+              presets/backends. Top-1 candidate + alternatives surfaced; queued.
+      LOW:    Only protocol/transport detected, no preset match. Queued with a
+              "name this device" prompt.
+    """
+    ...
+```
+
+Tier thresholds are deliberately stricter than SP2's init-time tiers — SP2 has the operator's full attention; SP-HP HIGH must justify writing the manifest unattended.
+
+#### 4. `queue.py` — hash-chained event log
+
+```jsonl
+# ~/.robot-md/hotplug-events.jsonl (one record per line)
+{"id":"evt_01H...","ts":"2026-04-27T19:30:11Z","kind":"pending","event":{...DeviceEvent...},"decision":{...Decision...},"prev_hash":"sha256:0000...","this_hash":"sha256:abcd..."}
+{"id":"evt_01H...","ts":"2026-04-27T19:30:12Z","kind":"resolved","ref":"evt_01H...","resolution":"bind","by":"daemon_auto","outcome":{...},"prev_hash":"sha256:abcd...","this_hash":"sha256:beef..."}
+{"id":"evt_01H...","ts":"2026-04-27T19:31:05Z","kind":"pending","event":{...},"decision":{...},"prev_hash":"sha256:beef...","this_hash":"sha256:cafe..."}
+```
+
+**State model:** every `pending` record is in one of three terminal states: `bind | reject | expired`. The terminal state is a separate `kind: "resolved"` record referencing the original by `id` — first writer wins. The MCP server (when subscribed) and the pendant (when reachable) each call `hotplug_confirm` independently; both go through the daemon's socket-or-file API; the daemon serializes resolution writes (see Concurrency below).
+
+**TTL:** pending events expire after **7 days** (configurable via `~/.robot-md/hotplug.toml` key `pending_ttl_days`). The daemon scans the queue on start and once an hour, appending `resolution: "expired"` for any pending older than the TTL.
+
+**Hash chain:** `this_hash = sha256(prev_hash || canonical_json(record_minus_hash))`. Same shape as RRF's compliance audit trail; tooling reusable.
+
+**Concurrency:** queue file is opened with `O_APPEND`; appends are atomic on POSIX. Resolution races are handled by the daemon serializing writes — both `hotplug_confirm` callers nudge the daemon over the socket, which checks the queue under a fcntl lock and writes the first `resolved` record; subsequent callers get back "already resolved" with the resolver name.
+
+#### 5. `audit.py` — per-RRN audit log
+
+Same hash-chained shape as queue; one file per `RRN-*` value. Records every:
+- `hotplug_event` (raw DeviceEvent + Decision)
+- `hotplug_bind` (manifest merge outcome)
+- `hotplug_reject` (operator-driven via `hotplug confirm --reject`)
+- `hotplug_expired` (TTL elapsed)
+- `merge_failed` (manifest validation failed)
+
+Rolls into the existing `~/.robot-md/audit/` directory used by SP1/SP2's compliance trail.
+
+#### 6. `manifest.py` — schema-gated merge
+
+```python
+def merge(proposal: BindProposal, *, manifest_path: Path) -> MergeOutcome:
+    """Append a new drivers[] entry. Preserves all other fields. Sets
+    backend: from resolved entry-point.
+
+    Schema validation BEFORE write — daemon refuses to write a non-validating
+    manifest; operator gets a queued event with status: "merge_failed" and
+    the validator's error.
+    """
+    spec = parse_robot_md(manifest_path)
+    new_spec = spec.with_appended_driver(proposal.to_driver_entry())
+    validate_against_schema(new_spec)  # raises on violation
+    write_atomic(manifest_path, render(new_spec))
+    return MergeOutcome.success(rrn=spec.rrn, driver_id=proposal.driver_id_suggestion)
+```
+
+Existing `drivers[]` entries are NEVER modified — auto-bind is strictly additive.
+
+#### MCP server changes
+
+- **inotify watch on the active `ROBOT.md`** (Linux; `kqueue` on macOS via `watchdog`; `ReadDirectoryChangesW` on Windows). On change: reload `RobotSpec`, refresh `BackendRegistry`'s in-memory mapping, emit `notifications/tools/list_changed` so Claude sees newly-bound capabilities without a session restart.
+- **Socket subscriber on connect** (Linux only): connect to `/run/user/$UID/robot-md-hotplug.sock`. On any 1-byte nudge, drain the queue and update the in-memory pending list. If the socket is missing or fails to connect, fall back to polling the queue file every 2 s.
+- **Two new tools** (registered alongside SP3's tools):
+  - `hotplug_review()` — returns `[{event_id, tier, bind_proposal, alternatives, reasons}, ...]` for all pending events.
+  - `hotplug_confirm(event_id, decision: "bind" | "reject", choice_index?: int)` — calls back to the daemon which appends the resolution record.
+
+#### Cross-platform commitments
+
+| Platform | Watcher | Latency | Socket nudge | Service wrapper |
+|---|---|---|---|---|
+| Linux | `pyudev` netlink monitor | <50 ms | yes (Unix domain socket at `/run/user/$UID/robot-md-hotplug.sock`) | systemd user unit |
+| macOS | `ioreg` + `pyserial.tools.list_ports` polling, 1.5 s tick | 1–2 s | **no** (file-poll only) | launchd plist |
+| Windows | `pywin32` `WM_DEVICECHANGE` + polling fallback | 1–2 s | **no** (file-poll only) | Scheduled Task |
+
+The Linux socket is a **performance optimization** — it cuts MCP-server-side detection-to-surface from 2 s (file poll cadence) to <100 ms (kernel wakeup). The architecture stays correct without it; macOS and Windows users see the same UX with a 1–2 s caveat. This is documented to operators.
+
+### Data Flow
+
+#### HIGH-tier auto-bind (the headline demo moment)
+
+```
+Operator                                State
+─────────────────────────────────────────────────────────────────
+(Robot rebooting, no display, audio
+ only. Claude session is open
+ elsewhere on the operator's laptop.)
+
+(USB plug click)                  →   Linux: pyudev fires <50ms
+                                      DeviceEvent(vid=1a86, pid=7523,
+                                                  serial=AB12,
+                                                  transport=feetech,
+                                                  path=/dev/ttyACM0)
+
+                                      matcher.classify():
+                                        VID:PID:serial → so_arm101 preset
+                                        Backends installed: lerobot only
+                                        unambiguous=True, tier=HIGH
+
+                                      manifest.merge() validates + writes:
+                                        ROBOT.md gains new drivers[]:
+                                          - id: arm_servos
+                                            protocol: feetech
+                                            backend: lerobot
+                                            port: /dev/ttyACM0
+
+                                      queue.append_pending → resolved (bind)
+                                      audit.append(hotplug_bind, ...)
+
+                                      socket_listener.nudge_subscribers()
+
+(MCP server in Claude session     →   inotify fires on ROBOT.md change.
+ wakes up)                            Reload RobotSpec; refresh
+                                      BackendRegistry.
+                                      Emit notifications/tools/list_changed.
+
+(SP-AN takes over from here.)     →   See SP-AN spec for the audio
+                                      announcement + Claude-chat surface.
+```
+
+#### MEDIUM-tier queued event
+
+```
+(USB plug, but VID:PID maps to    →   matcher.classify():
+ a generic feetech-bus chip that      VID:PID matches multiple presets
+ multiple presets share)              (so_arm101, koch_arm, custom_feetech)
+                                      Backends installed: lerobot,
+                                                          feetech_depthai
+                                      tier=MEDIUM, unambiguous=False
+
+                                      queue.append_pending (no merge)
+                                      audit.append(hotplug_event, ...)
+                                      socket nudge
+
+(Operator's pendant or Claude     →   hotplug_review() →
+ chat session)                          [{event_id, tier=MEDIUM,
+                                          bind_proposal: {preset=so_arm101,
+                                                          backend=lerobot},
+                                          alternatives: [koch_arm/lerobot,
+                                                         so_arm101/feetech_depthai,
+                                                         ...],
+                                          reasons: ["VID:PID matches 3 presets",
+                                                    "2 backends could drive this"]}]
+
+(Operator answers via Claude:     →   hotplug_confirm(event_id,
+ "yes, the SO-ARM101 with lerobot")     decision="bind", choice_index=0)
+                                      Daemon merges manifest, appends
+                                      resolution=bind to queue, appends
+                                      hotplug_bind to audit.
+                                      socket nudge → MCP reloads spec.
+```
+
+#### LOW-tier queued event (unknown hardware)
+
+```
+(USB plug, VID:PID not in any      →   matcher.classify():
+ preset table)                          transport=unknown OR no preset match
+                                       tier=LOW
+
+                                       queue.append_pending with reasons:
+                                         ["No preset matches VID:PID 1234:5678",
+                                          "Hint: this looks like a feetech bus,
+                                           try `pip install robot-md[hardware]`
+                                           if you don't have it yet"]
+
+(Operator answers via Claude:      →   Two paths:
+ "name this 'left arm' and use         (a) hotplug_confirm + manual driver_id
+  the lerobot backend")                (b) trigger SP4 author-backend flow
+                                          if no backend can drive it
+```
+
+#### No active channel — durable replay
+
+```
+(Robot reboots, daemon restarts.    →   Queue file persists; daemon doesn't
+ No Claude session is running. No       lose state across restarts.
+ pendant attached.)
+                                        HIGH-tier still auto-binds (no
+                                        operator dependency).
+                                        MEDIUM/LOW pending records persist.
+
+(Operator opens Claude later)        →  MCP server connects, drains queue
+                                        via socket nudge (Linux) or file
+                                        poll (macOS/Windows), surfaces all
+                                        pending events to Claude.
+```
+
+#### State summary
+
+| Hot-plug case | Tier | Auto-bind? | Manifest write? | Queue record |
+|---|---|---|---|---|
+| Exact preset + single backend match | HIGH | yes | yes | pending → resolved (bind, by=daemon_auto) |
+| Multi-preset / multi-backend | MEDIUM | no | no | pending until operator confirms |
+| Unknown VID:PID | LOW | no | no | pending with naming prompt |
+| Daemon already saw this device | (any) | no-op | no | not re-emitted (deduped on VID:PID:serial:path) |
+| Manifest validation fails on HIGH-tier merge | HIGH | aborted | no | pending → resolved (merge_failed) |
+| TTL elapsed (7d) on pending | (any) | no | no | pending → resolved (expired) |
+
+### Error Handling
+
+#### (a) Caught — structured handling
+
+| Failure | Where caught | Operator/author sees |
+|---|---|---|
+| `pyudev` import fails (Linux without USB perms) | daemon startup | Logs `udev_unavailable`; daemon falls back to polling at 2 s tick. Operator sees a warning at `robot-md hotplug-daemon status`. |
+| Socket bind fails (file exists, no other daemon) | daemon startup | Logs `stale_socket`; unlinks + retries once; if still fails, runs without socket (file-poll only on the MCP-server side). |
+| Two daemons race-start | second daemon | `EADDRINUSE` on socket bind → exits with status 2 + clear message. systemd's `Restart=on-failure` won't re-trigger because exit-code 2 is in `RestartPreventExitStatus`. |
+| Manifest validation fails on HIGH-tier merge | `manifest.merge()` | Append `resolution: merge_failed` with validator output; do NOT write the manifest. Operator surfaces the error via `hotplug_review`. |
+| Queue file corruption (truncated last record) | `EventQueue.open()` | Log `queue_truncated_record_dropped`; rebuild hash chain from prior valid record; emit a one-time alert via the queue itself (`{"kind":"daemon_alert","msg":"queue tail truncated"}`). |
+| MCP server's inotify drops events under load | `watchdog` callback | Worst-case: tool list goes stale until next manifest change. SP-AN's surfaces also poll the queue on a 5 s cadence as a backstop. |
+| Socket-unavailable on the MCP-server side | subscriber | Falls back to polling the queue file every 2 s. Logged once; not repeated. |
+
+#### (b) Pass-through
+
+| Failure | Surface |
+|---|---|
+| OS service install fails (e.g., systemd not present) | `robot-md hotplug install-service` returns non-zero with the OS-specific error (e.g., "systemd not detected; run with `--launchd` on macOS"). |
+| `pip install 'robot-md[hardware]'` not done at the time of hot-plug | LOW-tier event with `missing_backend_extra` hint; operator gets the install command. |
+
+#### (c) Edge cases — defensive handling
+
+| Edge case | Defense |
+|---|---|
+| Same device replugged within 1 s | Dedupe on `(vid, pid, serial, path)`; only emit once per unique key per hour. |
+| Two arms plugged simultaneously | Each generates a separate event; matcher classifies each independently; both queue or both auto-bind. |
+| HIGH-tier match but operator just rejected the same device an hour ago | Honor the recent rejection: emit pending with `tier=MEDIUM` + reason `"recently rejected; not auto-binding"`. Operator must confirm. |
+| Manifest disappears mid-watch (operator deleted it) | inotify fires `delete`; MCP server clears `RobotSpec` from memory; daemon keeps queueing events until a manifest reappears. HIGH-tier needs a manifest target — emits `merge_failed: no_manifest_in_cwd` instead. |
+| Audit log write fails (disk full) | Daemon logs the failure; continues operating but emits a `daemon_alert` queue record. Compliance gap acknowledged. Operator sees the alert via `hotplug_review`. |
+| Operator runs `robot-md init` while the daemon has a HIGH-tier merge in flight | `init` and daemon both call `manifest.merge`; both take an `flock` on the manifest. First wins; second sees the new manifest and re-validates its own write against it. |
+
+#### Explicit non-goals
+
+- **Hot-unplug graceful unbinding.** v1: removed device → audit-log entry only. The manifest stays bound. Re-plug behaves like a new HIGH-tier event (already idempotent on dedupe).
+- **Cross-host event sync.** Single-host only. Multi-host rigs need a different design.
+- **Driver download.** Daemon never invokes `pip install` automatically.
+- **VID:PID database curation.** Initial table ships with the SO-ARM and RealSense families; community contributions land via PR. No autoupdate.
+
+### Testing
+
+#### Daemon core
+
+| Test | Verifies |
+|---|---|
+| `test_daemon_starts_and_stops_clean.py` (NEW) | Daemon process starts, binds socket, exits on SIGTERM with status 0. |
+| `test_daemon_dedupes_replug_within_window.py` (NEW) | Same `(vid,pid,serial,path)` within 1 hour → single queue record. |
+| `test_daemon_two_instances_second_exits_eaddrinuse.py` (NEW) | Second daemon exits status 2 with clear message; first keeps running. |
+| `test_daemon_handles_pending_ttl_expiry.py` (NEW) | Pending event older than `pending_ttl_days` is rewritten to `resolution: expired` on next scan. |
+
+#### Per-platform watchers
+
+| Test | Verifies |
+|---|---|
+| `test_linux_watch_devices_emits_on_pyudev_event.py` (NEW, `@linux`) | Mock pyudev monitor; emit fake "add" → `DeviceEvent` produced with correct VID:PID. |
+| `test_linux_watch_devices_filters_subsystems.py` (NEW, `@linux`) | Only `usb` + `tty` events make it through. |
+| `test_macos_watch_devices_polling_diff.py` (NEW, `@darwin`) | Mock `ioreg` output; new device appears between polls → emitted; existing device → not re-emitted. |
+| `test_windows_watch_devices_message_pump.py` (NEW, `@win32`) | Mock `WM_DEVICECHANGE` message; emitted as `DeviceEvent`. |
+| `test_device_event_shape_consistent_across_platforms.py` (NEW) | Hand-crafted fixture per platform → all yield the same `DeviceEvent` schema. |
+
+#### Matcher
+
+| Test | Verifies |
+|---|---|
+| `test_matcher_high_tier_exact_preset_single_backend.py` (NEW) | SO-ARM101 VID:PID:serial + only `lerobot` installed → `tier=HIGH, unambiguous=True`. |
+| `test_matcher_medium_tier_multi_preset.py` (NEW) | Generic feetech VID:PID → `tier=MEDIUM` with 3 alternatives ordered. |
+| `test_matcher_medium_tier_multi_backend.py` (NEW) | SO-ARM101 VID:PID + both `lerobot` and `feetech_depthai` installed → `tier=MEDIUM` with 2 alternatives. |
+| `test_matcher_low_tier_unknown_vid_pid.py` (NEW) | Unknown VID:PID → `tier=LOW` with `missing_preset_match` reason. |
+| `test_matcher_low_tier_no_backend.py` (NEW) | Known VID:PID but no backend installed → `tier=LOW` with `missing_backend_extra` hint. |
+| `test_matcher_recent_reject_demotes_high_to_medium.py` (NEW) | Same device rejected <1h ago → next plug demoted from HIGH to MEDIUM. |
+
+#### Queue
+
+| Test | Verifies |
+|---|---|
+| `test_queue_append_pending_is_atomic.py` (NEW) | Concurrent appenders → all records present; hash chain unbroken. |
+| `test_queue_resolution_first_writer_wins.py` (NEW) | Two `hotplug_confirm` calls race → first writes resolved record; second gets back `already_resolved`. |
+| `test_queue_truncation_recovery.py` (NEW) | Last record bytes truncated → `EventQueue.open()` drops invalid record, emits `daemon_alert`, continues. |
+| `test_queue_hash_chain_validates_with_existing_audit_tooling.py` (NEW) | RRF's `verify_audit_chain` helper accepts queue file. |
+
+#### Manifest merge
+
+| Test | Verifies |
+|---|---|
+| `test_manifest_merge_appends_driver_preserves_others.py` (NEW) | Existing manifest → new `drivers[]` entry appended; other fields byte-identical. |
+| `test_manifest_merge_validates_before_write.py` (NEW) | Bad proposal (e.g., backend name with spaces) → no write, `merge_failed` queue record. |
+| `test_manifest_merge_locking.py` (NEW) | `init` and daemon both attempting merge → fcntl lock serializes; both succeed sequentially. |
+| `test_manifest_merge_no_manifest_returns_clear_error.py` (NEW) | No `ROBOT.md` in cwd → `merge_failed: no_manifest_in_cwd`. |
+
+#### MCP server integration
+
+| Test | Verifies |
+|---|---|
+| `test_mcp_inotify_reload_on_manifest_change.py` (NEW) | Touch `ROBOT.md` → `RobotSpec` reloaded, registry refreshed, `notifications/tools/list_changed` emitted. |
+| `test_mcp_socket_subscribe_drains_queue.py` (NEW, `@linux`) | Daemon nudges socket → MCP server drains queue, returns new pending events from `hotplug_review`. |
+| `test_mcp_socket_fallback_to_polling.py` (NEW) | Socket missing → MCP polls queue every 2 s and still surfaces events. |
+| `test_hotplug_review_returns_pending_only.py` (NEW) | Resolved events excluded from `hotplug_review` output. |
+| `test_hotplug_confirm_bind_writes_manifest.py` (NEW) | `hotplug_confirm(id, "bind", 0)` triggers daemon merge → manifest gains driver. |
+| `test_hotplug_confirm_reject_appends_resolution.py` (NEW) | `hotplug_confirm(id, "reject")` → resolution=reject queued; manifest unchanged. |
+
+#### CLI
+
+| Test | Verifies |
+|---|---|
+| `test_cli_hotplug_install_service_linux.py` (NEW, `@linux`) | Writes `~/.config/systemd/user/robot-md-hotplug.service` with the right ExecStart. |
+| `test_cli_hotplug_install_service_macos.py` (NEW, `@darwin`) | Writes `~/Library/LaunchAgents/dev.robotmd.hotplug.plist` with the right `ProgramArguments`. |
+| `test_cli_hotplug_status_reports_running.py` (NEW) | `robot-md hotplug-daemon status` returns running PID + queue depth + last event time. |
+| `test_cli_hotplug_review_lists_pending.py` (NEW) | `robot-md hotplug review` prints pending events as a table. |
+
+#### Hardware tests
+
+| Test | Verifies |
+|---|---|
+| `test_sphp_replug_so_arm101_high_tier.py` (NEW, `@hardware`) | Real SO-ARM101 replug on bob → daemon emits HIGH-tier auto-bind; manifest updated; MCP server reloads. End-to-end <1 s wall clock from plug-click. |
+| `test_sphp_unknown_device_low_tier.py` (NEW, `@hardware`) | Plug a CH340 dev board → LOW tier with `missing_preset_match` reason. |
+
+#### Manual smoke checklist — `cli/tests/manual/sphp_smoke.md`
+
+1. **Linux: HIGH-tier auto-bind.** Daemon running on bob; replug SO-ARM101; verify `ROBOT.md` gains `drivers[]` entry within 1 s; MCP server in Claude session emits tools/list_changed.
+2. **Linux: MEDIUM-tier queue + confirm.** Plug a generic feetech bus chip; verify queue has pending event; in Claude, `hotplug_review` surfaces it; `hotplug_confirm` binds it.
+3. **macOS: file-poll path.** Same as #1 on macOS; verify 1–2 s detection latency; manifest still updates.
+4. **Windows: WM_DEVICECHANGE path.** Same as #1 on Windows; verify message pump triggers.
+5. **Daemon survives Claude restart.** Kill Claude session mid-event; verify pending event persists; reopen Claude; `hotplug_review` still surfaces it.
+6. **TTL expiry.** Set `pending_ttl_days = 0.001`; queue an event; wait; verify resolution=expired record appears.
+
+#### Coverage gaps acknowledged
+
+- Cross-platform CI: GitHub Actions covers Linux + macOS + Windows runners, but USB hot-plug isn't physically simulatable in CI. Watcher tests are mocked; hardware tests are bob-local.
+- Long-haul daemon stability: 7-day TTL handling tested via clock skew, not real elapsed time.
+- Multi-arm rigs: single-arm scenarios are the v1 baseline; multi-arm tested by hand only on bob.
+
+## Open Questions
+
+1. **`pending_ttl_days` default.** 7 days picked to give operators a vacation-length window. Roll back to 3 days if event-queue accumulation becomes a UX problem.
+2. **Pendant subscription path.** v1 limitation: pendant subscribes only via an active Claude session's MCP notifications. Future: pendant hosts its own socket subscriber. Decided: out of scope for SP-HP v1; called out in SP-AN.
+3. **macOS launchd permission prompt.** First daemon launch may trigger macOS's "allow background app" prompt. Action: smoke-test on a fresh macOS account; document the click-through.
+
+## Success Criteria
+
+SP-HP is done when:
+
+- [ ] Six in-process components implemented + tested.
+- [ ] OS service wrappers ship for Linux/macOS/Windows; `robot-md hotplug install-service` works on all three.
+- [ ] All unit + integration tests pass on Linux, macOS, Windows runners.
+- [ ] Hardware tests pass on bob (SO-ARM101 replug → HIGH-tier auto-bind end-to-end <1 s wall clock).
+- [ ] Manual smoke checklist passes 6/6.
+- [ ] Daemon survives a 24-hour idle soak with no socket leaks, queue corruption, or audit-log gaps.
+- [ ] Demo dry-run: bob reboots, no display attached; SO-ARM101 powered up; daemon detects, binds, manifest updated; Claude (in another window) sees `tools/list_changed`. (SP-AN delivers the operator-facing announcement on top of this.)
+
+## Sub-project Relationships
+
+- **SP3 → SP-HP.** SP-HP consumes SP3's `enumerate_capabilities()` to preview a backend's tools at hot-plug time. Without the SP3 addendum, SP-HP would have to re-build the lookup.
+- **SP-HP → SP-AN.** SP-AN's surfaces (audio + Claude chat + pendant) are subscribers of the queue SP-HP produces. SP-AN doesn't write to the queue.
+- **SP-HP ↔ SP1.** SP1's MCP server gains the inotify watch + socket subscriber + two new tools as part of SP-HP. No SP1 changes outside that delta.
+- **SP-HP ↔ SP4.** When LOW-tier events surface "no backend can drive this hardware," SP4's `author-backend` flow is the operator's path forward. SP-HP doesn't trigger SP4 automatically; surfaces the option.
+- **SP-HP unblocks the auto-onboard demo moment.** Combined with SP-AN, the headline beat is: *robot reboots, no display, audio onboarding, Claude takes over.* SP-HP is the eyes; SP-AN is the mouth.

--- a/docs/superpowers/specs/2026-04-27-sp-hp-hotplug-daemon-design.md
+++ b/docs/superpowers/specs/2026-04-27-sp-hp-hotplug-daemon-design.md
@@ -11,7 +11,7 @@
 Once SP3 ships, an operator with `robot-md` installed can plug in any vendor's arm and *if they re-run* `robot-md init`, autodetect picks up the change. The "headless auto-onboard" demo moment — *robot reboots, no screen, just audio I/O, and Claude's like "I see a new arm, want me to bind it?"* — does NOT work today. Two specific gaps:
 
 1. **No runtime device watcher.** `robot-md init` only runs when the operator invokes it.
-2. **No durable event surface.** Even if `init` ran on every boot, there's no place to queue "I detected an arm, but I need confirmation" so an operator (via Claude or pendant) can answer it later.
+2. **No durable event surface.** Even if `init` ran on every boot, there's no place to queue "I detected an arm, but I need confirmation" so an operator (via Claude, terminal CLI, or — in the future — pendant) can answer it later.
 
 For the Anthropic acquisition demo, the auto-onboard moment is a strong reveal — *it just works the way you'd want a robot to work*. Without SP-HP, that moment requires manual operator intervention (re-run init), which weakens the demo.
 
@@ -32,7 +32,7 @@ For the Anthropic acquisition demo, the auto-onboard moment is a strong reveal �
 - **Multi-host robot rigs.** Single host assumed; cross-host event sync is out of scope.
 - **Automatic driver download from a registry.** The matching backend's pip extra must already be installed; if no backend matches the device's protocol, the event lands as LOW with a `missing_backend_extra` hint.
 - **Backend hot-uninstall mid-session.** Manifest stays bound to the named backend even if `pip uninstall` removed the entry-point. Runtime fails with a clean error on next call.
-- **Pendant subscription without an active Claude session.** The pendant subscribes via MCP notifications; no Claude session = pendant doesn't see live events. Events still queue and surface on next Claude connect. Future work: pendant hosts its own socket subscriber. (Tracked in SP-AN.)
+- **Pendant integration.** Originally co-scoped, **deferred to SP-AN v2** because the pendant repo is in early bring-up. SP-HP's queue contract is shape-correct for any future surface; pendant slots in without queue-shape changes. (Tracked in SP-AN.)
 
 ## Design
 
@@ -200,7 +200,7 @@ Tier thresholds are deliberately stricter than SP2's init-time tiers — SP2 has
 {"id":"evt_01H...","ts":"2026-04-27T19:31:05Z","kind":"pending","event":{...},"decision":{...},"prev_hash":"sha256:beef...","this_hash":"sha256:cafe..."}
 ```
 
-**State model:** every `pending` record is in one of three terminal states: `bind | reject | expired`. The terminal state is a separate `kind: "resolved"` record referencing the original by `id` — first writer wins. The MCP server (when subscribed) and the pendant (when reachable) each call `hotplug_confirm` independently; both go through the daemon's socket-or-file API; the daemon serializes resolution writes (see Concurrency below).
+**State model:** every `pending` record is in one of three terminal states: `bind | reject | expired`. The terminal state is a separate `kind: "resolved"` record referencing the original by `id` — first writer wins. In v1 the resolution channels are the MCP server (when subscribed) and the terminal CLI (`robot-md hotplug confirm`); each calls `hotplug_confirm` independently; both go through the daemon's socket-or-file API; the daemon serializes resolution writes (see Concurrency below). v2 surfaces (pendant, web UI) plug into the same path.
 
 **TTL:** pending events expire after **7 days** (configurable via `~/.robot-md/hotplug.toml` key `pending_ttl_days`). The daemon scans the queue on start and once an hour, appending `resolution: "expired"` for any pending older than the TTL.
 
@@ -314,7 +314,8 @@ Operator                                State
                                       audit.append(hotplug_event, ...)
                                       socket nudge
 
-(Operator's pendant or Claude     →   hotplug_review() →
+(Operator's Claude chat session   →   hotplug_review() →
+ or terminal CLI)
  chat session)                          [{event_id, tier=MEDIUM,
                                           bind_proposal: {preset=so_arm101,
                                                           backend=lerobot},
@@ -355,8 +356,7 @@ Operator                                State
 
 ```
 (Robot reboots, daemon restarts.    →   Queue file persists; daemon doesn't
- No Claude session is running. No       lose state across restarts.
- pendant attached.)
+ No Claude session is running.)         lose state across restarts.
                                         HIGH-tier still auto-binds (no
                                         operator dependency).
                                         MEDIUM/LOW pending records persist.
@@ -509,11 +509,11 @@ Operator                                State
 - Long-haul daemon stability: 7-day TTL handling tested via clock skew, not real elapsed time.
 - Multi-arm rigs: single-arm scenarios are the v1 baseline; multi-arm tested by hand only on bob.
 
-## Open Questions
+## Decisions deferred / future work
 
-1. **`pending_ttl_days` default.** 7 days picked to give operators a vacation-length window. Roll back to 3 days if event-queue accumulation becomes a UX problem.
-2. **Pendant subscription path.** v1 limitation: pendant subscribes only via an active Claude session's MCP notifications. Future: pendant hosts its own socket subscriber. Decided: out of scope for SP-HP v1; called out in SP-AN.
-3. **macOS launchd permission prompt.** First daemon launch may trigger macOS's "allow background app" prompt. Action: smoke-test on a fresh macOS account; document the click-through.
+1. **`pending_ttl_days` default.** Picked 7 days as a vacation-length window. Roll back to 3 days if event-queue accumulation becomes a UX problem after first hands-on use.
+2. **macOS launchd permission prompt.** First daemon launch may trigger macOS's "allow background app" prompt. Action item (not a question): smoke-test on a fresh macOS account during plan execution and document the click-through in the operator install hint.
+3. **Pendant + web UI surfaces (SP-AN v2).** Tracked in SP-AN. SP-HP's queue contract is shape-correct for any future subscriber; no SP-HP changes needed when those land.
 
 ## Success Criteria
 
@@ -530,7 +530,7 @@ SP-HP is done when:
 ## Sub-project Relationships
 
 - **SP3 → SP-HP.** SP-HP consumes SP3's `enumerate_capabilities()` to preview a backend's tools at hot-plug time. Without the SP3 addendum, SP-HP would have to re-build the lookup.
-- **SP-HP → SP-AN.** SP-AN's surfaces (audio + Claude chat + pendant) are subscribers of the queue SP-HP produces. SP-AN doesn't write to the queue.
+- **SP-HP → SP-AN.** SP-AN v1's surfaces (audio + Claude chat) are subscribers of the queue SP-HP produces; SP-AN v2 adds the pendant surface. SP-AN doesn't write to the queue.
 - **SP-HP ↔ SP1.** SP1's MCP server gains the inotify watch + socket subscriber + two new tools as part of SP-HP. No SP1 changes outside that delta.
 - **SP-HP ↔ SP4.** When LOW-tier events surface "no backend can drive this hardware," SP4's `author-backend` flow is the operator's path forward. SP-HP doesn't trigger SP4 automatically; surfaces the option.
 - **SP-HP unblocks the auto-onboard demo moment.** Combined with SP-AN, the headline beat is: *robot reboots, no display, audio onboarding, Claude takes over.* SP-HP is the eyes; SP-AN is the mouth.


### PR DESCRIPTION
## Summary

Lands SP3 Slice 0 (scaffold + plans) on top of the latest main. Sets up the capability tier validator and core JSON-Schema so downstream backend adapters (lerobot, realsense) and agent-facing tools (\`describe-capabilities\`, robot-md-http bridge, SP-HP hotplug daemon) can plug in without further infrastructure work. The lerobot and realsense backend implementations themselves are NOT in this PR — they ride the plans landed here.

## What's in Slice 0

**Scaffold (4 code commits, 16 files):**
- \`cli/src/robot_md/schemas/capabilities.json\` — core capability JSON-Schema (Draft 2020-12), drift test pinned
- \`cli/src/robot_md/backends/registry.py\` — capability tier validator (core prefixes vs \`<vendor>.<name>\` regex), wired into \`discover_backends()\` to skip malformed backends
- 6 new test files in \`cli/tests/backends/\` covering schema-loads, schema-arg-validation, schema-all-core-prefixes-present, namespace-core-accepted, namespace-vendor-accepted, namespace-malformed-rejected (20 tests, all passing)

**Plans (3 docs, ~5050 lines):**
- \`docs/superpowers/plans/2026-04-27-sp3-sdk-adapter-pattern.md\` — 198 tasks (full SP3 implementation plan)
- \`docs/superpowers/plans/2026-04-27-sp-hp-hotplug-daemon.md\` — 128 tasks (companion SP-HP plan)
- \`docs/superpowers/plans/2026-04-27-sp-an-announce-confirm.md\` — 54 tasks (companion SP-AN plan)

**Specs (3 design docs, ~1006 lines):**
- \`docs/superpowers/specs/2026-04-26-sp3-sdk-adapter-pattern-design.md\` (with the 2026-04-27 capability-metadata addendum)
- \`docs/superpowers/specs/2026-04-27-sp-hp-hotplug-daemon-design.md\`
- \`docs/superpowers/specs/2026-04-27-sp-an-announce-confirm-design.md\`

## Why merge now (long-term maintenance)

Holding this in a worktree while 380 plan tasks accumulate creates rebase drift risk. The Slice 0 boundary is clean — schema + validator + plans land, no behavior change for existing \`feetech_depthai\` callers. Future Slice 1 (lerobot + realsense backends + the \`Capability\` dataclass + \`enumerate_capabilities()\` walker + \`describe-capabilities\` CLI) executes against latest main without first rebasing 9 stale commits.

## Verification

- 20/20 backends tests pass post-rebase
- Rebased onto current main (\`a4f7c76\`); 0 conflicts (the worktree's diff vs main only showed main being ahead on \`signing.py\`, \`compliance_status.py\`, \`docs/design/*\`, and the schema-v2 plan — all stale-not-deleted)
- No changes to existing emit-* paths, signing, compliance-status, or eu-register

## What this does NOT include

- \`Capability\` dataclass + \`describe_capabilities()\` ABC default
- \`enumerate_capabilities(registry)\` walker
- \`backends/lerobot/\` and \`backends/realsense/\` packages
- \`describe-capabilities\` CLI subcommand
- Authoring guide + backend template
- SO-ARM preset \`preferred_backend: lerobot\` hint

Those are Slice 1 of the SP3 plan and ride this PR's scaffold.

## Test plan

- [x] \`pytest cli/tests/backends/ -v\` — 20 passed
- [ ] CI green

🤖 Generated with [Claude Code](https://claude.com/claude-code)