### PR TITLE
feat(sp3): Phase B — RealSense backend (Tasks 9-15)

### DIFF
--- a/cli/src/robot_md/backends/realsense/__init__.py
+++ b/cli/src/robot_md/backends/realsense/__init__.py
@@ -1,0 +1,53 @@
+"""RealSense camera adapter — perception only, no motion."""
+
+from __future__ import annotations
+
+from robot_md.backends.base import (
+    CapabilityBackend,
+    ExecutionResult,
+    SceneSnapshot,
+)
+from robot_md.robot_spec import RobotSpec
+
+
+class RealsenseBackend(CapabilityBackend):
+    name = "realsense"
+    protocols = frozenset({"realsense"})
+    read_only_capabilities = frozenset({"perceive.rgb", "perceive.depth"})
+
+    def __init__(self) -> None:
+        self._pipeline = None
+
+    def open(self, spec: RobotSpec) -> None:
+        # Implemented in Task 10.
+        raise NotImplementedError
+
+    def close(self) -> None:
+        if self._pipeline is not None:
+            self._pipeline.stop()
+            self._pipeline = None
+
+    def capabilities(self) -> frozenset[str]:
+        return frozenset(
+            {
+                "perceive.rgb",
+                "perceive.depth",
+                "realsense.aligned_depth",
+            }
+        )
+
+    def execute(
+        self,
+        capability: str,
+        args: dict,
+        *,
+        dry_run: bool,
+        estop,
+    ) -> ExecutionResult:
+        from robot_md.backends.realsense.capabilities import dispatch
+
+        return dispatch(self, capability=capability, args=dict(args), dry_run=dry_run, estop=estop)
+
+    def scene_describe(self) -> SceneSnapshot:
+        # Implemented in Task 13.
+        return SceneSnapshot.empty()

--- a/cli/src/robot_md/backends/realsense/__init__.py
+++ b/cli/src/robot_md/backends/realsense/__init__.py
@@ -54,5 +54,11 @@ class RealsenseBackend(CapabilityBackend):
         return dispatch(self, capability=capability, args=dict(args), dry_run=dry_run, estop=estop)
 
     def scene_describe(self) -> SceneSnapshot:
-        # Implemented in Task 13.
-        return SceneSnapshot.empty()
+        import time
+
+        if self._pipeline is None:
+            return SceneSnapshot.empty()
+        frames = self._pipeline.wait_for_frames(timeout_ms=1000)
+        color = frames.get_color_frame()
+        data = bytes(color.get_data()) if color is not None else None
+        return SceneSnapshot(frame=data, detections=(), joint_state={}, ts=time.time())

--- a/cli/src/robot_md/backends/realsense/__init__.py
+++ b/cli/src/robot_md/backends/realsense/__init__.py
@@ -19,8 +19,13 @@ class RealsenseBackend(CapabilityBackend):
         self._pipeline = None
 
     def open(self, spec: RobotSpec) -> None:
-        # Implemented in Task 10.
-        raise NotImplementedError
+        import pyrealsense2 as rs
+
+        self._pipeline = rs.pipeline()
+        config = rs.config()
+        config.enable_stream(rs.stream.color, 640, 480, rs.format.bgr8, 30)
+        config.enable_stream(rs.stream.depth, 640, 480, rs.format.z16, 30)
+        self._pipeline.start(config)
 
     def close(self) -> None:
         if self._pipeline is not None:

--- a/cli/src/robot_md/backends/realsense/capabilities.py
+++ b/cli/src/robot_md/backends/realsense/capabilities.py
@@ -1,14 +1,22 @@
-"""RealSense capability dispatch — populated incrementally."""
+"""RealSense capability dispatch."""
 
 from __future__ import annotations
 
 from robot_md.backends.base import ExecutionResult
+from robot_md.backends.realsense.perception import perceive_rgb
+
+HANDLERS = {
+    "perceive.rgb": perceive_rgb,
+}
 
 
 def dispatch(backend, *, capability: str, args: dict, dry_run: bool, estop) -> ExecutionResult:
