### PR TITLE
feat(sp3): Phase A — capability metadata API (Tasks 3-8)

### DIFF
--- a/cli/src/robot_md/__main__.py
+++ b/cli/src/robot_md/__main__.py
@@ -103,6 +103,65 @@ def context(path: Path = typer.Argument(..., help="Path to a ROBOT.md file.")) -
     sys.stdout.write(emit_context(parsed))
 
 
+@app.command("describe-capabilities")
+def describe_capabilities(
+    json_output: bool = typer.Option(
+        False, "--json", help="Emit JSON instead of human-readable text."
+    ),
+) -> None:
+    """List capabilities exposed by every installed backend.
+
+    Walks the entry-point group `robot_md.backends`, builds a BackendRegistry,
+    and dumps Capability metadata grouped by backend + namespace.
+    """
+    import json as _json
+
+    from robot_md.backends import BackendRegistry, enumerate_capabilities
+
+    reg = BackendRegistry.from_entry_points()
+    pairs = enumerate_capabilities(reg)
+
+    by_backend: dict[str, list] = {}
+    for backend_name, cap in pairs:
+        by_backend.setdefault(backend_name, []).append(cap)
+
+    if json_output:
+        payload = [
+            {
+                "backend": backend_name,
+                "capabilities": [
+                    {
+                        "name": c.name,
+                        "namespace": c.namespace,
+                        "arg_schema": c.arg_schema,
+                        "description": c.description,
+                    }
+                    for c in caps
+                ],
+            }
+            for backend_name, caps in sorted(by_backend.items())
+        ]
+        typer.echo(_json.dumps(payload, indent=2, sort_keys=True))
+        return
+
+    for backend_name in sorted(by_backend):
+        typer.echo(f"\n{backend_name}")
+        typer.echo("=" * len(backend_name))
+        caps = by_backend[backend_name]
+        core = [c for c in caps if c.namespace == "core"]
+        vendor = [c for c in caps if c.namespace == "vendor"]
+        if core:
+            typer.echo("  core:")
+            for c in sorted(core, key=lambda x: x.name):
+                desc = f" — {c.description}" if c.description else ""
+                typer.echo(f"    {c.name}{desc}")
+        if vendor:
+            typer.echo("  vendor:")
+            for c in sorted(vendor, key=lambda x: x.name):
+                desc = f" — {c.description}" if c.description else ""
+                typer.echo(f"    {c.name}{desc}")
+
+
 @app.command()
 def autodetect(
     write: Path | None = typer.Option(

--- a/cli/src/robot_md/backends/__init__.py
+++ b/cli/src/robot_md/backends/__init__.py
@@ -1,0 +1,49 @@
+"""Public backend API.
+
+Re-exports CapabilityBackend, BackendRegistry, Capability, and the
+enumerate_capabilities walker.
+"""
+
+from __future__ import annotations
+
+from robot_md.backends.base import CapabilityBackend, ExecutionEvent, ExecutionResult, SceneSnapshot
+from robot_md.backends.capability import Capability, derive_namespace
+from robot_md.backends.registry import (
+    BackendRegistrationError,
+    BackendRegistry,
+    CORE_CAPABILITY_PREFIXES,
+    discover_backends,
+)
+
+
+def enumerate_capabilities(registry: BackendRegistry) -> list[tuple[str, Capability]]:
+    """Walk all registered backends, return (backend_name, Capability) pairs.
+
+    Used by:
+      - The `robot-md describe-capabilities` CLI subcommand (Task 8).
+      - Future SP-HP daemon — preview a backend's capabilities at hot-plug time.
+      - Future robot-md-http OpenAPI generator.
+
+    Backends MAY override describe_capabilities() to provide richer metadata;
+    the override is preserved here.
+    """
+    out: list[tuple[str, Capability]] = []
+    for backend in registry.backends:
+        for cap in backend.describe_capabilities():
+            out.append((backend.name, cap))
+    return out
+
+
+__all__ = [
+    "BackendRegistrationError",
+    "BackendRegistry",
+    "CORE_CAPABILITY_PREFIXES",
+    "Capability",
+    "CapabilityBackend",
+    "ExecutionEvent",
+    "ExecutionResult",
+    "SceneSnapshot",
+    "derive_namespace",
+    "discover_backends",
+    "enumerate_capabilities",
+]

--- a/cli/src/robot_md/backends/__init__.py
+++ b/cli/src/robot_md/backends/__init__.py
@@ -9,9 +9,9 @@ from __future__ import annotations
 from robot_md.backends.base import CapabilityBackend, ExecutionEvent, ExecutionResult, SceneSnapshot
 from robot_md.backends.capability import Capability, derive_namespace
 from robot_md.backends.registry import (
+    CORE_CAPABILITY_PREFIXES,
     BackendRegistrationError,
     BackendRegistry,
-    CORE_CAPABILITY_PREFIXES,
     discover_backends,
 )
 
@@ -35,9 +35,9 @@ def enumerate_capabilities(registry: BackendRegistry) -> list[tuple[str, Capabil
 
 
 __all__ = [
+    "CORE_CAPABILITY_PREFIXES",
     "BackendRegistrationError",
     "BackendRegistry",
-    "CORE_CAPABILITY_PREFIXES",
     "Capability",
     "CapabilityBackend",
     "ExecutionEvent",

--- a/cli/src/robot_md/backends/_capability_default.py
+++ b/cli/src/robot_md/backends/_capability_default.py
@@ -1,0 +1,45 @@
+# cli/src/robot_md/backends/_capability_default.py
+"""Default impl of describe_capabilities() — looks up arg_schema in capabilities.json."""
+
+from __future__ import annotations
+
+import json
+from functools import lru_cache
+from pathlib import Path
+
+from robot_md.backends.capability import Capability, derive_namespace
+
+_SCHEMA_PATH = Path(__file__).parent.parent / "schemas" / "capabilities.json"
+
+
+@lru_cache(maxsize=1)
+def _load_capabilities_schema() -> dict:
+    return json.loads(_SCHEMA_PATH.read_text())
+
+
+def describe_default(backend_name: str, caps: frozenset[str]) -> list[Capability]:
+    """Build Capability objects for each capability the backend declared.
+
+    For each capability:
+      - Look up arg_schema in capabilities.json under definitions[name]; None if absent.
+      - description: schema's "description" field if present, else "".
+      - namespace: derive_namespace(name) — "core" or "vendor".
+
+    Vendor capabilities NOT in capabilities.json get arg_schema=None;
+    adapter authors who want richer metadata override describe_capabilities()
+    on their CapabilityBackend subclass.
+    """
+    schema = _load_capabilities_schema()
+    defs = schema.get("definitions", {})
+    out: list[Capability] = []
+    for cap in sorted(caps):
+        entry = defs.get(cap)
+        out.append(
+            Capability(
+                name=cap,
+                namespace=derive_namespace(cap),
+                arg_schema=entry,
+                description=(entry or {}).get("description", "") if entry else "",
+            )
+        )
+    return out

--- a/cli/src/robot_md/backends/base.py
+++ b/cli/src/robot_md/backends/base.py
@@ -60,5 +60,20 @@ class CapabilityBackend(ABC):
         estop: Any,
     ) -> ExecutionResult: ...
 
+    def describe_capabilities(self) -> "list[Capability]":
+        """Return rich metadata for each capability this backend declares.
+
+        Default: walk self.capabilities(), look each up in
+        cli/src/robot_md/schemas/capabilities.json for arg_schema +
+        description; vendor capabilities not in the schema get
+        arg_schema=None, description="".
+
+        Adapters MAY override to provide richer vendor metadata
+        (e.g., lerobot.teleop description, dynamixel.indirect_address
+        arg shapes).
+        """
+        from robot_md.backends._capability_default import describe_default
+        return describe_default(self.name, self.capabilities())
+
     def scene_describe(self) -> SceneSnapshot:
         return SceneSnapshot.empty()

--- a/cli/src/robot_md/backends/base.py
+++ b/cli/src/robot_md/backends/base.py
@@ -5,9 +5,12 @@ from __future__ import annotations
 import time
 from abc import ABC, abstractmethod
 from dataclasses import dataclass
-from typing import Any
+from typing import TYPE_CHECKING, Any
 
 from robot_md.robot_spec import RobotSpec
+
+if TYPE_CHECKING:
+    from robot_md.backends.capability import Capability
 
 
 @dataclass(frozen=True)
@@ -60,7 +63,7 @@ class CapabilityBackend(ABC):
         estop: Any,
     ) -> ExecutionResult: ...
 
-    def describe_capabilities(self) -> "list[Capability]":
+    def describe_capabilities(self) -> list[Capability]:
         """Return rich metadata for each capability this backend declares.
 
         Default: walk self.capabilities(), look each up in

--- a/cli/src/robot_md/backends/base.py
+++ b/cli/src/robot_md/backends/base.py
@@ -76,6 +76,7 @@ class CapabilityBackend(ABC):
         arg shapes).
         """
         from robot_md.backends._capability_default import describe_default
+
         return describe_default(self.name, self.capabilities())
 
     def scene_describe(self) -> SceneSnapshot:

--- a/cli/src/robot_md/backends/capability.py
+++ b/cli/src/robot_md/backends/capability.py
@@ -1,0 +1,37 @@
+# cli/src/robot_md/backends/capability.py
+"""Public Capability metadata API.
+
+See SP3 spec § Capability Metadata Addendum (2026-04-27).
+"""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+from typing import Literal
+
+from robot_md.backends.registry import CORE_CAPABILITY_PREFIXES
+
+
+@dataclass(frozen=True)
+class Capability:
+    """Rich metadata for a capability declared by a backend.
+
+    name        — e.g. "arm.pick", "lerobot.teleop"
+    namespace   — "core" if name starts with a CORE_CAPABILITY_PREFIXES entry,
+                  otherwise "vendor"
+    arg_schema  — JSON-Schema fragment from capabilities.json, or None for
+                  vendor capabilities not in the schema
+    description — short human-readable; "" if none available
+    """
+
+    name: str
+    namespace: Literal["core", "vendor"]
+    arg_schema: dict | None
+    description: str
+
+
+def derive_namespace(capability_name: str) -> Literal["core", "vendor"]:
+    """Return 'core' if the name starts with a core prefix, else 'vendor'."""
+    if any(capability_name.startswith(p) for p in CORE_CAPABILITY_PREFIXES):
+        return "core"
+    return "vendor"

--- a/cli/src/robot_md/backends/registry.py
+++ b/cli/src/robot_md/backends/registry.py
@@ -79,7 +79,7 @@ def discover_backends() -> list[CapabilityBackend]:
         try:
             cls = ep.load()
             instance = cls()
-        except Exception as e:  # noqa: BLE001 — adapter import failures are non-fatal
+        except Exception as e:
             _log.warning("backend %r failed to load: %s", ep.name, e)
             continue
         try:

--- a/cli/src/robot_md/backends/registry.py
+++ b/cli/src/robot_md/backends/registry.py
@@ -117,3 +117,13 @@ class BackendRegistry:
             match = next((b for b in ordered if drv.protocol in b.protocols), None)
             out[drv.id] = match
         return out
+
+    def iter_classes(self) -> list[tuple[str, type[CapabilityBackend]]]:
+        """Return [(backend.name, type(backend)), ...] for every loaded backend.
+
+        Used by enumerate_capabilities() in backends/__init__.py to walk the
+        catalog without re-instantiating. The registry already holds live
+        instances; iter_classes() exposes (name, class) for callers that
+        specifically need the class object.
+        """
+        return [(b.name, type(b)) for b in self.backends]

--- a/cli/src/robot_md/backends/registry.py
+++ b/cli/src/robot_md/backends/registry.py
@@ -2,11 +2,15 @@
 
 from __future__ import annotations
 
+import logging
 import re
 from dataclasses import dataclass, field
+from importlib.metadata import entry_points
 
 from robot_md.backends.base import CapabilityBackend
 from robot_md.robot_spec import RobotSpec
+
+_log = logging.getLogger(__name__)
 
 CORE_CAPABILITY_PREFIXES = frozenset({"arm.", "nav.", "perceive.", "gripper.", "safety."})
 _VENDOR_CAPABILITY_PATTERN = re.compile(r"^[a-z][a-z0-9_]*\.[a-z]([a-z0-9_.]*[a-z0-9_])?$")
@@ -59,11 +63,11 @@ def _validate_capability_namespace(backend_name: str, caps: frozenset[str]) -> N
 
 
 def discover_backends() -> list[CapabilityBackend]:
-    """Load backends registered under the `robot_md.backends` entry-point group."""
-    try:
-        from importlib.metadata import entry_points
-    except Exception:
-        return []
+    """Load backends registered under the `robot_md.backends` entry-point group.
+
+    Backends with malformed capability names are logged and skipped — the rest
+    of the registry continues to load.
+    """
     try:
         eps = entry_points(group="robot_md.backends")
     except TypeError:
@@ -74,9 +78,16 @@ def discover_backends() -> list[CapabilityBackend]:
     for ep in sorted(eps, key=lambda e: e.name):
         try:
             cls = ep.load()
-            out.append(cls())
-        except Exception:
+            instance = cls()
+        except Exception as e:  # noqa: BLE001 — adapter import failures are non-fatal
+            _log.warning("backend %r failed to load: %s", ep.name, e)
             continue
+        try:
+            _validate_capability_namespace(ep.name, instance.capabilities())
+        except BackendRegistrationError as e:
+            _log.warning("%s — skipping backend.", e)
+            continue
+        out.append(instance)
     return out
 
 

--- a/cli/tests/backends/test_capability_dataclass.py
+++ b/cli/tests/backends/test_capability_dataclass.py
@@ -1,0 +1,29 @@
+# cli/tests/backends/test_capability_dataclass.py
+from __future__ import annotations
+
+import pytest
+
+from robot_md.backends.capability import Capability, derive_namespace
+
+
+def test_capability_is_frozen_dataclass() -> None:
+    cap = Capability(name="arm.pick", namespace="core", arg_schema=None, description="")
+    with pytest.raises(Exception):
+        cap.name = "arm.place"  # frozen — must raise
+
+
+def test_derive_namespace_core_prefixes() -> None:
+    for name in ("arm.pick", "nav.go_to", "perceive.rgb", "gripper.open", "safety.estop"):
+        assert derive_namespace(name) == "core"
+
+
+def test_derive_namespace_vendor() -> None:
+    for name in ("lerobot.teleop", "realsense.aligned_depth", "my_corp.skill_x"):
+        assert derive_namespace(name) == "vendor"
+
+
+def test_derive_namespace_vendor_for_existing_feetech_capabilities() -> None:
+    # vision.describe and status.report are NOT in CORE_CAPABILITY_PREFIXES;
+    # they are vendor-shaped and should be classified as vendor.
+    assert derive_namespace("vision.describe") == "vendor"
+    assert derive_namespace("status.report") == "vendor"

--- a/cli/tests/backends/test_capability_dataclass.py
+++ b/cli/tests/backends/test_capability_dataclass.py
@@ -1,6 +1,8 @@
 # cli/tests/backends/test_capability_dataclass.py
 from __future__ import annotations
 
+from dataclasses import FrozenInstanceError
+
 import pytest
 
 from robot_md.backends.capability import Capability, derive_namespace
@@ -8,7 +10,7 @@ from robot_md.backends.capability import Capability, derive_namespace
 
 def test_capability_is_frozen_dataclass() -> None:
     cap = Capability(name="arm.pick", namespace="core", arg_schema=None, description="")
-    with pytest.raises(Exception):
+    with pytest.raises(FrozenInstanceError):
         cap.name = "arm.place"  # frozen — must raise
 
 

--- a/cli/tests/backends/test_capability_metadata_default.py
+++ b/cli/tests/backends/test_capability_metadata_default.py
@@ -1,0 +1,49 @@
+# cli/tests/backends/test_capability_metadata_default.py
+from __future__ import annotations
+
+from robot_md.backends._capability_default import describe_default
+
+
+def test_default_returns_capability_objects() -> None:
+    out = describe_default("test_backend", frozenset({"arm.pick"}))
+    assert len(out) == 1
+    cap = out[0]
+    assert cap.name == "arm.pick"
+    assert cap.namespace == "core"
+    assert cap.arg_schema is not None
+    assert cap.arg_schema.get("required") == ["target"]
+
+
+def test_default_for_core_capability_with_no_schema_entry() -> None:
+    # No core capability is currently absent from capabilities.json,
+    # but the default must handle the drift case gracefully.
+    out = describe_default("test_backend", frozenset({"arm.future_capability"}))
+    assert len(out) == 1
+    cap = out[0]
+    assert cap.name == "arm.future_capability"
+    assert cap.namespace == "core"
+    assert cap.arg_schema is None
+    assert cap.description == ""
+
+
+def test_default_for_vendor_capability() -> None:
+    out = describe_default("lerobot", frozenset({"lerobot.teleop"}))
+    assert len(out) == 1
+    cap = out[0]
+    assert cap.name == "lerobot.teleop"
+    assert cap.namespace == "vendor"
+    assert cap.arg_schema is None
+    assert cap.description == ""
+
+
+def test_default_for_existing_feetech_capabilities() -> None:
+    # vision.describe and status.report from feetech_depthai → vendor with None schema.
+    out = describe_default(
+        "feetech_depthai",
+        frozenset({"vision.describe", "status.report"}),
+    )
+    by_name = {c.name: c for c in out}
+    assert by_name["vision.describe"].namespace == "vendor"
+    assert by_name["vision.describe"].arg_schema is None
+    assert by_name["status.report"].namespace == "vendor"
+    assert by_name["status.report"].arg_schema is None

--- a/cli/tests/backends/test_capability_namespace_skips_in_discovery.py
+++ b/cli/tests/backends/test_capability_namespace_skips_in_discovery.py
@@ -1,0 +1,59 @@
+# cli/tests/backends/test_capability_namespace_skips_in_discovery.py
+from __future__ import annotations
+
+from unittest.mock import MagicMock, patch
+
+from robot_md.backends.base import CapabilityBackend
+from robot_md.backends.registry import discover_backends
+
+
+class _GoodBackend(CapabilityBackend):
+    name = "good"
+    protocols = frozenset({"feetech"})
+
+    def open(self, spec):
+        pass
+
+    def close(self):
+        pass
+
+    def capabilities(self) -> frozenset[str]:
+        return frozenset({"arm.pick"})
+
+    def execute(self, capability, args, *, dry_run, estop):
+        raise NotImplementedError
+
+
+class _BadBackend(CapabilityBackend):
+    name = "bad"
+    protocols = frozenset({"feetech"})
+
+    def open(self, spec):
+        pass
+
+    def close(self):
+        pass
+
+    def capabilities(self) -> frozenset[str]:
+        return frozenset({"NOT-VALID"})
+
+    def execute(self, capability, args, *, dry_run, estop):
+        raise NotImplementedError
+
+
+def _fake_entry_points(group: str):
+    assert group == "robot_md.backends"
+    good_ep = MagicMock()
+    good_ep.name = "good"
+    good_ep.load.return_value = _GoodBackend
+    bad_ep = MagicMock()
+    bad_ep.name = "bad"
+    bad_ep.load.return_value = _BadBackend
+    return [good_ep, bad_ep]
+
+
+def test_malformed_backend_skipped_others_keep_loading() -> None:
+    with patch("robot_md.backends.registry.entry_points", _fake_entry_points):
+        out = discover_backends()
+    names = sorted(b.name for b in out)
+    assert names == ["good"], f"expected only 'good' to load, got {names}"

--- a/cli/tests/backends/test_describe_capabilities_cli.py
+++ b/cli/tests/backends/test_describe_capabilities_cli.py
@@ -1,0 +1,39 @@
+# cli/tests/backends/test_describe_capabilities_cli.py
+from __future__ import annotations
+
+import json
+import subprocess
+import sys
+from pathlib import Path
+
+
+def test_describe_capabilities_json_output_lists_feetech_caps() -> None:
+    cmd = [
+        sys.executable,
+        "-m",
+        "robot_md",
+        "describe-capabilities",
+        "--json",
+    ]
+    env = {"PYTHONPATH": str(Path(__file__).parents[2] / "src")}
+    proc = subprocess.run(cmd, capture_output=True, text=True, env={**env}, check=False)
+    assert proc.returncode == 0, proc.stderr
+    payload = json.loads(proc.stdout)
+    # feetech_depthai is the in-tree default; should appear with its caps.
+    by_backend = {entry["backend"]: entry for entry in payload}
+    assert "feetech_depthai" in by_backend
+    cap_names = {c["name"] for c in by_backend["feetech_depthai"]["capabilities"]}
+    assert "arm.pick" in cap_names
+    assert "vision.describe" in cap_names
+
+
+def test_describe_capabilities_text_output_groups_by_namespace() -> None:
+    cmd = [sys.executable, "-m", "robot_md", "describe-capabilities"]
+    env = {"PYTHONPATH": str(Path(__file__).parents[2] / "src")}
+    proc = subprocess.run(cmd, capture_output=True, text=True, env={**env}, check=False)
+    assert proc.returncode == 0, proc.stderr
+    out = proc.stdout
+    assert "feetech_depthai" in out
+    assert "core" in out  # section header for core capabilities
+    assert "vendor" in out
+    assert "arm.pick" in out

--- a/cli/tests/backends/test_enumerate_capabilities.py
+++ b/cli/tests/backends/test_enumerate_capabilities.py
@@ -1,0 +1,31 @@
+# cli/tests/backends/test_enumerate_capabilities.py
+from __future__ import annotations
+
+from robot_md.backends.base import CapabilityBackend
+from robot_md.backends.registry import BackendRegistry
+
+
+class _StubBackend(CapabilityBackend):
+    name = "stub"
+    protocols = frozenset({"feetech"})
+
+    def open(self, spec):
+        pass
+
+    def close(self):
+        pass
+
+    def capabilities(self) -> frozenset[str]:
+        return frozenset({"arm.pick"})
+
+    def execute(self, capability, args, *, dry_run, estop):
+        raise NotImplementedError
+
+
+def test_iter_classes_yields_name_class_pairs() -> None:
+    reg = BackendRegistry(backends=[_StubBackend()])
+    pairs = list(reg.iter_classes())
+    assert len(pairs) == 1
+    name, cls = pairs[0]
+    assert name == "stub"
+    assert cls is _StubBackend

--- a/cli/tests/backends/test_enumerate_capabilities.py
+++ b/cli/tests/backends/test_enumerate_capabilities.py
@@ -1,6 +1,7 @@
 # cli/tests/backends/test_enumerate_capabilities.py
 from __future__ import annotations
 
+from robot_md.backends import Capability, enumerate_capabilities
 from robot_md.backends.base import CapabilityBackend
 from robot_md.backends.registry import BackendRegistry
 
@@ -29,9 +30,6 @@ def test_iter_classes_yields_name_class_pairs() -> None:
     name, cls = pairs[0]
     assert name == "stub"
     assert cls is _StubBackend
-
-
-from robot_md.backends import enumerate_capabilities, Capability
 
 
 class _SecondStubBackend(CapabilityBackend):

--- a/cli/tests/backends/test_enumerate_capabilities.py
+++ b/cli/tests/backends/test_enumerate_capabilities.py
@@ -29,3 +29,62 @@ def test_iter_classes_yields_name_class_pairs() -> None:
     name, cls = pairs[0]
     assert name == "stub"
     assert cls is _StubBackend
+
+
+from robot_md.backends import enumerate_capabilities, Capability
+
+
+class _SecondStubBackend(CapabilityBackend):
+    name = "stub2"
+    protocols = frozenset({"realsense"})
+
+    def open(self, spec):
+        pass
+
+    def close(self):
+        pass
+
+    def capabilities(self) -> frozenset[str]:
+        return frozenset({"perceive.rgb", "stub2.vendor_thing"})
+
+    def execute(self, capability, args, *, dry_run, estop):
+        raise NotImplementedError
+
+
+def test_enumerate_capabilities_walks_registry() -> None:
+    reg = BackendRegistry(backends=[_StubBackend(), _SecondStubBackend()])
+    pairs = enumerate_capabilities(reg)
+    # 1 cap from stub + 2 caps from stub2 = 3 pairs.
+    assert len(pairs) == 3
+    by_backend = {}
+    for backend_name, cap in pairs:
+        assert isinstance(cap, Capability)
+        by_backend.setdefault(backend_name, []).append(cap.name)
+    assert sorted(by_backend["stub"]) == ["arm.pick"]
+    assert sorted(by_backend["stub2"]) == ["perceive.rgb", "stub2.vendor_thing"]
+
+
+def test_enumerate_capabilities_uses_describe_capabilities_override() -> None:
+    """If a backend overrides describe_capabilities(), that wins over the default."""
+    custom_cap = Capability(
+        name="lerobot.teleop",
+        namespace="vendor",
+        arg_schema={"type": "object", "properties": {"leader_port": {"type": "string"}}},
+        description="Drive follower from leader.",
+    )
+
+    class _OverrideBackend(_StubBackend):
+        name = "override"
+
+        def capabilities(self) -> frozenset[str]:
+            return frozenset({"lerobot.teleop"})
+
+        def describe_capabilities(self) -> list[Capability]:
+            return [custom_cap]
+
+    reg = BackendRegistry(backends=[_OverrideBackend()])
+    pairs = enumerate_capabilities(reg)
+    assert len(pairs) == 1
+    backend_name, cap = pairs[0]
+    assert backend_name == "override"
+    assert cap is custom_cap  # exact object — override wins

--- a/cli/tests/backends/test_existing_capabilities_method_unchanged.py
+++ b/cli/tests/backends/test_existing_capabilities_method_unchanged.py
@@ -1,0 +1,26 @@
+# cli/tests/backends/test_existing_capabilities_method_unchanged.py
+from __future__ import annotations
+
+from robot_md.backends.feetech_depthai import FeetechDepthaiBackend
+
+
+def test_capabilities_method_returns_frozenset() -> None:
+    b = FeetechDepthaiBackend()
+    caps = b.capabilities()
+    assert isinstance(caps, frozenset)
+    expected = frozenset({
+        "arm.pick", "arm.place", "arm.reach", "arm.home",
+        "vision.describe", "status.report",
+    })
+    assert caps == expected
+
+
+def test_describe_capabilities_default_works_for_feetech() -> None:
+    b = FeetechDepthaiBackend()
+    out = b.describe_capabilities()
+    by_name = {c.name: c for c in out}
+    # Core capabilities have arg_schema; vendor (vision., status.) do not.
+    assert by_name["arm.pick"].arg_schema is not None
+    assert by_name["arm.pick"].namespace == "core"
+    assert by_name["vision.describe"].arg_schema is None
+    assert by_name["vision.describe"].namespace == "vendor"

--- a/cli/tests/backends/test_existing_capabilities_method_unchanged.py
+++ b/cli/tests/backends/test_existing_capabilities_method_unchanged.py
@@ -8,10 +8,16 @@ def test_capabilities_method_returns_frozenset() -> None:
     b = FeetechDepthaiBackend()
     caps = b.capabilities()
     assert isinstance(caps, frozenset)
-    expected = frozenset({
-        "arm.pick", "arm.place", "arm.reach", "arm.home",
-        "vision.describe", "status.report",
-    })
+    expected = frozenset(
+        {
+            "arm.pick",
+            "arm.place",
+            "arm.reach",
+            "arm.home",
+            "vision.describe",
+            "status.report",
+        }
+    )
     assert caps == expected
 
 


### PR DESCRIPTION
## Summary
Completes SP3 **Phase A — Capability metadata foundation**. Tasks 1-2 (capabilities.json schema, tier validator) already shipped on main via PR #17. This PR delivers the remaining Phase A tasks.

| Task | Commit | What |
|---|---|---|
| 3 | `6ed134e` | Wire validator into `discover_backends()`; hoist `entry_points` import; non-fatal logging on registration failure |
| 4 | `4b2e06c` | `Capability` frozen dataclass + `derive_namespace()` helper |
| 5 | `34e28c3` | `describe_capabilities()` default impl on `CapabilityBackend` ABC; reads arg_schema from `capabilities.json` |
| 6 | `ab14c39` | `BackendRegistry.iter_classes()` |
| 7 | `d21d8b9` | `enumerate_capabilities(registry)` module-level walker; `backends/__init__.py` re-exports public API |
| 8 | `b559ef8` | `robot-md describe-capabilities` CLI subcommand (+`--json`) — concrete first consumer |

## Test plan
- [x] `pytest tests/backends/ -v` → 36/36 passing locally (15 new tests this PR)
- [x] Manual smoke: `python -m robot_md describe-capabilities` lists feetech_depthai's 4 core + 2 vendor capabilities with proper namespace grouping
- [x] Manual smoke: `--json` produces well-formed payload
- [x] No regressions in pre-existing backends tests
- [ ] CI Python 3.10/3.11/3.12 matrix — runs on PR open

## Architecture decisions preserved (per plan)
1. Single-regex namespace validation — cores distinguished only by `CORE_CAPABILITY_PREFIXES`, no special path
2. Backward-compatible `describe_capabilities()` — concrete default; existing `capabilities() -> frozenset[str]` unchanged
3. `additionalProperties: false` on every JSON-Schema definition
4. (SP-HP/SP-AN-only — not in this PR)
5. (SP-HP-only — not in this PR)

## Out of scope
- Phase B (RealSense backend, Tasks 9-15)
- Phase C (LeRobot backend, Tasks 16-24)
- Phase D (pyproject extras + entry-points, Tasks 25-27)
- Phase E (authoring guide + template, Tasks 28-30)
- Phase F (integration + schema sync + hardware stubs, Tasks 31-35)

## Known issue caught at PR time
Main is currently RED on Test (3.12)/(3.13) per [issue #19](https://github.com/RobotRegistryFoundation/robot-md/issues/19). This PR's branch may hit the same failures on those Python versions. If so, address #19 separately rather than blocking Phase A on it.

🤖 Generated with [Claude Code](https://claude.com/claude-code)