### PR TITLE
docs(proposals): add proposals/ with four UX design specs

### DIFF
--- a/proposals/README.md
+++ b/proposals/README.md
@@ -1,0 +1,39 @@
+# `robot-md/proposals/`
+
+Proposals to extend the core ROBOT.md spec. Each proposal is a versioned design document that's actively being evaluated — empirically — by the [`robot-md-autoresearch`](https://github.com/RobotRegistryFoundation/robot-md-autoresearch) eval rig.
+
+## How proposals progress
+
+```
+proposals/<slug>.md   ──(eval validates)──▶   spec/<section>.md
+   (open, evolving)                              (merged into core spec)
+```
+
+Each proposal that lands here has a corresponding spec-seeded variant in `robot-md-autoresearch/variants/specs_seeded/`. When that variant beats `baseline` in the autoresearch loop by ≥5% margin (composite score) and clears the cold-start headline gate, the autoresearch promoter opens a PR proposing to merge the proposal into the core spec.
+
+## Current proposals
+
+| Slug | Source | What it proposes |
+|---|---|---|
+| `easy-ux-design.md` | drafted with Craig 2026-04-27 | Single-utterance UX, two-layer safety architecture (`hitl_gates` + new `hitl_overrides` block), layered failure UX (silent retry → visual disambiguation → plain-English), 2-min cold-start headline target |
+| `perception-architecture-v2.md` | drafted with Craig 2026-04-27 | Descriptor store at `<robot_root>/.bob/objects.db`, Claude-multimodal-as-perception-brain, MCP primitives (`grab_frame`, `depth_at_pixel`, `detect_candidates`, `back_project`), `vision.object_descriptors[]` becomes thin migration target |
+| `hand-eye-calibration-v2.md` | drafted with Craig 2026-04-27 | Fiducial-on-gripper auto-calibration; the only manual setup step for DIY robots |
+| `calibrate-zero-v2.md` | drafted with Craig 2026-04-27 | Agent-orchestrated zero-pose calibration via MCP tools, no shell |
+
+All four were drafted in the wake of a session that exposed UX friction points during a single physical pick attempt. Proposals are *design proposals, not yet implemented* — that's what `robot-md-autoresearch` is built to test.
+
+## Authoring a new proposal
+
+1. Write the proposal as a self-contained markdown document. Include:
+   - **Status:** "design proposal, not yet implemented"
+   - **Companion specs:** if the proposal depends on other proposals, list them
+   - **Thesis:** one paragraph
+   - **Manifest changes:** what fields/sections this adds or restructures
+   - **Out of scope** + **Open questions**
+2. Add it as `proposals/<slug>.md`.
+3. Open a corresponding spec-seeded variant in `robot-md-autoresearch/variants/specs_seeded/<slug>/` so the eval can score it.
+4. The autoresearch loop will surface evidence; promotion to the core spec follows from results.
+
+## Why this directory exists
+
+Without `proposals/`, design proposals lived as loose markdown files in a contributor's `~/`. They weren't versioned, didn't have a stable URL, and couldn't be cited from `robot-md-autoresearch`'s `provenance.source.commit`. This directory is the staging ground that closes that gap.