-    return ExecutionResult(
-        status="error",
-        trajectory=None,
-        events=[],
-        error={"reason": "not_implemented", "detail": f"capability {capability!r}"},
-    )
+    handler = HANDLERS.get(capability)
+    if handler is None:
+        return ExecutionResult(
+            status="error",
+            trajectory=None,
+            events=[],
+            error={"reason": "not_implemented", "detail": f"capability {capability!r}"},
+        )
+    return handler(backend, args, dry_run=dry_run, estop=estop)

--- a/cli/src/robot_md/backends/realsense/capabilities.py
+++ b/cli/src/robot_md/backends/realsense/capabilities.py
@@ -3,11 +3,16 @@
 from __future__ import annotations
 
 from robot_md.backends.base import ExecutionResult
-from robot_md.backends.realsense.perception import perceive_depth, perceive_rgb
+from robot_md.backends.realsense.perception import (
+    perceive_depth,
+    perceive_rgb,
+    realsense_aligned_depth,
+)
 
 HANDLERS = {
     "perceive.rgb": perceive_rgb,
     "perceive.depth": perceive_depth,
+    "realsense.aligned_depth": realsense_aligned_depth,
 }
 
 

--- a/cli/src/robot_md/backends/realsense/capabilities.py
+++ b/cli/src/robot_md/backends/realsense/capabilities.py
@@ -3,10 +3,11 @@
 from __future__ import annotations
 
 from robot_md.backends.base import ExecutionResult
-from robot_md.backends.realsense.perception import perceive_rgb
+from robot_md.backends.realsense.perception import perceive_depth, perceive_rgb
 
 HANDLERS = {
     "perceive.rgb": perceive_rgb,
+    "perceive.depth": perceive_depth,
 }
 
 

--- a/cli/src/robot_md/backends/realsense/capabilities.py
+++ b/cli/src/robot_md/backends/realsense/capabilities.py
@@ -1,0 +1,14 @@
+"""RealSense capability dispatch — populated incrementally."""
+
+from __future__ import annotations
+
+from robot_md.backends.base import ExecutionResult
+
+
+def dispatch(backend, *, capability: str, args: dict, dry_run: bool, estop) -> ExecutionResult:
+    return ExecutionResult(
+        status="error",
+        trajectory=None,
+        events=[],
+        error={"reason": "not_implemented", "detail": f"capability {capability!r}"},
+    )

--- a/cli/src/robot_md/backends/realsense/perception.py
+++ b/cli/src/robot_md/backends/realsense/perception.py
@@ -20,3 +20,22 @@ def perceive_rgb(backend, args: dict, *, dry_run: bool, estop) -> ExecutionResul
         events=[ExecutionEvent(kind="frame", data={"frame_bytes": data, "format": "bgr8"})],
         error=None,
     )
+
+
+def perceive_depth(backend, args: dict, *, dry_run: bool, estop) -> ExecutionResult:
+    if dry_run:
+        return ExecutionResult(
+            status="ok",
+            trajectory=None,
+            events=[ExecutionEvent(kind="dry_run", data={"capability": "perceive.depth"})],
+            error=None,
+        )
+    frames = backend._pipeline.wait_for_frames(timeout_ms=1000)
+    depth = frames.get_depth_frame()
+    data = bytes(depth.get_data()) if depth is not None else b""
+    return ExecutionResult(
+        status="ok",
+        trajectory=None,
+        events=[ExecutionEvent(kind="frame", data={"frame_bytes": data, "format": "z16"})],
+        error=None,
+    )

--- a/cli/src/robot_md/backends/realsense/perception.py
+++ b/cli/src/robot_md/backends/realsense/perception.py
@@ -1,0 +1,22 @@
+from __future__ import annotations
+
+from robot_md.backends.base import ExecutionEvent, ExecutionResult
+
+
+def perceive_rgb(backend, args: dict, *, dry_run: bool, estop) -> ExecutionResult:
+    if dry_run:
+        return ExecutionResult(
+            status="ok",
+            trajectory=None,
+            events=[ExecutionEvent(kind="dry_run", data={"capability": "perceive.rgb"})],
+            error=None,
+        )
+    frames = backend._pipeline.wait_for_frames(timeout_ms=1000)
+    color = frames.get_color_frame()
+    data = bytes(color.get_data()) if color is not None else b""
+    return ExecutionResult(
+        status="ok",
+        trajectory=None,
+        events=[ExecutionEvent(kind="frame", data={"frame_bytes": data, "format": "bgr8"})],
+        error=None,
+    )

--- a/cli/src/robot_md/backends/realsense/perception.py
+++ b/cli/src/robot_md/backends/realsense/perception.py
@@ -39,3 +39,37 @@ def perceive_depth(backend, args: dict, *, dry_run: bool, estop) -> ExecutionRes
         events=[ExecutionEvent(kind="frame", data={"frame_bytes": data, "format": "z16"})],
         error=None,
     )
+
+
+def realsense_aligned_depth(backend, args: dict, *, dry_run: bool, estop) -> ExecutionResult:
+    if dry_run:
+        return ExecutionResult(
+            status="ok",
+            trajectory=None,
+            events=[ExecutionEvent(kind="dry_run", data={"capability": "realsense.aligned_depth"})],
+            error=None,
+        )
+    align = _ensure_align(backend)
+    frames = backend._pipeline.wait_for_frames(timeout_ms=1000)
+    aligned_frames = align.process(frames)
+    aligned = aligned_frames.get_depth_frame()
+    data = bytes(aligned.get_data()) if aligned is not None else b""
+    return ExecutionResult(
+        status="ok",
+        trajectory=None,
+        events=[
+            ExecutionEvent(
+                kind="frame",
+                data={"frame_bytes": data, "format": "z16", "aligned_to": "color"},
+            )
+        ],
+        error=None,
+    )
+
+
+def _ensure_align(backend):
+    if getattr(backend, "_align_processor", None) is None:
+        import pyrealsense2 as rs
+
+        backend._align_processor = rs.align(rs.stream.color)
+    return backend._align_processor

--- a/cli/tests/backends/test_realsense_aligned_depth.py
+++ b/cli/tests/backends/test_realsense_aligned_depth.py
@@ -1,0 +1,25 @@
+from __future__ import annotations
+
+from unittest.mock import MagicMock
+
+from robot_md.backends.realsense import RealsenseBackend
+
+
+def test_aligned_depth_uses_align_processor() -> None:
+    aligned_depth = MagicMock()
+    aligned_depth.get_data.return_value = b"ALIGNED_DEPTH"
+    align_processor = MagicMock()
+    align_processor.process.return_value.get_depth_frame.return_value = aligned_depth
+    frames = MagicMock()
+    pipeline = MagicMock()
+    pipeline.wait_for_frames.return_value = frames
+
+    b = RealsenseBackend()
+    b._pipeline = pipeline
+    b._align_processor = align_processor
+    result = b.execute("realsense.aligned_depth", {}, dry_run=False, estop=None)
+    assert result.status == "ok"
+    payload = result.events[-1].data
+    assert payload["frame_bytes"] == b"ALIGNED_DEPTH"
+    assert payload["aligned_to"] == "color"
+    align_processor.process.assert_called_once_with(frames)

--- a/cli/tests/backends/test_realsense_backend_protocols.py
+++ b/cli/tests/backends/test_realsense_backend_protocols.py
@@ -1,0 +1,16 @@
+"""Test RealsenseBackend class attributes and basic protocol info."""
+
+from __future__ import annotations
+
+from robot_md.backends.realsense import RealsenseBackend
+
+
+def test_name_and_protocols() -> None:
+    b = RealsenseBackend()
+    assert b.name == "realsense"
+    assert b.protocols == frozenset({"realsense"})
+
+
+def test_read_only_capabilities_marks_perception() -> None:
+    b = RealsenseBackend()
+    assert b.read_only_capabilities == frozenset({"perceive.rgb", "perceive.depth"})