--- a/proposals/calibrate-zero-v2.md
+++ b/proposals/calibrate-zero-v2.md
@@ -1,0 +1,103 @@
+# Spec: zero-calibration UX in `robot-md-mcp`
+
+**Status:** design proposal, not yet implemented.
+**Target repo:** `~/robot-md-mcp` (dev repo, out of scope for today).
+**Audience:** complete beginners running Claude Code with the `robot-md` plugin.
+**Author:** drafted with Craig, 2026-04-27.
+
+## Problem
+
+Today, zero-calibration of a Feetech-bus arm requires the operator to run shell commands:
+
+```
+! robot-md calibrate --zero --dry-run /path/to/ROBOT.md
+```
+
+The CLI prompts at stdin ("Pose the arm... press Enter"), then writes the manifest. This is fine for developers but wrong for first-time users: they don't know what `!` does, why the path is needed, or how to tell whether a dry-run "worked." Worse, when an agent (Claude) tries to drive it, `--yes` aborts the prompt — there is no agent-friendly path through the workflow at all.
+
+Zero-calibration is one of the first things a new operator does after unboxing. The friction lands on the worst possible user.
+
+## Design
+
+Move orchestration into the agent. Expose three MCP tools and one slash-command prompt. The user only ever speaks natural language; Claude calls tools.
+
+### MCP tools
+
+| Tool | Purpose | Mutates manifest? | Hardware effect |
+|---|---|---|---|
+| `mcp__robot-md__torque_off` | Disable torque on all kinematic-bus servos | no | arm goes limp |
+| `mcp__robot-md__torque_on` | Re-enable torque on all kinematic-bus servos | no | arm holds position |
+| `mcp__robot-md__zero_capture_and_commit` | Read current encoders, write `zero_pose_steps` for every joint | yes | none (read-only on bus) |
+
+**Signatures (input/output shape, not full JSONSchema):**
+
+- `torque_off(robot_md_path: str) → { servos: [{id, ok, comm_err, status_err}], port: str }`
+- `torque_on(robot_md_path: str) → { servos: [{id, ok, comm_err, status_err}], port: str }`
+- `zero_capture_and_commit(robot_md_path: str, dry_run: bool) → { proposed: {joint_id: steps}, current_in_manifest: {joint_id: steps}, written: bool, manifest_path: str }`
+
+### Slash command: `/calibrate-zero`
+
+Prompt content (paraphrased — implementer writes the actual text):
+
+> Walk the operator through zero-calibration. Steps:
+> 1. Confirm the manifest path. Default to a `ROBOT.md` in cwd if exactly one exists; otherwise ask.
+> 2. Run `validate` first. Bail if invalid.
+> 3. Tell the operator what's about to happen in plain English ("the arm will go limp; support it if needed"). Wait for them to say ready.
+> 4. Call `torque_off`.
+> 5. Tell them how to pose the arm: "straight along the base +x axis, gripper forward" — but read the manifest's `solver.base_frame` to phrase it correctly for non-default conventions. Wait for them to say it's posed.
+> 6. Call `zero_capture_and_commit(dry_run=true)`. Show a markdown table: joint | current | proposed | delta. Ask if they want to commit.
+> 7. On confirmation, call `zero_capture_and_commit(dry_run=false)`. Show what was written.
+> 8. Always finish with `torque_on`, including on cancel/abort paths.
+
+## Closed design decisions
+
+### 1. Cleanup on abort
+
+`torque_on` is a standalone tool *and* the `/calibrate-zero` flow guarantees it runs on every exit path including user cancel, error, or "no don't commit." If the agent session dies between `torque_off` and `torque_on`, the next session's `/calibrate-zero` (or any tool that opens the bus) re-enables torque before doing anything else. Cleanup is belt + suspenders, not either/or.
+
+### 2. HiTL gate granularity — workflow-level
+
+Invoking `/calibrate-zero` is the authorization for the whole sequence on scope `arm`. Individual tools (`torque_off`, `zero_capture_and_commit`) **do not** re-prompt for HiTL within a single workflow. Outside the workflow (e.g. an agent calling `torque_off` directly during some other task), the `arm`-scope HiTL gate fires normally on the first call.
+
+This matches the precedent set in interactive sessions: when an operator says "disable torque for me," that's workflow-level auth, not a per-tool ask.
+
+### 3. Capture and commit are one tool
+
+Two-step (`zero_capture` → `zero_commit`) was tempting for the "show diff, ask, then commit" UX. Rejected because: between capture and commit, the operator might bump the arm — commit would write the bumped pose instead of the captured one.
+
+Instead: `zero_capture_and_commit(dry_run: bool)`. The slash command calls it twice — once with `dry_run=true` to show the diff, once with `dry_run=false` to commit. Each call re-reads encoders. If the operator bumps the arm between the two calls, the commit writes the *current* pose (which is what they actually want — they re-posed). The diff displayed in step 6 is then technically stale by step 7, but trivially so; if it's a meaningful drift, the implementer can compare proposed-now to proposed-then and re-show.
+
+### 4. Scope: `--zero` only
+
+This spec covers zero-calibration. `--sign` (per-joint encoder direction test) and `--extrinsic` (camera-to-arm via gripper silhouette) have the same shell-prompt UX problem and want the same agent-orchestrated treatment, but they're future work. Same pattern: torque-gated tools + a slash command per workflow.
+
+## Pre-flight checks the tools must do
+
+- **Port busy.** If `/dev/ttyACM0` (or whatever `drivers[].port` declares) is held by another process — typically `castor-gateway` — fail fast with a clear message naming the process and the systemctl command to stop it. Do not hang.
+- **Servo enumeration.** Before any write, confirm all servos in `physics.kinematics[].servo_id` respond. Surface missing servos by id; do not silently skip and write a partial manifest.
+- **Manifest validity.** Run schema validation first. A broken manifest doesn't get a calibration write.
+
+## Out of scope
+
+- Implementation. This is a spec.
+- New protocol support beyond Feetech. The existing CLI only supports `protocol: feetech` for `--zero`; this spec inherits that.
+- Touching the `robot-md` CLI. The CLI keeps its existing flags; the new MCP tools live in `robot-md-mcp` and may share helpers with `robot-md/calibrate.py`, but this spec doesn't dictate where the shared logic lives.
+- Calibration of the camera extrinsic or per-joint sign — see "Scope" above.
+
+## Open questions for implementer
+
+- **Where does the slash command live?** Plugin's `commands/` dir vs. an MCP `prompts/` entry. Both work; Claude Code surfaces them differently. Probably MCP prompt for parity with `/brief-me` and `/check-safety`.
+- **Audit trail.** Should `zero_capture_and_commit` write an entry to `~/.robot-md/audit/`? Probably yes, with the before/after `zero_pose_steps` table. Decide format.
+- **Auto-`torque_on` on bus open.** The "session-died-mid-flow" recovery path: should *every* tool that opens the Feetech bus first ensure torque is enabled? Or only the calibration tools? The conservative answer is "every tool re-enables on entry, disables on intentional flow only" — but that has its own footguns (e.g. an inspect-only read tool re-enabling torque is surprising). Decide.
+
+## Lesson from 2026-04-27 session: capture pose ≠ held pose
+
+When `zero_capture_and_commit` was run with torque off and the operator hand-posing the arm, the captured `zero_pose_steps` reflected the **limp pose** (where gravity settled the arm) — not the **held pose** (where the operator intended). After torque was re-enabled with goal=present, the arm settled into the held pose, ~7° offset from the captured zero on `shoulder_lift`. Every subsequent FK calculation was off by that much.
+
+This is a workflow bug, not a code bug. The fix is in the slash command's UX:
+
+1. After torque-off and the operator's "ready" signal, the tool should briefly re-enable torque at *low* current (or with the operator supporting the arm) and read present positions while the arm is **actively held** in the zero configuration — not while it's drooping under gravity.
+2. Alternatively: capture two readings — once limp, once with operator supporting the arm against gravity — and report the discrepancy. If >2° on any joint, prompt the operator to physically support the arm and recapture.
+3. Or: provide a calibration jig (3D-printable) that physically locks the arm in zero pose, eliminating gravity-droop entirely.
+
+The implementer's choice. The MCP tool spec needs a `/zero-cal-recapture` operation that handles "I noticed the captured pose was limp, let me redo it correctly" without having to walk the operator through the whole flow again.