--- a/cli/tests/backends/test_realsense_capabilities_camera_only.py
+++ b/cli/tests/backends/test_realsense_capabilities_camera_only.py
@@ -1,0 +1,25 @@
+"""Test RealsenseBackend capability set (perception only, no motion)."""
+
+from __future__ import annotations
+
+from robot_md.backends.realsense import RealsenseBackend
+
+
+def test_capabilities_are_perception_plus_aligned_depth() -> None:
+    b = RealsenseBackend()
+    caps = b.capabilities()
+    assert caps == frozenset(
+        {
+            "perceive.rgb",
+            "perceive.depth",
+            "realsense.aligned_depth",
+        }
+    )
+
+
+def test_no_arm_or_gripper_capabilities() -> None:
+    b = RealsenseBackend()
+    caps = b.capabilities()
+    for cap in caps:
+        assert not cap.startswith("arm."), f"unexpected arm capability {cap}"
+        assert not cap.startswith("gripper."), f"unexpected gripper capability {cap}"

--- a/cli/tests/backends/test_realsense_no_arm_capability.py
+++ b/cli/tests/backends/test_realsense_no_arm_capability.py
@@ -1,0 +1,17 @@
+from __future__ import annotations
+
+from robot_md.backends.realsense import RealsenseBackend
+
+
+def test_arm_pick_returns_not_implemented() -> None:
+    b = RealsenseBackend()
+    result = b.execute("arm.pick", {"target": "red_lego"}, dry_run=True, estop=None)
+    assert result.status == "error"
+    assert result.error["reason"] == "not_implemented"
+
+
+def test_gripper_open_returns_not_implemented() -> None:
+    b = RealsenseBackend()
+    result = b.execute("gripper.open", {}, dry_run=True, estop=None)
+    assert result.status == "error"
+    assert result.error["reason"] == "not_implemented"

--- a/cli/tests/backends/test_realsense_open_mocked.py
+++ b/cli/tests/backends/test_realsense_open_mocked.py
@@ -1,0 +1,107 @@
+# cli/tests/backends/test_realsense_open_mocked.py
+from __future__ import annotations
+
+import sys
+import types
+from unittest.mock import MagicMock
+
+from robot_md.robot_spec import (
+    MetadataBlock,
+    PhysicsBlock,
+    RobotSpec,
+    SafetyBlock,
+    VisionBlock,
+)
+
+
+def _make_minimal_spec(rrn: str) -> RobotSpec:
+    """Create a minimal RobotSpec for testing."""
+    return RobotSpec(
+        rcan_version="3.1",
+        metadata=MetadataBlock(
+            robot_name="test",
+            rrn=rrn,
+            device_id=None,
+            manufacturer=None,
+            model=None,
+            version=None,
+            license=None,
+        ),
+        physics=PhysicsBlock(
+            type="",
+            dof=0,
+            kinematics=(),
+            solver={},
+            cameras=(),
+            poses={},
+            workspace=None,
+        ),
+        drivers=(),
+        safety=SafetyBlock(
+            max_joint_velocity_dps=None,
+            max_linear_velocity_ms=None,
+            payload_kg=None,
+            workspace_bounds_m=None,
+            failsafe_behavior=None,
+            estop_software=False,
+            estop_hardware=False,
+            estop_response_ms=0,
+            hitl_gates=(),
+        ),
+        capabilities=frozenset(),
+        brain=None,
+        raw_yaml="",
+        capability_contracts={},
+        vision=VisionBlock(object_descriptors=()),
+        learned_skills=(),
+    )
+
+
+def _install_fake_pyrealsense2(monkeypatch) -> tuple[MagicMock, MagicMock]:
+    fake = types.ModuleType("pyrealsense2")
+    pipeline = MagicMock(name="rs.pipeline_instance")
+    pipeline_factory = MagicMock(name="rs.pipeline_factory", return_value=pipeline)
+    config = MagicMock(name="rs.config_instance")
+    config_factory = MagicMock(name="rs.config_factory", return_value=config)
+    fake.pipeline = pipeline_factory
+    fake.config = config_factory
+
+    class _Stream:
+        color = "color"
+        depth = "depth"
+
+    class _Format:
+        bgr8 = "bgr8"
+        z16 = "z16"
+
+    fake.stream = _Stream()
+    fake.format = _Format()
+    monkeypatch.setitem(sys.modules, "pyrealsense2", fake)
+    return pipeline, config
+
+
+def test_open_starts_pipeline_with_color_and_depth_streams(monkeypatch) -> None:
+    pipeline, config = _install_fake_pyrealsense2(monkeypatch)
+    from robot_md.backends.realsense import RealsenseBackend
+
+    spec = _make_minimal_spec(rrn="RRN-test")
+    b = RealsenseBackend()
+    b.open(spec)
+
+    pipeline.start.assert_called_once()
+    args, _ = pipeline.start.call_args
+    assert args[0] is config
+
+    enable_calls = config.enable_stream.call_args_list
+    enabled = {call.args[0] for call in enable_calls}
+    assert enabled == {"color", "depth"}
+
+
+def test_close_stops_pipeline(monkeypatch) -> None:
+    pipeline, _ = _install_fake_pyrealsense2(monkeypatch)
+    from robot_md.backends.realsense import RealsenseBackend
+
+    b = RealsenseBackend()
+    b.open(_make_minimal_spec(rrn="RRN-test"))
+    b.close()
+    pipeline.stop.assert_called_once()

--- a/cli/tests/backends/test_realsense_perceive_depth.py
+++ b/cli/tests/backends/test_realsense_perceive_depth.py
@@ -1,0 +1,22 @@
+from __future__ import annotations
+
+from unittest.mock import MagicMock
+
+from robot_md.backends.realsense import RealsenseBackend
+
+
+def test_perceive_depth_returns_z16_bytes() -> None:
+    depth_frame = MagicMock()
+    depth_frame.get_data.return_value = b"FAKE_DEPTH_BYTES"
+    frames = MagicMock()
+    frames.get_depth_frame.return_value = depth_frame
+    pipeline = MagicMock()
+    pipeline.wait_for_frames.return_value = frames
+
+    b = RealsenseBackend()
+    b._pipeline = pipeline
+    result = b.execute("perceive.depth", {}, dry_run=False, estop=None)
+    assert result.status == "ok"
+    payload = result.events[-1].data
+    assert payload["frame_bytes"] == b"FAKE_DEPTH_BYTES"
+    assert payload["format"] == "z16"

--- a/cli/tests/backends/test_realsense_perceive_rgb.py
+++ b/cli/tests/backends/test_realsense_perceive_rgb.py
@@ -1,0 +1,31 @@
+from __future__ import annotations
+
+from unittest.mock import MagicMock
+
+from robot_md.backends.realsense import RealsenseBackend
+
+
+def test_perceive_rgb_returns_frame_bytes() -> None:
+    color_frame = MagicMock()
+    color_frame.get_data.return_value = b"FAKE_RGB_BYTES"
+    frames = MagicMock()
+    frames.get_color_frame.return_value = color_frame
+    pipeline = MagicMock()
+    pipeline.wait_for_frames.return_value = frames
+
+    b = RealsenseBackend()
+    b._pipeline = pipeline
+    result = b.execute("perceive.rgb", {}, dry_run=False, estop=None)
+    assert result.status == "ok"
+    payload = result.events[-1].data
+    assert payload["frame_bytes"] == b"FAKE_RGB_BYTES"
+    assert payload["format"] == "bgr8"
+
+
+def test_perceive_rgb_dry_run_short_circuits() -> None:
+    b = RealsenseBackend()
+    b._pipeline = MagicMock()  # would raise if called
+    result = b.execute("perceive.rgb", {}, dry_run=True, estop=None)
+    assert result.status == "ok"
+    assert result.events[-1].kind == "dry_run"
+    b._pipeline.wait_for_frames.assert_not_called()