--- a/proposals/easy-ux-design.md
+++ b/proposals/easy-ux-design.md
@@ -1,0 +1,178 @@
+# Spec: extreme ease-of-use UX for robot-md across Anthropic surfaces
+
+**Status:** design proposal, not yet implemented.
+**Target:** the user-facing UX layer for robot-md, spanning Claude Code, claude.ai (web/desktop), Claude mobile, and voice.
+**Author:** drafted with Craig, 2026-04-27 (after a full-session attempt at picking a blue lego that exposed the friction points this spec aims to remove).
+**Companion specs:** `perception-architecture-v2-spec.md`, `hand-eye-calibration-v2-spec.md`, `calibrate-zero-spec.md`.
+
+## Thesis
+
+LLMs + agent harnesses can solve robotics with **great UX from any Anthropic surface**. The same MCP server, the same conversation, the same continuity — driven from Claude Code, claude.ai web, Claude desktop, Claude mobile, or voice. Surfaces differ in what they show; the *robot* and the *conversation* are the same.
+
+## Headline demo
+
+**A complete novice plugs in bob, opens any Claude surface, and within ~2 minutes is making bob pick things up.**
+
+This is the falsifiable proof point. Filmable. Repeatable. If we hit it for out-of-box robots and the same UX path applies to DIY robots (just with a one-time fiducial-on-gripper step), the thesis lands. Other proof points — surface portability, autonomous task completion, classroom demos — fall out of the same architecture.
+
+## Design philosophy
+
+Three principles that reinforce each other:
+
+1. **Extreme ease of use for non-developers.** The default user has a robot and a goal — "pick the blue lego, put it in the bowl" — not a robotics engineer. Manifest edits, depth bounds, axis conventions, IK envelope reasoning all live *inside the agent's loop*, never on the operator's plate.
+
+2. **Data-rich primitives so the agent can reason.** Every operation surfaces enough context for Claude to diagnose: raw frames, all detection candidates with metadata, kinematic envelope details with axis-decomposed reasons, FK + IK traces. The agent is the analyst; the CLI/MCP is the data plane.
+
+3. **The agent is reactive, not driven.** Operator says one thing. Everything between that utterance and the result — choosing among candidates, tightening descriptors, panning the arm to clear an occlusion, switching IK branches, retrying a failed grasp — happens *autonomously* inside the agent's loop. The operator answers questions only when there is genuine ambiguity or a HiTL gate fires.
+
+Together: rich data lets the agent be reactive, reactivity lets the operator stay at one utterance, and ease of use is the result.
+
+## Audience
+
+A **single UX baseline** simple enough for a complete beginner, with **depth available on demand** for tinkerers, researchers, and developers. There are not separate "consumer" and "developer" modes; there is one experience that lets the operator dig deeper when they want to. Depth surfaces as: status panels in the surface UI, slash-commands in Claude Code, MCP resources for direct programmatic access. Beginners never encounter these unless they go looking.
+
+## First-time UX
+
+### Out-of-box robot
+
+The robot ships pre-calibrated: zero-pose values, camera extrinsic, workspace bounds, declared object descriptors all populated and validated. ROBOT.md travels with the device.
+
+1. Operator powers on the robot. The MCP connector / plugin announces the robot to the operator's logged-in Claude account.
+2. Operator opens any Claude surface and asks for something — "hi" or "what can bob do" or "pick something up."
+3. Bob responds within seconds. First useful action (a wave, a pick, a scene description) within ~30 seconds.
+4. **Time to first pick: ~2 minutes** including unboxing physical setup. The minimal-UX pattern (one utterance → action → "got it") applies from the first command.
+
+No setup wizard, no calibration prompts, no manifest editing. The operator interacts as if Bob has always existed.
+
+### DIY robot
+
+The operator has assembled the robot themselves: chosen mount orientation, attached the camera at some position, set up the workspace. ROBOT.md exists but the per-instance values (zero, extrinsic, workspace) need to be discovered.
+
+1. Operator powers on, connects via MCP plugin (same as out-of-box).
+2. First time the operator says anything that needs the calibrated state, bob detects "uncalibrated" and offers a one-action setup: **"Tape this fiducial onto the gripper face and let me do the rest."** Bob displays/links the fiducial PDF (a small ChArUco board sized for the gripper). Operator prints, tapes, says "done."
+3. Bob runs the full calibration autonomously: zero pose discovery, hand-eye extrinsic via the fiducial sweep, workspace bounds via reach probing. Operator watches; total ~5–10 minutes including print + tape time.
+4. From that point on, the operator's experience is identical to the out-of-box flow.
+
+The fiducial-on-gripper step is the *only* manual action a DIY operator does for setup. Mounting orientation, axis conventions, workspace shape — all auto-discovered. (Today, every one of these is a manifest edit; in the new architecture, none are.)
+
+## Routine pick UX
+
+Minimal. The operator says it; bob does it.
+
+> **Operator:** "pick the red lego"
+>
+> *(arm motion)*
+>
+> **Bob:** "got it"
+
+No mid-motion narration, no per-pick auth prompts, no descriptor tuning. If bob succeeds, the operator hears one word and sees the result on whatever surface they're on (text on Claude Code; live camera with a green target overlay on web/mobile; voice narration on voice).
+
+## Safety architecture
+
+Two layers, both encoded in the manifest's `safety.hitl_gates`:
+
+1. **Workflow-level auth, prompted once per session.** When the operator first asks for arm motion in a session (the first "pick X" or "place Y" or "wave"), bob asks once: "okay to let me move?" After approval, all routine motions inherit that auth — silent for the rest of the session.
+
+2. **Unusual-condition overrides, always fire per-action.** Even after workflow-level auth, certain conditions still prompt:
+   - Payload near declared limit
+   - Velocity near declared max
+   - Trajectory passing close to workspace boundary or a singularity
+   - Target outside any descriptor bob has high confidence in
+   - Duty-cycle warnings (e.g., wrist_flex stall risk)
+
+The manifest's existing `safety.hitl_gates` is reframed: *scope: arm, require_auth: true* becomes "auth-once-per-session for routine, auth-per-action for unusual." The unusual-condition list lives in `safety.hitl_overrides` (new manifest block) so each robot can declare its own envelope.
+
+## Failure UX
+
+Layered, in this order:
+
+1. **Silent auto-retry.** Bob tries alternative IK branches, tightens descriptor depth bounds, pans the arm to clear occlusion, re-detects after small motions — all without saying anything. Most failures resolve here.
+
+2. **Visual disambiguation.** When there is genuine ambiguity (two equally-good red legos), surfaces with screens highlight the candidates with bounding boxes; the operator taps/clicks the right one. Text on Claude Code: "two red legos — left or right?" Voice: same as text.
+
+3. **Plain-English fallback.** When fundamentally blocked (out of reach, no detection at all, manifest contradiction), bob says one line in plain English with one suggested fix: *"Can't reach that — it's about 5 cm below my arm's range. Try moving it up a bit."*
+
+The agent never returns an opaque error code or boolean to the operator. The structured failure data from the primitives is consumed by Claude and translated into one of the three layers above.
+
+## Vocabulary and perception
+
+**Claude's multimodal vision is the perception brain.** Bob exposes primitives — `grab_frame`, `depth_at_pixel`, `detect_candidates`, `back_project`, `plan_motion`, `execute_motion` — and Claude composes them. When the operator says "the red lego," Claude looks at the frame, identifies what's there, picks the right candidate, and proceeds. There is no on-device ML model trained on object classes.
+
+**Show-and-tell for novel objects.** "Call this one 'sort target'" while bob's camera is on it; "watch where I drop this"; "the thing I'm holding." Bob captures the visual fingerprint (Claude-generated embedding) and stores it in the descriptor store. Next time the operator says "sort target," it just works.
+
+**Descriptive language as fallback.** "The small red rectangle near the bowl." "The tall blue thing." Claude parses the description against the current frame.
+
+**Descriptor store** lives in `<robot_root>/.bob/objects.db` (per the perception-architecture-v2 spec). Holds Claude-generated embeddings + per-object metadata (last_known_pose, registered/ephemeral class, lighting hints). The manifest's `vision.object_descriptors[]` becomes a thin migration target — registered descriptors only, not the catalog.
+
+## Multi-step task composition
+
+Hybrid:
+
+- **Default: single utterance, silent execution.** "Pick the red lego and put it in the bowl" → bob plans pick + place, executes, says "done." One green checkmark.
+- **Long sequences: narrate phase transitions only.** "Sort the legos by color" → bob says "sorting" at start, transitions ("picked the blue one, placing"), and "done" at end. Not chatty; just enough for the operator to know the phase.
+- **Demonstration / imitation as a separate explicit feature.** "Watch me do this — I want you to call it 'sort'." Operator hand-guides bob through the task once (torque off; visual servoing); bob captures the trajectory and the perception conditions; afterwards, "do sort" replays it adapted to current scene.
+
+## Visualization and surface adaptation
+
+Same MCP backend, surface-tailored front-ends:
+
+| Surface | Visual treatment |
+|---|---|
+| **Claude Code** | Text-mostly. Status lines like "moving... grasp complete." Image attachments (camera snapshot with overlays) included in replies when useful. |
+| **claude.ai web / desktop** | Live camera feed panel alongside the chat. Overlays for current target, planned trajectory, completed grasp. Status panel showing arm pose. |
+| **Claude mobile** | Full-screen video on capture/in-action; text-overlay status. Native to "operator standing near the robot." |
+| **Voice** | Rich narration: "I see the red lego near the bowl. Picking it up now. Got it. Where would you like it?" |
+
+The MCP server exposes resources surfaces can render: `current_frame_url`, `current_target_overlay`, `arm_pose_status`, `task_phase`. Surfaces consume what they can, ignore the rest.
+
+**Multimodal data flow back to Claude.** Frames, depth maps, FK trace, motion overlays, candidate detection lists — all available as MCP resources Claude can read on demand. This makes Claude's reasoning richer: when something fails, Claude can pull the actual depth at the centroid, see the candidate alternatives, render the planned trajectory in 3D — without going outside the published API.
+
+## Memory and continuity
+
+> **Status: open. The shape below is a working draft, not a settled commitment.** Memory/continuity needs more brainstorming before this spec is finalized or used as marketing copy. Not yet on the site.
+
+The aspirational target is **full continuity** — same bob across sessions and across surfaces. Working draft of what that might mean:
+
+- **Persistent state:** descriptor store entries (objects bob knows), calibration values, operator preferences (default cautiousness, preferred narration verbosity), learned tasks (from demonstration), in-progress task state.
+- **Conversation continuity:** the operator can start a "sort the legos" task on Claude Code at the desk, switch to Claude mobile to watch from across the room, ask a question on claude.ai web on a laptop — same task, same conversation thread.
+- **Storage:** persistent state in `<robot_root>/.bob/` (descriptor store, preferences, task log). Conversation continuity via standard Claude session-handoff mechanisms (Claude memory, project state).
+
+**Open questions before this section gets nailed down:**
+
+- *Conversation continuity across surfaces:* what mechanism actually delivers this? Claude memory features differ between Claude Code, claude.ai, and Claude mobile. Is "the same conversation" carried by Claude's session/memory infrastructure, or do we need our own session ID we attach to messages? Likely depends on what Anthropic ships and exposes; needs research.
+- *Auth carryover:* if the operator authorizes motion on Claude Code, does that auth carry to a Claude mobile conversation about the same task? (Same operator, same robot — but different Claude instance.)
+- *Task state persistence:* is "in-progress task" something the agent reasons about (carried in conversation context) or something the robot side persists (carried in a server-side state machine)?
+- *Privacy boundary:* what state lives on the robot vs. what crosses to Anthropic? Descriptor embeddings + frames the agent has analyzed are sensitive; the storage model needs to make this explicit.
+
+Until these resolve, the spec asserts only the *minimum*: persistent objects + persistent calibration in `<robot_root>/.bob/`. Cross-surface conversation continuity is a stated *goal*, not a spec'd guarantee.
+
+## Architecture notes (high level)
+
+This spec describes the UX. The architecture that delivers it is composed from the three companion specs:
+
+- **MCP server** ([perception-architecture-v2-spec.md](perception-architecture-v2-spec.md)) exposes the rich primitives + descriptor store + slash commands. Same server, every surface.
+- **Hand-eye calibration v2** ([hand-eye-calibration-v2-spec.md](hand-eye-calibration-v2-spec.md)) provides the fiducial-on-gripper auto-calibration that makes DIY first-run viable.
+- **Calibrate-zero v2** ([calibrate-zero-spec.md](calibrate-zero-spec.md)) handles zero-pose calibration via MCP tools, no shell.
+- **This spec** ties them together into the operator-facing experience.
+
+## Out of scope
+
+- Specific ML model selection for the descriptor store (deferred to perception spec; depends on device benchmarking).
+- Voice surface implementation details (the abstract "voice" target stands in for whatever Anthropic ships).
+- Multi-robot fleets / shared vocabularies across robots.
+- Cloud / remote operation (local-first design assumed).
+- Bob's "personality" / tone — kept neutral and minimal by default; could be a future config knob.
+
+## Open questions
+
+- **Workflow-level auth lifetime.** A "session" — is that a Claude conversation? A time window? Until the operator closes the surface? Likely: per-conversation, with re-auth required on a fresh conversation.
+- **Cross-surface auth handoff.** If the operator authorizes motion on Claude Code, then opens Claude mobile, does the auth carry? Probably yes if it's the same Claude conversation; ambiguous if it's a separate conversation referencing the same task. Implementer to decide.
+- **Demonstration mode safety.** Hand-guided imitation requires torque-off; the captured trajectory then replays under torque. The replay's safety envelope must be derived from the demonstrated trajectory's bounds, not the manifest's full envelope, to prevent runaway motion. Spec needed.
+- **What "done" means in a multi-step task.** When does bob declare a place "successful"? Visual confirmation that the object is in the target zone? Force-sensor confirmation of a release? Operator confirmation? Probably: visual + IK-position check by default, operator override available.
+- **Failure modes for `current_frame_url`.** If the camera disconnects mid-task, what's the surface UX? Text fallback is obvious; the visual surfaces need a graceful "camera offline" state.
+
+## Why this matters
+
+The session this spec was drafted from spent hours on a single pick attempt. The blockers were not algorithmic novelty — every individual primitive worked — they were **UX**: opaque error codes, manual manifest edits, axis conventions the operator and the system disagreed on, calibration that needed a printer the operator didn't have. None of those should ever reach the operator's awareness.
+
+If we hit the headline ("2 minutes from box to first pick, on any Anthropic surface"), the thesis is proven: agent harnesses + multimodal LLMs can run robotics with consumer-grade UX. The path from this spec to that demo runs through the three companion specs — perception primitives, fiducial calibration, agent-orchestrated zero — all of which are specced. The work remaining is implementation.