--- a/cli/tests/backends/test_realsense_scene_describe_mocked.py
+++ b/cli/tests/backends/test_realsense_scene_describe_mocked.py
@@ -1,0 +1,27 @@
+from __future__ import annotations
+
+from unittest.mock import MagicMock
+
+from robot_md.backends.realsense import RealsenseBackend
+
+
+def test_scene_describe_returns_snapshot_with_color_bytes() -> None:
+    color_frame = MagicMock()
+    color_frame.get_data.return_value = b"COLOR_BYTES"
+    frames = MagicMock()
+    frames.get_color_frame.return_value = color_frame
+    pipeline = MagicMock()
+    pipeline.wait_for_frames.return_value = frames
+
+    b = RealsenseBackend()
+    b._pipeline = pipeline
+    snap = b.scene_describe()
+    assert snap.frame == b"COLOR_BYTES"
+    assert snap.detections == ()
+    assert snap.joint_state == {}
+
+
+def test_scene_describe_with_no_pipeline_returns_empty() -> None:
+    b = RealsenseBackend()
+    snap = b.scene_describe()
+    assert snap.frame is None


### PR DESCRIPTION
## Summary
Completes SP3 **Phase B — RealSense camera backend**. Camera-only adapter (no motion). Builds confidence in the SP3 adapter pattern + describe_capabilities() integration before tackling the heavier LeRobot adapter in Phase C.

| Task | Commit | What |
|---|---|---|
| 9 | \`3a28b49\` | \`RealsenseBackend\` skeleton — name="realsense", capabilities = {perceive.rgb, perceive.depth, realsense.aligned_depth} |
| 10 | \`c7d1c5a\` | \`open()\`/\`close()\` — pyrealsense2 pipeline (color BGR8 + depth Z16, both 640x480 @30fps) |
| 11 | \`f41d197\` | \`perceive.rgb\` handler |
| 12 | \`a735b13\` | \`perceive.depth\` handler |
| 13 | \`abb4ade\` | \`scene_describe()\` returns SceneSnapshot with color frame bytes |
| 14 | \`78b0767\` | \`realsense.aligned_depth\` vendor capability — uses rs.align(rs.stream.color) |
| 15 | \`c3d2cd7\` | Lock no-arm contract — arm.* and gripper.* calls return not_implemented |

## Test plan
- [x] \`pytest tests/backends/ -q\` → 50/50 passing locally (was 36 after Phase A; +14 new for Phase B)
- [x] \`ruff check src tests\` + \`ruff format --check src tests\` → clean
- [x] All tests use mocked pyrealsense2 — no real RealSense hardware required
- [ ] CI Python 3.10/3.11/3.12/3.13 matrix — runs on PR open

## Architecture invariants preserved
- \`pyrealsense2\` is lazy-imported inside \`open()\` and \`_ensure_align()\` — package loads cleanly when the SDK isn't installed.
- The \`HANDLERS\` dict pattern in \`capabilities.py\` allows new capabilities to be added by name without touching \`execute()\` dispatch.
- \`read_only_capabilities = {perceive.rgb, perceive.depth}\` lets downstream gating treat perception as side-effect-free.
- Tier validator from Phase A is exercised: all RealSense capability names pass the \`<vendor>.<name>\` regex.

## Out of scope
- Phase C (LeRobot motion backend, Tasks 16-24)
- Phase D (pyproject extras + entry-points, Tasks 25-27)
- Phase E (authoring guide + template, Tasks 28-30)
- Phase F (integration + schema sync + hardware stubs, Tasks 31-35)

🤖 Generated with [Claude Code](https://claude.com/claude-code)