--- a/proposals/hand-eye-calibration-v2.md
+++ b/proposals/hand-eye-calibration-v2.md
@@ -1,0 +1,126 @@
+# Spec: hand-eye calibration v2 — fiducial-based, agent-orchestrated
+
+**Status:** design proposal, not yet implemented.
+**Target repo:** `~/robot-md` (CLI/types) and `~/robot-md-mcp` (MCP server). Both dev repos.
+**Author:** drafted with Craig, 2026-04-27.
+
+## Problem
+
+The existing `robot-md calibrate --extrinsic` mode uses a **gripper-silhouette + wrist-wiggle** algorithm: move the arm through 6 sweep poses, capture depth, shift wrist_flex by a small delta and capture again, diff to isolate the gripper, solve Procrustes from FK gripper position ↔ camera-frame centroid.
+
+In a real session it produced **216 mm and 243 mm residuals** on consecutive runs. The method is fundamentally fragile for typical SO-ARM101 + OAK-D setups:
+
+- **The "marker" is the gripper itself** — small, matte, low-texture. Stereo depth has holes on it. The wiggle-diff becomes "subtract two noisy depth maps and hope the gripper is the largest residual."
+- **Six pose samples is too few** for a 6-DoF rigid transform under noise.
+- **Operator manual measurement** as the fallback (what we resorted to in the session) is fragile because it requires the operator to decompose a single straight-line distance into per-axis components in the *arm's* frame, which depends on the mounting orientation — a step where the operator and the manifest's `base_frame` convention silently disagree.
+
+The session's session-end measurement put the camera at "23 inches from arm base," which the operator interpreted as straight-line and Claude initially modeled as purely vertical. The math then put a lego on the bowl-table at world arm-z = −545 mm (outside workspace), when it was physically reachable. No amount of HSV-tuning or workspace-bound-loosening fixed it because the underlying transform was wrong.
+
+## Design
+
+A **fiducial-on-gripper hand-eye calibration** that:
+1. Uses a **printed visual marker** (ArUco / ChArUco / AprilTag) attached to the gripper at a known offset.
+2. Detects the marker corners with subpixel accuracy in each frame (OpenCV `cv2.aruco` is mature; runs on CPU at >100 FPS).
+3. Moves the arm through 15–25 poses (vs. 6), all with the marker visible to the camera.
+4. Solves AX = XB (or Procrustes on marker-3D-pose ↔ FK-3D-pose) with `cv2.calibrateHandEye`.
+5. Expected residual under 5 mm; typical sub-mm on a clean run.
+
+### Operator UX
+
+```
+> /calibrate-camera
+Bob: I see your gripper has the ArUco-12 marker. I'll move through 18 poses
+     to learn the camera-to-arm transform. Workspace clear?
+Operator: yes
+Bob: Authorizing 18 commanded arm motions on scope `arm`. Starting now.
+[runs ~90 s]
+Bob: Calibrated. Residual 2.3 mm. Camera is at (-12, +47, +584) mm in arm frame,
+     looking down with 4.2° forward tilt. Saved to ROBOT.md.
+     extrinsic_source: aruco_handeye_calibrated
+```
+
+That's the entire flow. No depth-bound tweaks, no manual measurement, no axis-mapping debate.
+
+### MCP tools
+
+| Tool | Purpose |
+|---|---|
+| `mcp__robot-md__detect_marker` | Run ArUco detection on the current frame, return `[{marker_id, corners_pixel, pose_camera_frame, confidence}]` |
+| `mcp__robot-md__plan_calibration_poses` | Generate N safe poses (workspace-checked, marker-visible-from-camera-checked, joint-envelope-safe) |
+| `mcp__robot-md__execute_calibration_sweep` | HiTL-gated: visit each pose, capture marker pose, capture FK gripper pose, return paired list |
+| `mcp__robot-md__solve_handeye` | Run `cv2.calibrateHandEye` on the paired list, return `{extrinsic_6vec, residual_mm, per_pose_error}` |
+| `mcp__robot-md__commit_extrinsic` | Write to ROBOT.md after operator approves the residual |
+
+These are deliberately separable so the agent can intervene mid-flow ("residual is 4 mm — looks good, committing" vs. "residual is 80 mm and pose 7 had no marker detection — let me re-run with one more pose").
+
+### Slash command
+
+`/calibrate-camera` orchestrates the above. On failure modes:
+
+- **No marker detected at start** → operator instruction in plain English: "I don't see the calibration marker on the gripper. It should be a ChArUco/ArUco patch — print one from `~/.robot-md/marker.pdf` and tape it to the gripper face, then retry."
+- **Some sweep poses miss the marker** → agent retries those poses (marker detection sometimes fails at extreme angles); if persistent, reduces sweep diversity.
+- **High residual (>10 mm)** → agent surfaces per-pose errors; operator decides: re-run with more poses, or investigate physical issue (mast wobble, marker not flat, arm zero off).
+
+## Closed design decisions
+
+### 1. Marker type: ChArUco
+
+ArUco alone is single-marker, less robust at extreme angles. ChArUco interleaves checkerboard corners with ArUco IDs, gives more correspondence points per detection, and is OpenCV-supported out of the box. A small ChArUco board (e.g., 5×4 ArUco-25 mixed with checkerboard) on the gripper face is enough.
+
+The board is shipped as a printable PDF in `~/.robot-md/marker.pdf` (sized to fit a typical small-gripper face). First-run UX: `robot-md` checks if the manifest's `solver.gripper.marker` block is populated; if not, generates the PDF and prompts the operator to print + tape it.
+
+### 2. Manifest declaration
+
+```yaml
+physics:
+  solver:
+    gripper:
+      marker:
+        type: charuco
+        dict: DICT_4X4_50
+        ids: [12, 13, 14, 15]    # the ChArUco corner IDs used
+        size_mm: 30               # board edge
+        offset_from_tip_mm: [0, 0, -10]   # marker center relative to gripper tip in gripper frame
+```
+
+This block is what `detect_marker` consults at runtime. It's a *registered* descriptor (auditable), not in the dynamic store.
+
+### 3. Pose-sweep generation
+
+`plan_calibration_poses(n=18)` returns poses that:
+- Lie inside `physics.workspace.bounds_mm`
+- Place the marker inside the camera's FOV (predicted via current best-guess extrinsic — bootstrapping)
+- Span sufficient orientation variance (Procrustes degenerates if all poses share an axis)
+- Pass `analyze_envelope` (no joint near limit, no duty-cycle violation)
+
+Bootstrapping problem: the first calibration has no prior extrinsic, so "marker in FOV" can't be predicted. Solution: the first sweep uses a coarse sweep through the *full* workspace; the agent observes which poses produce successful marker detections and concentrates the next sweep around those. Two-stage: rough sweep (n=12) → refined sweep (n=12). Total ~24 motions, ~2 minutes.
+
+### 4. The mounting-orientation problem stops mattering
+
+Once the calibration is sub-mm, "is the camera 23 inches above or 21 inches forward + 8 inches up" stops being a manual reasoning problem — the math falls out of the AX=XB solve regardless of the operator's intuition about mounting geometry. The session's primary blocker simply disappears.
+
+### 5. Backwards compatibility
+
+The existing `--extrinsic` (silhouette) mode stays in place as a fallback for setups where a marker can't be added. But the docs and the `robot-md doctor` recommendations point at the marker-based mode as the default for new robots.
+
+## Out of scope
+
+- Implementation. This is a spec.
+- Multi-camera calibration (each camera calibrates independently against the same gripper marker).
+- Continuous (online) recalibration — out of scope; the assumption is the camera-arm rigid mount doesn't drift between sessions.
+
+## Open questions for implementer
+
+- **Marker size vs. arm size.** The SO-ARM101 gripper face is small (~30 mm). ChArUco boards under 25 mm get unreliable corner detection at typical OAK-D RGB resolution + 800 mm working distance. Size needs validation per arm.
+- **Where the marker mounts.** Gripper face vs. wrist flange vs. dedicated calibration jig. Gripper face is operator-friendly (no extra hardware) but obstructed during pick. Wrist flange is robust but needs hardware. Default: gripper face, with a "swap to flange" flag for users who want a permanent mount.
+- **What if the operator can't print a board?** Fallback: a single saturated-color sticker (e.g., a fluorescent green dot) at known offset. Lower accuracy (centroid only, no corners), but better than the silhouette method.
+- **Validating the result.** After calibration, do a verification pose: command the arm to put the gripper at a known world-frame point, observe where the marker actually appears in the camera, report the discrepancy. If >5 mm, surface to operator.
+
+## Companion specs
+
+- `/home/craigm26/perception-architecture-v2-spec.md` — uses the same MCP-tool pattern; the gripper-marker block declared here is consumed by the `detect_gripper` primitive in that spec.
+- `/home/craigm26/calibrate-zero-spec.md` — zero-pose calibration. Should run *before* hand-eye (FK accuracy is a prerequisite for hand-eye to converge).
+
+## Why this matters
+
+The session's failure to pick a lego on a clearly-visible bowl-table came down to ~2 cm of camera-pose uncertainty. Sub-mm hand-eye calibration would have made the entire arc — manifest tweaks, extrinsic guesses, axis confusion, IK reach errors, visual servoing — unnecessary. The right ergonomic answer for an operator-facing robot is: print a board, tape it on, run one slash command, done.

--- a/proposals/perception-architecture-v2.md
+++ b/proposals/perception-architecture-v2.md
@@ -1,0 +1,209 @@
+# Spec: perception architecture v2 + agent-orchestrated primitives
+
+**Status:** design proposal, not yet implemented. Updated 2026-04-27 evening with second-session lessons (drop-and-pick attempt + visual servoing exploration).
+**Target repo:** `~/robot-md` (CLI/types) and `~/robot-md-mcp` (MCP server). Both dev repos, out of scope for tonight.
+**Author:** drafted with Craig, 2026-04-27.
+
+## Design philosophy
+
+**Extreme ease of use for non-developer operators.** The default user is someone with a robot and a goal — "pick the blue lego, put it in the bowl" — not a robotics engineer. Every primitive should compose into single-utterance workflows. Manifest edits, depth-bound tuning, axis conventions, and IK envelope reasoning should be *inside* the agent's loop, not on the operator's plate.
+
+**Data-rich primitives so the agent can reason.** Every operation that can fail must return enough data for the agent (Claude) to diagnose without reaching past the API: raw frames, all detection candidates with metadata, kinematic envelope details with axis-decomposed reasons, FK + IK trace at every waypoint. The agent is the analyst; the CLI's job is to surface the data, not pre-summarize it into one-line booleans.
+
+**The agent is reactive, not driven.** The operator says "pick the blue lego." Everything between that and a successful pick — choosing among multiple candidates, tightening a depth window, panning the arm to clear an occlusion, switching from one IK branch to another, retrying a failed grasp — happens *autonomously inside the agent's loop*, with the agent observing the data the primitives surface and adjusting in real time. The operator answers questions only when there is genuine ambiguity (which of two visible legos? approve a motion that hits a HiTL gate?). They never tweak depth bounds, joint limits, descriptor params, or workspace bounds by hand.
+
+These three goals reinforce each other: rich data lets the agent be reactive, reactivity lets the operator stay at "pick the blue lego," and ease of use is the result.
+
+## Problem
+
+Two related shortcomings in the current design surfaced repeatedly during a real-world bob session:
+
+**1. Object vocabulary lives in the manifest.** Every object the robot can see is declared as a `vision.object_descriptors[]` entry with explicit HSV params + depth bounds. Adding "remember the blue lego over there" requires editing ROBOT.md. The manifest is meant to be the robot's *identity contract* — auditable, stable, RCAN-provenanced — and shouldn't be churning every time the agent encounters a new object. Worse, HSV with hand-tuned depth bounds is fragile: a lighting change, a scene shift, or a workspace rearrangement breaks the descriptor silently and the detector falls through to whatever red blob is the next-largest in frame.
+
+**2. The CLI's high-level primitives are opaque.** `vision_find(descriptor)` returns `ok | no_match | error`. `execute_capability(arm.pick)` returns `ok | unreachable | blocked`. Every failure mode in a real session needs to be opened up — *which* candidate did HSV pick? *Why* is the IK envelope at risk? *What's* the depth at the centroid? The agent's only path to diagnosis is reaching past the primitives into the package internals (Perception class, raw frames, contour lists, IK solver). That's not an architecture; that's an escape hatch.
+
+These aren't edge cases. In tonight's session every failure required low-level diagnosis: a wrong-blob HSV detection (smaller red object closer to camera won over the actual lego), depth filter rejecting valid depth, IK envelope warnings hiding "elbow at 89.7°" behind a single boolean, extrinsic miscalibration mistaken for axis-mapping error. The agent did all of this by hand; the primitives didn't help.
+
+## Design
+
+Two coupled changes:
+
+### A. Object vocabulary moves to a local vector store
+
+Manifest declares the perception *system*, not the *catalog*:
+
+```yaml
+vision:
+  descriptor_store:
+    backend: sqlite-vec
+    path: ./.bob/objects.db   # robot-scoped, sibling to ROBOT.md
+  detectors:
+    - hsv             # the algorithm, not a tuned instance
+    - clip            # planned: image embeddings via on-device CLIP
+    - depth_segment
+```
+
+Object entries live in the store with two provenance classes:
+
+- **Registered** — the operator (or a calibration tool) added it deliberately. Has RCAN-equivalent provenance (operator id, timestamp, signing). Survives store rebuilds. Used for safety-relevant objects (e.g., e-stop button location, calibration markers).
+- **Ephemeral** — agent-added during a session. Cleared on store rebuild or session end. Used for "the red lego at this corner of the table." No safety contract.
+
+Schema for an entry: `id`, `class` (registered|ephemeral), `embedding` (vector), `detector_hint` (which algorithm worked best), `last_known_pose_world_mm`, `created_at`, `created_by`. The HSV-style params (`h_ranges`, etc.) become a per-entry `detector_hint.params` blob, not a separate type — this also gives a path for keeping the existing manifest-declared HSV descriptors working: they get migrated into the store as `class: registered`.
+
+### B. CLI exposes deterministic *primitives*; agent orchestrates the *workflow*
+
+Today's high-level tools (`vision_find`, `execute_capability`) stay — they're auditable and useful for production "do the thing" calls. New low-level MCP tools sit alongside them:
+
+| Tool | Purpose | Mutates state? |
+|---|---|---|
+| `mcp__robot-md__grab_frame` | Returns RGB + depth + intrinsics from the active camera | no |
+| `mcp__robot-md__detect_candidates` | Runs a detector, returns *all* candidates with metadata (pixel, depth, area, embedding) — not filtered to one | no |
+| `mcp__robot-md__back_project` | (pixel, depth) → camera-frame XYZ | no |
+| `mcp__robot-md__apply_extrinsic` | camera-frame XYZ → world-frame XYZ | no |
+| `mcp__robot-md__describe_reachability` | world-frame XYZ → `{ workspace_ok, ik_solution, envelope_risk, suggested_approach_height_mm }` with the *reasons*, not just a boolean | no |
+| `mcp__robot-md__plan_pick` | (world-frame XYZ, gripper_state) → trajectory waypoints (no execution) | no |
+| `mcp__robot-md__replay_trajectory` | Execute waypoints, dry-run flag, HiTL-gated | yes (motion) |
+| `mcp__robot-md__store_descriptor` | Add an entry to the descriptor store; class=ephemeral by default, registered requires extra auth | yes (descriptor store) |
+| `mcp__robot-md__query_descriptors` | Lookup by id, by embedding similarity, or by last-known-pose | no |
+
+**Signatures (shape, not full JSONSchema):**
+
+- `grab_frame() → { rgb_b64, depth_b64, K, frame_id }`
+- `detect_candidates(detector: str, params: dict, max: int = 8) → [{ pixel, depth_mm, area_or_score, descriptor_match: str|null }]`
+- `describe_reachability(xyz_world_mm: tuple) → { workspace_ok, workspace_violation: str|null, ik_status: ok|unreachable|envelope_risk, ik_solution: dict|null, envelope_detail: str|null, recommended_approach_height_mm: float }`
+- `plan_pick(xyz_world_mm, approach_height_mm: float|null) → { waypoints, total_motion_estimate_s }` 
+- `replay_trajectory(waypoints, dry_run: bool, confirm_token: str|null) → { status, error: str|null, executed_waypoints, final_pose }`
+- `store_descriptor(name, embedding, detector_hint, registered: bool, last_known_pose: tuple|null) → { id, persisted_to: str }`
+
+### Slash commands
+
+| Slash command | What it orchestrates |
+|---|---|
+| `/find` | "Find the X." Agent: grab_frame → detect_candidates → score against descriptor store → return the top candidate with reasoning. If multiple competing matches, surfaces all of them and asks which. |
+| `/pick` | "Pick the X." Agent: find → describe_reachability → plan_pick → operator confirm → replay_trajectory. *Crucially*, on any failure (not in workspace, IK envelope risk, multiple candidates), surfaces *why* in plain English and offers the actionable fix ("move the lego ~5 cm closer to the arm" rather than `outside_workspace: True`). |
+| `/remember-this` | Agent stores the currently-detected object as an ephemeral descriptor. Operator can later promote to registered. |
+| `/where-is` | Query the descriptor store by name, returns last-known-pose and recency. |
+
+The slash commands are MCP prompts, parallel to `/check-safety` and `/brief-me`.
+
+## Closed design decisions
+
+### 1. Two stores, not three
+
+Manifest descriptors and DB descriptors are unified. Existing `vision.object_descriptors[]` entries get migrated into the store as `class: registered` on first run. The manifest field becomes a thin migration target ("declare these on first boot if they're not already in the store"); long-term, descriptors live only in the store. No third "in-memory" tier; ephemeral entries persist to disk so the next session can ask "where was the lego last time?" — they just don't have RCAN provenance.
+
+### 2. Embedding model: deferred, plug-in interface
+
+Hard to commit to a specific model (CLIP, DINO, MobileCLIP, etc.) without device-specific benchmarking. Pi 5 + Hailo-8 NPU has good ML acceleration for common architectures. The spec defines the *interface* (`detector: clip` calls a registered embedding plugin and stores the vector), not the model. v1 implementation can use a small CLIP variant; later versions swap in something faster.
+
+### 3. The descriptor store is robot-scoped
+
+`./.bob/objects.db` (sibling to ROBOT.md), not `~/.robot-md/`. A robot's vocabulary belongs to that robot, not to the host. Multiple robots on one host get independent stores. This also makes per-robot backups straightforward (one tarball with ROBOT.md + objects.db).
+
+### 4. Provenance gates apply to *registered* descriptors only
+
+Motions targeting an ephemeral descriptor still hit `arm` HiTL gates. But ephemeral descriptors don't get the audit trail / RCAN signature that registered ones do — there's no signed claim "this is the e-stop button." Motions targeting a *registered* descriptor get the full RCAN-traceable audit (descriptor id → signature → pick log). That's the safety story: ephemeral is convenient, registered is auditable, both are gated.
+
+### 5. The high-level tools stay
+
+`arm.pick(target=descriptor)` and `vision_find(descriptor)` aren't deprecated. They're the audited "do the thing" interface — for production code, scripts, or operators who want a single call. The new low-level tools are for development, diagnosis, and agent orchestration. Both layers coexist; they share the descriptor store and the same kinematics/perception modules underneath.
+
+### 6. Failure surfaces are *informational*, not just `error`
+
+`describe_reachability` returns reasons in a structure the agent can render to plain English:
+- `outside_workspace` → which axis violated, by how much, suggested move direction
+- `envelope_risk` → which joint, what angle, how close to limit, alternative IK branch
+- `multiple_candidates` → list of competing matches with reasons each was non-decisive
+
+The CLI's existing terse error reasons are kept for backwards compat, but every primitive that can fail returns a *narratable* reason in addition.
+
+## Out of scope
+
+- Implementation. This is a spec.
+- Specific embedding model selection (defer to device benchmarking).
+- Multi-camera support (current design assumes one active camera).
+- Object-pose estimation beyond centroid + depth (no 6-DoF pose for now).
+- Replacing the existing manifest entirely. The manifest still owns identity, capabilities, safety, kinematics, and the vision *system* declaration.
+
+## Open questions for implementer
+
+- **Migration path.** Do existing `vision.object_descriptors[]` get auto-imported on first run, or does the operator have to opt in? Auto-import preserves existing behavior; opt-in avoids surprise. Probably auto-import with a one-time confirmation prompt.
+- **Where ephemeral descriptors decay.** Cleared on session end? On day boundary? Manual `/forget`? Probably manual + LRU eviction at some store size cap.
+- **Multi-robot composition.** If two robot-md installs share a vector DB (a fleet), how do registered descriptors propagate? Probably out of scope for v2 — single-robot first.
+- **Audit log integration.** `~/.robot-md/audit/` already exists. Should descriptor-store mutations go there? Yes for registered; ephemeral can stay in the DB only.
+- **Slash command UX for ambiguity.** When `/pick the red lego` finds two red blobs, the prompt's question to the operator should include the pixel coordinates + a thumbnail or text description of each. Implementer needs to design the disambiguation UX.
+
+## Companion specs
+
+- `/home/craigm26/calibrate-zero-spec.md` — same pattern (low-level MCP tools + slash command) for the zero-calibration workflow.
+- `/home/craigm26/hand-eye-calibration-v2-spec.md` — fiducial-based hand-eye calibration, replacing the failed gripper-silhouette method.
+- This spec generalizes that pattern: any robot-md operation that today fails opaquely behind a single CLI boolean is a candidate for the same treatment.
+
+## Second-session lessons (2026-04-27 evening)
+
+A second session attempted a "drop the lego, pick it back up, place in bowl" workflow. It surfaced these additional failure modes that the v2 architecture needs to address:
+
+### Gripper-tip identification is a first-class problem
+
+Closed-loop visual servoing requires reliable gripper-tip detection. HSV blue tape (which the operator added to the gripper) is **not enough** when the scene contains other blue objects — the algorithm picks different blobs as "the gripper" between runs as scene composition changes, making the empirical Jacobian noisy and divergent. v2 must include:
+
+- A **gripper marker spec** in the manifest (separate from `vision.object_descriptors[]`) declaring the marker type (color patch, ArUco, AprilTag, ChArUco), expected size, and expected position relative to the gripper FK.
+- A **`detect_gripper`** MCP primitive that uses the marker spec, with FK-position-prior to disambiguate from scene clutter.
+- The manifest's `solver.gripper.marker:` block holds this declaration, validated and rendered in `doctor`.
+
+This is a separate concern from object-vocabulary descriptors and must not share infrastructure with them — operator-added "remember this object" entries should not pollute the gripper-tracking pipeline.
+
+### IK constraint reasons must be axis-decomposed
+
+IK errors during the session looked like:
+- `outside_workspace: True` (which axis? by how much? which direction would help?)
+- `ik_failed: target unreachable: need 452.5mm, max 250.0mm` (max 250 was the *2-link planar reach*, opaque to the operator; the actual constraint was a hard-coded "gripper points down" assumption that forced wrist-target perpendicular)
+- `envelope_risk: elbow_flex=89.7° is 100% of envelope` (was the envelope conservative, or did this configuration actually risk a latch?)
+
+`describe_reachability` must return:
+- For workspace violations: per-axis `(violated_axis, target_value, bound, suggested_move_mm)`.
+- For IK failures: which constraint bound (joint limit, planar 2-link reach, gripper-orientation constraint), and which alternative IK branches were tried.
+- For envelope warnings: which joint, what angle, distance from limit, and whether the current envelope is conservative (declared margin) vs hard limit (servo specification).
+
+The agent translates these into actionable plain-English suggestions ("the lego is 5 cm below the arm's vertical reach — raise it 5 cm or lower the arm mount"). The CLI provides the data; the agent does the synthesis.
+
+### The mounting orientation problem
+
+The session's bob is mounted with the arm extending sideways from a vertical mast, camera on top of the mast. The manifest's `base_frame: {up: z, forward: x}` is a kinematic-chain convention, not a world-mounting declaration. When the arm is desktop-mounted, those align; when it's mast-mounted, they don't, and every "the arm extends in +x at zero pose" assumption needs explicit re-derivation. Worse, the workspace bounds are in arm-frame, but the operator thinks in world-frame ("the lego is 17 inches below the table mount").
+
+Add `mount` to the manifest:
+```yaml
+physics:
+  mount:
+    type: vertical_mast | horizontal_table | wall_plate | ceiling
+    base_to_world_transform: [tx, ty, tz, rx, ry, rz]   # arm-base frame in world frame
+```
+
+Then `doctor` and `describe_reachability` can render workspace bounds and reach errors in world-frame *and* arm-frame, so the operator's mental model and the kinematics agree.
+
+### Multi-candidate detection by default
+
+`vision_find(descriptor)` returns one match. Tonight's session repeatedly hit the wrong-blob trap: actual lego at depth 1049 mm was filtered out by `max_depth_mm: 700`, and a smaller-but-in-range red marker on the arm itself won the "largest red blob" contest. The agent only saw `ok` with wrong coordinates.
+
+Replace with `detect_candidates(descriptor)` returning *all* matches (and explicit *near-misses* with reasons each was rejected: `out_of_depth_window`, `too_small`, `outside_workspace`, etc.). The agent picks. This is more verbose for the API but makes the failure mode visible — the wrong-blob trap is impossible if the agent sees the in-range candidate alongside the rejection reasons.
+
+### Hot-reload of descriptor params
+
+Every depth-bound tweak (`max_depth_mm: 700 → 1500 → 1080`) required a manifest edit + `validate` + restart of the perception subprocess. For tonight's work that was 6+ cycles. Hot-reload should be a first-class capability:
+
+- `set_descriptor_param(id, key, value)` MCP primitive: applies the change to the in-memory store, mutates the on-disk descriptor entry (registered or ephemeral), no restart.
+- The agent uses this naturally during `/find`: "I see two competing red blobs; let me tighten the depth window to disambiguate" → tool call → re-detect → continue.
+- Manifest-declared descriptors stay validated; the hot-reload writes to the descriptor store and the migration layer keeps the manifest as a snapshot.
+
+### Drop-and-re-detect requires temporal tracking
+
+After the gripper opened and dropped the lego, the descriptor's "last_known_pose" was stale (still pointed at the gripper position from before the drop). The agent had to re-discover the lego from scratch.
+
+The descriptor store should support:
+- `update_pose(descriptor_id, new_world_xyz_mm)` for tracked objects.
+- An `is_held_by_gripper: bool` flag per ephemeral descriptor — when true, the pose follows the gripper FK; when false (e.g., after gripper opens), it's frozen at last-observed position.
+- A `/drop` slash command that opens the gripper, captures a fresh frame, and updates the descriptor's pose to wherever the object lands.
+
+## Why this matters
+
+The session that prompted this spec spent an hour on calibration and pick attempts that all surfaced as one-line errors (`outside_workspace`, `invalid_depth`, `ik_failed`, `envelope_risk`). Every diagnosis required the agent to bypass the CLI and read package internals. The robot has all the data — frames, depths, candidate lists, kinematic envelopes — but the CLI's interface is too narrow to expose it. This spec widens the interface so the agent can do its job using the tools robot-md publishes, instead of around them.


### PR DESCRIPTION
## Summary

- Adds new `proposals/` directory as the staging ground for design proposals that extend the core ROBOT.md spec
- Imports four design proposals drafted 2026-04-27 (easy-ux, perception-arch-v2, hand-eye-calib-v2, calibrate-zero-v2) — currently they live only as loose markdown files in `~/`
- Adds `proposals/README.md` documenting how proposals progress (proposals/ → eval validates via robot-md-autoresearch → spec/ merge PR)

## Why

Unblocks [`RobotRegistryFoundation/robot-md-autoresearch`](https://github.com/RobotRegistryFoundation/robot-md-autoresearch) v1.0 implementation. The autoresearch rig's spec-seeded variants need `provenance.source.commit` to populate, which requires the specs to live in a versioned repo with stable git history. This PR creates that home.

Design reference: [`opencastor-ops/docs/superpowers/specs/2026-04-28-robot-md-autoresearch-design.md`](https://github.com/craigm26/opencastor-ops/blob/master/docs/superpowers/specs/2026-04-28-robot-md-autoresearch-design.md) — see decision row 14.

## What changes for core spec

Nothing in the core spec changes. `proposals/` is a new sibling directory; nothing in `spec/`, `cli/`, `schema/`, or `examples/` is touched. Proposals only graduate to the core spec via separate, evidence-backed PRs once the autoresearch loop validates them by ≥5% margin against `baseline`.

## Test plan

- [ ] `proposals/README.md` renders cleanly on github.com
- [ ] All four proposal markdown files render cleanly
- [ ] No file outside `proposals/` is touched (review diff)
- [ ] No CI regression — this is doc-only

🤖 Generated with [Claude Code](https://claude.com/claude-code)