### PR TITLE
feat(sp3): Phase C — LeRobot motion + camera backend (Tasks 16-24)

### DIFF
--- a/cli/src/robot_md/backends/lerobot/__init__.py
+++ b/cli/src/robot_md/backends/lerobot/__init__.py
@@ -1,0 +1,60 @@
+"""LeRobot adapter — motion + camera, wraps HuggingFace LeRobot SDK."""
+
+from __future__ import annotations
+
+import contextlib
+
+from robot_md.backends.base import (
+    CapabilityBackend,
+    ExecutionResult,
+    SceneSnapshot,
+)
+from robot_md.robot_spec import RobotSpec
+
+
+class LerobotBackend(CapabilityBackend):
+    name = "lerobot"
+    protocols = frozenset({"feetech", "dynamixel"})
+    read_only_capabilities = frozenset({"perceive.rgb", "perceive.depth"})
+
+    def __init__(self) -> None:
+        self._robot = None
+
+    def open(self, spec: RobotSpec) -> None:
+        # Implemented in Task 18.
+        raise NotImplementedError
+
+    def close(self) -> None:
+        if self._robot is not None:
+            with contextlib.suppress(Exception):
+                self._robot.disconnect()
+            self._robot = None
+
+    def capabilities(self) -> frozenset[str]:
+        return frozenset(
+            {
+                "arm.pick",
+                "arm.place",
+                "arm.home",
+                "perceive.rgb",
+                "perceive.depth",
+                "gripper.open",
+                "gripper.close",
+                "lerobot.teleop",
+            }
+        )
+
+    def execute(
+        self,
+        capability: str,
+        args: dict,
+        *,
+        dry_run: bool,
+        estop,
+    ) -> ExecutionResult:
+        from robot_md.backends.lerobot.capabilities import dispatch
+
+        return dispatch(self, capability=capability, args=dict(args), dry_run=dry_run, estop=estop)
+
+    def scene_describe(self) -> SceneSnapshot:
+        return SceneSnapshot.empty()

--- a/cli/src/robot_md/backends/lerobot/__init__.py
+++ b/cli/src/robot_md/backends/lerobot/__init__.py
@@ -21,8 +21,13 @@ class LerobotBackend(CapabilityBackend):
         self._robot = None
 
     def open(self, spec: RobotSpec) -> None:
-        # Implemented in Task 18.
-        raise NotImplementedError
+        from lerobot.common.robot_devices.robots.factory import make_robot
+
+        from robot_md.backends.lerobot.config import build_lerobot_config
+
+        cfg = build_lerobot_config(spec)
+        self._robot = make_robot(cfg)
+        self._robot.connect()
 
     def close(self) -> None:
         if self._robot is not None:

--- a/cli/src/robot_md/backends/lerobot/capabilities.py
+++ b/cli/src/robot_md/backends/lerobot/capabilities.py
@@ -10,6 +10,7 @@ from robot_md.backends.lerobot.motion import (
     gripper_close,
     gripper_open,
 )
+from robot_md.backends.lerobot.perception import perceive_depth, perceive_rgb
 
 HANDLERS = {
     "arm.pick": arm_pick,
@@ -17,6 +18,8 @@ HANDLERS = {
     "arm.home": arm_home,
     "gripper.open": gripper_open,
     "gripper.close": gripper_close,
+    "perceive.rgb": perceive_rgb,
+    "perceive.depth": perceive_depth,
 }
 
 

--- a/cli/src/robot_md/backends/lerobot/capabilities.py
+++ b/cli/src/robot_md/backends/lerobot/capabilities.py
@@ -1,0 +1,14 @@
+"""LeRobot capability dispatch — populated incrementally."""
+
+from __future__ import annotations
+
+from robot_md.backends.base import ExecutionResult
+
+
+def dispatch(backend, *, capability: str, args: dict, dry_run: bool, estop) -> ExecutionResult:
+    return ExecutionResult(
+        status="error",
+        trajectory=None,
+        events=[],
+        error={"reason": "not_implemented", "detail": f"capability {capability!r}"},
+    )

--- a/cli/src/robot_md/backends/lerobot/capabilities.py
+++ b/cli/src/robot_md/backends/lerobot/capabilities.py
@@ -3,12 +3,20 @@
 from __future__ import annotations
 
 from robot_md.backends.base import ExecutionResult
-from robot_md.backends.lerobot.motion import arm_home, arm_pick, arm_place
+from robot_md.backends.lerobot.motion import (
+    arm_home,
+    arm_pick,
+    arm_place,
+    gripper_close,
+    gripper_open,
+)
 
 HANDLERS = {
     "arm.pick": arm_pick,
     "arm.place": arm_place,
     "arm.home": arm_home,
+    "gripper.open": gripper_open,
+    "gripper.close": gripper_close,
 }
 
 

--- a/cli/src/robot_md/backends/lerobot/capabilities.py
+++ b/cli/src/robot_md/backends/lerobot/capabilities.py
@@ -9,6 +9,7 @@ from robot_md.backends.lerobot.motion import (
     arm_place,
     gripper_close,
     gripper_open,
+    lerobot_teleop,
 )
 from robot_md.backends.lerobot.perception import perceive_depth, perceive_rgb
 
@@ -20,6 +21,7 @@ HANDLERS = {
     "gripper.close": gripper_close,
     "perceive.rgb": perceive_rgb,
     "perceive.depth": perceive_depth,
+    "lerobot.teleop": lerobot_teleop,
 }
 
 

--- a/cli/src/robot_md/backends/lerobot/capabilities.py
+++ b/cli/src/robot_md/backends/lerobot/capabilities.py
@@ -3,12 +3,20 @@
 from __future__ import annotations
 
 from robot_md.backends.base import ExecutionResult
+from robot_md.backends.lerobot.motion import arm_pick
+
+HANDLERS = {
+    "arm.pick": arm_pick,
+}
 
 
 def dispatch(backend, *, capability: str, args: dict, dry_run: bool, estop) -> ExecutionResult:
-    return ExecutionResult(
-        status="error",
-        trajectory=None,
-        events=[],
-        error={"reason": "not_implemented", "detail": f"capability {capability!r}"},
-    )
+    handler = HANDLERS.get(capability)
+    if handler is None:
+        return ExecutionResult(
+            status="error",
+            trajectory=None,
+            events=[],
+            error={"reason": "not_implemented", "detail": f"capability {capability!r}"},
+        )
+    return handler(backend, args, dry_run=dry_run, estop=estop)

--- a/cli/src/robot_md/backends/lerobot/capabilities.py
+++ b/cli/src/robot_md/backends/lerobot/capabilities.py
@@ -3,10 +3,12 @@
 from __future__ import annotations
 
 from robot_md.backends.base import ExecutionResult
-from robot_md.backends.lerobot.motion import arm_pick
+from robot_md.backends.lerobot.motion import arm_home, arm_pick, arm_place
 
 HANDLERS = {
     "arm.pick": arm_pick,
+    "arm.place": arm_place,
+    "arm.home": arm_home,
 }
 
 

--- a/cli/src/robot_md/backends/lerobot/config.py
+++ b/cli/src/robot_md/backends/lerobot/config.py
@@ -1,0 +1,43 @@
+"""Translate RobotSpec → LeRobot make_robot() config dict."""
+
+from __future__ import annotations
+
+from robot_md.robot_spec import RobotSpec
+
+_ARM_PROTOCOLS = frozenset({"feetech", "dynamixel"})
+
+
+def build_lerobot_config(spec: RobotSpec) -> dict:
+    """Pull port + baud_rate + per-joint servo mapping out of a RobotSpec.
+
+    Driver gives transport (port, baud_rate, model, count); physics.kinematics
+    gives the joint id ↔ servo_id mapping. Both sources are required.
+    """
+    arm_driver = next(
+        (d for d in spec.drivers if d.protocol in _ARM_PROTOCOLS),
+        None,
+    )
+    if arm_driver is None:
+        raise ValueError(
+            "RobotSpec has no feetech/dynamixel arm driver; LeRobot adapter requires one"
+        )
+    if not spec.physics.kinematics:
+        raise ValueError(
+            f"Driver {arm_driver.id!r} declared but physics.kinematics is empty; "
+            "cannot build per-motor mapping"
+        )
+    motors = [
+        {
+            "joint": kin["id"],
+            "servo_id": kin["servo_id"],
+            "model": arm_driver.model,
+        }
+        for kin in spec.physics.kinematics
+    ]
+    return {
+        "robot_type": "so_arm",
+        "port": arm_driver.port,
+        "baud_rate": arm_driver.baud_rate,
+        "model": arm_driver.model,
+        "motors": motors,
+    }

--- a/cli/src/robot_md/backends/lerobot/motion.py
+++ b/cli/src/robot_md/backends/lerobot/motion.py
@@ -141,3 +141,39 @@ def arm_home(backend, args: dict, *, dry_run: bool, estop) -> ExecutionResult:
         events=[ExecutionEvent(kind="motion_complete", data={"capability": "arm.home"})],
         error=None,
     )
+
+
+def gripper_open(backend, args: dict, *, dry_run: bool, estop) -> ExecutionResult:
+    cmd = {"phase": "gripper.open", "gripper": "open"}
+    if dry_run:
+        return ExecutionResult(
+            status="ok",
+            trajectory=[cmd],
+            events=[ExecutionEvent(kind="dry_run", data={"capability": "gripper.open"})],
+            error=None,
+        )
+    backend._robot.send_action(cmd)
+    return ExecutionResult(
+        status="ok",
+        trajectory=[cmd],
+        events=[ExecutionEvent(kind="motion_complete", data={"capability": "gripper.open"})],
+        error=None,
+    )
+
+
+def gripper_close(backend, args: dict, *, dry_run: bool, estop) -> ExecutionResult:
+    cmd = {"phase": "gripper.close", "gripper": "close"}
+    if dry_run:
+        return ExecutionResult(
+            status="ok",
+            trajectory=[cmd],
+            events=[ExecutionEvent(kind="dry_run", data={"capability": "gripper.close"})],
+            error=None,
+        )
+    backend._robot.send_action(cmd)
+    return ExecutionResult(
+        status="ok",
+        trajectory=[cmd],
+        events=[ExecutionEvent(kind="motion_complete", data={"capability": "gripper.close"})],
+        error=None,
+    )

--- a/cli/src/robot_md/backends/lerobot/motion.py
+++ b/cli/src/robot_md/backends/lerobot/motion.py
@@ -68,3 +68,76 @@ def arm_pick(backend, args: dict, *, dry_run: bool, estop) -> ExecutionResult:
         ],
         error=None,
     )
+
+
+def arm_place(backend, args: dict, *, dry_run: bool, estop) -> ExecutionResult:
+    if "destination" not in args:
+        return ExecutionResult(
+            status="error",
+            trajectory=None,
+            events=[],
+            error={"reason": "missing_args", "detail": "arm.place requires 'destination'"},
+        )
+    if not isinstance(args["destination"], str):
+        return ExecutionResult(
+            status="error",
+            trajectory=None,
+            events=[],
+            error={"reason": "schema_violation", "detail": "'destination' must be string"},
+        )
+    destination = args["destination"]
+    plan = [
+        {
+            "phase": "transport",
+            "joints": [0.5, -0.3, 0.6, 0.0, 0.0, 0.6],
+            "destination": destination,
+        },
+        {"phase": "release", "joints": [0.5, -0.5, 0.4, 0.0, 0.0, 0.0]},
+        {"phase": "retract", "joints": [0.0, -0.3, 0.6, 0.0, 0.0, 0.0]},
+    ]
+    if dry_run:
+        return ExecutionResult(
+            status="ok",
+            trajectory=plan,
+            events=[
+                ExecutionEvent(
+                    kind="dry_run",
+                    data={"capability": "arm.place", "destination": destination},
+                )
+            ],
+            error=None,
+        )
+    for step in plan:
+        backend._robot.send_action(step)
+    return ExecutionResult(
+        status="ok",
+        trajectory=plan,
+        events=[
+            ExecutionEvent(
+                kind="motion_complete",
+                data={"capability": "arm.place", "destination": destination},
+            )
+        ],
+        error=None,
+    )
+
+
+_HOME_JOINTS = [0.0, 0.0, 0.0, 0.0, 0.0, 0.0]
+
+
+def arm_home(backend, args: dict, *, dry_run: bool, estop) -> ExecutionResult:
+    plan = [{"phase": "home", "joints": list(_HOME_JOINTS)}]
+    if dry_run:
+        return ExecutionResult(
+            status="ok",
+            trajectory=plan,
+            events=[ExecutionEvent(kind="dry_run", data={"capability": "arm.home"})],
+            error=None,
+        )
+    backend._robot.send_action(plan[0])
+    return ExecutionResult(
+        status="ok",
+        trajectory=plan,
+        events=[ExecutionEvent(kind="motion_complete", data={"capability": "arm.home"})],
+        error=None,
+    )

--- a/cli/src/robot_md/backends/lerobot/motion.py
+++ b/cli/src/robot_md/backends/lerobot/motion.py
@@ -1,0 +1,70 @@
+"""LeRobot arm.* / gripper.* handlers.
+
+Wraps the connected robot's send_action interface with simple per-capability
+action plans. Plans are intentionally generic — a real adapter would compute IK
+or invoke a learned policy. For SP3, the goal is to prove dispatch plumbing;
+trajectory quality is out of scope.
+"""
+
+from __future__ import annotations
+
+from robot_md.backends.base import ExecutionEvent, ExecutionResult
+
+
+def _validate_pick_args(args: dict) -> ExecutionResult | None:
+    if "target" not in args:
+        return ExecutionResult(
+            status="error",
+            trajectory=None,
+            events=[],
+            error={"reason": "missing_args", "detail": "arm.pick requires 'target'"},
+        )
+    if not isinstance(args["target"], str):
+        return ExecutionResult(
+            status="error",
+            trajectory=None,
+            events=[],
+            error={"reason": "schema_violation", "detail": "'target' must be string"},
+        )
+    return None
+
+
+def arm_pick(backend, args: dict, *, dry_run: bool, estop) -> ExecutionResult:
+    bad = _validate_pick_args(args)
+    if bad is not None:
+        return bad
+    target = args["target"]
+    approach_height_mm = float(args.get("approach_height_mm", 50))
+    plan = [
+        {
+            "phase": "approach",
+            "joints": [0.0, -0.3, 0.6, 0.0, 0.0, 0.0],
+            "approach_height_mm": approach_height_mm,
+            "target": target,
+        },
+        {"phase": "descend", "joints": [0.0, -0.5, 0.4, 0.0, 0.0, 0.0]},
+        {"phase": "grasp", "joints": [0.0, -0.5, 0.4, 0.0, 0.0, 0.6]},
+        {"phase": "lift", "joints": [0.0, -0.3, 0.6, 0.0, 0.0, 0.6]},
+    ]
+    if dry_run:
+        return ExecutionResult(
+            status="ok",
+            trajectory=plan,
+            events=[
+                ExecutionEvent(kind="dry_run", data={"capability": "arm.pick", "target": target})
+            ],
+            error=None,
+        )
+    for step in plan:
+        backend._robot.send_action(step)
+    return ExecutionResult(
+        status="ok",
+        trajectory=plan,
+        events=[
+            ExecutionEvent(
+                kind="motion_complete",
+                data={"capability": "arm.pick", "target": target},
+            )
+        ],
+        error=None,
+    )

--- a/cli/src/robot_md/backends/lerobot/motion.py
+++ b/cli/src/robot_md/backends/lerobot/motion.py
@@ -177,3 +177,32 @@ def gripper_close(backend, args: dict, *, dry_run: bool, estop) -> ExecutionResu
         events=[ExecutionEvent(kind="motion_complete", data={"capability": "gripper.close"})],
         error=None,
     )
+
+
+def lerobot_teleop(backend, args: dict, *, dry_run: bool, estop) -> ExecutionResult:
+    max_steps = int(args.get("max_steps", 100))
+    if dry_run:
+        return ExecutionResult(
+            status="ok",
+            trajectory=None,
+            events=[
+                ExecutionEvent(
+                    kind="dry_run",
+                    data={"capability": "lerobot.teleop", "max_steps": max_steps},
+                )
+            ],
+            error=None,
+        )
+    streamed = 0
+    for _ in range(max_steps):
+        state = backend._robot.read_leader_state()
+        if state is None:
+            break
+        backend._robot.send_action(state)
+        streamed += 1
+    return ExecutionResult(
+        status="ok",
+        trajectory=None,
+        events=[ExecutionEvent(kind="teleop_complete", data={"steps": streamed})],
+        error=None,
+    )

--- a/cli/src/robot_md/backends/lerobot/perception.py
+++ b/cli/src/robot_md/backends/lerobot/perception.py
@@ -1,0 +1,78 @@
+"""LeRobot perception handlers — wrap the connected robot's capture_observation()."""
+
+from __future__ import annotations
+
+from robot_md.backends.base import ExecutionEvent, ExecutionResult
+
+
+def _first_image_key(obs: dict, prefix: str) -> str | None:
+    for k in obs:
+        if k.startswith(prefix):
+            return k
+    return None
+
+
+def perceive_rgb(backend, args: dict, *, dry_run: bool, estop) -> ExecutionResult:
+    if dry_run:
+        return ExecutionResult(
+            status="ok",
+            trajectory=None,
+            events=[ExecutionEvent(kind="dry_run", data={"capability": "perceive.rgb"})],
+            error=None,
+        )
+    obs = backend._robot.capture_observation()
+    key = _first_image_key(obs, "observation.images.")
+    if key is None:
+        return ExecutionResult(
+            status="error",
+            trajectory=None,
+            events=[],
+            error={
+                "reason": "no_camera",
+                "detail": "no observation.images.* in observation dict",
+            },
+        )
+    return ExecutionResult(
+        status="ok",
+        trajectory=None,
+        events=[
+            ExecutionEvent(
+                kind="frame",
+                data={"frame_bytes": obs[key], "format": "bgr8", "source": key},
+            )
+        ],
+        error=None,
+    )
+
+
+def perceive_depth(backend, args: dict, *, dry_run: bool, estop) -> ExecutionResult:
+    if dry_run:
+        return ExecutionResult(
+            status="ok",
+            trajectory=None,
+            events=[ExecutionEvent(kind="dry_run", data={"capability": "perceive.depth"})],
+            error=None,
+        )
+    obs = backend._robot.capture_observation()
+    key = _first_image_key(obs, "observation.depth.")
+    if key is None:
+        return ExecutionResult(
+            status="error",
+            trajectory=None,
+            events=[],
+            error={
+                "reason": "no_depth_camera",
+                "detail": "no observation.depth.* in observation dict",
+            },
+        )
+    return ExecutionResult(
+        status="ok",
+        trajectory=None,
+        events=[
+            ExecutionEvent(
+                kind="frame",
+                data={"frame_bytes": obs[key], "format": "z16", "source": key},
+            )
+        ],
+        error=None,
+    )

--- a/cli/tests/backends/test_lerobot_arm_place_home.py
+++ b/cli/tests/backends/test_lerobot_arm_place_home.py
@@ -1,0 +1,48 @@
+from __future__ import annotations
+
+from unittest.mock import MagicMock
+
+from robot_md.backends.lerobot import LerobotBackend
+
+
+def _backend() -> tuple[LerobotBackend, MagicMock]:
+    b = LerobotBackend()
+    b._robot = MagicMock()
+    return b, b._robot
+
+
+def test_arm_place_dry_run_returns_trajectory() -> None:
+    b, robot = _backend()
+    result = b.execute("arm.place", {"destination": "drop_zone"}, dry_run=True, estop=None)
+    assert result.status == "ok"
+    assert result.trajectory is not None
+    robot.send_action.assert_not_called()
+
+
+def test_arm_place_live_invokes_send_action() -> None:
+    b, robot = _backend()
+    result = b.execute("arm.place", {"destination": "drop_zone"}, dry_run=False, estop=None)
+    assert result.status == "ok"
+    assert robot.send_action.call_count >= 1
+
+
+def test_arm_place_missing_destination() -> None:
+    b, _ = _backend()
+    result = b.execute("arm.place", {}, dry_run=True, estop=None)
+    assert result.status == "error"
+    assert result.error["reason"] in {"missing_args", "schema_violation"}
+
+
+def test_arm_home_no_args_succeeds() -> None:
+    b, robot = _backend()
+    result = b.execute("arm.home", {}, dry_run=False, estop=None)
+    assert result.status == "ok"
+    robot.send_action.assert_called()
+
+
+def test_arm_home_dry_run() -> None:
+    b, robot = _backend()
+    result = b.execute("arm.home", {}, dry_run=True, estop=None)
+    assert result.status == "ok"
+    assert result.trajectory is not None
+    robot.send_action.assert_not_called()

--- a/cli/tests/backends/test_lerobot_backend_capabilities_valid.py
+++ b/cli/tests/backends/test_lerobot_backend_capabilities_valid.py
@@ -1,0 +1,27 @@
+"""Test LerobotBackend capability set and namespace validation."""
+
+from __future__ import annotations
+
+from robot_md.backends.lerobot import LerobotBackend
+from robot_md.backends.registry import _validate_capability_namespace
+
+
+def test_all_declared_capabilities_pass_tier_validator() -> None:
+    b = LerobotBackend()
+    _validate_capability_namespace("lerobot", b.capabilities())
+
+
+def test_capabilities_set_contents() -> None:
+    b = LerobotBackend()
+    assert b.capabilities() == frozenset(
+        {
+            "arm.pick",
+            "arm.place",
+            "arm.home",
+            "perceive.rgb",
+            "perceive.depth",
+            "gripper.open",
+            "gripper.close",
+            "lerobot.teleop",
+        }
+    )

--- a/cli/tests/backends/test_lerobot_backend_open_mocked.py
+++ b/cli/tests/backends/test_lerobot_backend_open_mocked.py
@@ -1,0 +1,64 @@
+from __future__ import annotations
+
+import sys
+import types
+from unittest.mock import MagicMock
+
+from robot_md.backends.lerobot import LerobotBackend
+from tests.backends.test_lerobot_build_config_so_arm101 import _so_arm101_spec
+
+
+def _install_fake_lerobot(monkeypatch) -> tuple[MagicMock, MagicMock]:
+    """Stand up enough of the lerobot package tree so the lazy import inside
+    open() resolves cleanly without the real SDK installed.
+
+    Mirrors the pyrealsense2 fake-module pattern in
+    test_realsense_open_mocked.py::_install_fake_pyrealsense2.
+    """
+    fake_robot = MagicMock(name="lerobot_robot_instance")
+    make_robot = MagicMock(name="make_robot", return_value=fake_robot)
+
+    factory_mod = types.ModuleType("lerobot.common.robot_devices.robots.factory")
+    factory_mod.make_robot = make_robot
+
+    robots_mod = types.ModuleType("lerobot.common.robot_devices.robots")
+    robots_mod.factory = factory_mod
+
+    devices_mod = types.ModuleType("lerobot.common.robot_devices")
+    devices_mod.robots = robots_mod
+
+    common_mod = types.ModuleType("lerobot.common")
+    common_mod.robot_devices = devices_mod
+
+    root = types.ModuleType("lerobot")
+    root.common = common_mod
+
+    monkeypatch.setitem(sys.modules, "lerobot", root)
+    monkeypatch.setitem(sys.modules, "lerobot.common", common_mod)
+    monkeypatch.setitem(sys.modules, "lerobot.common.robot_devices", devices_mod)
+    monkeypatch.setitem(sys.modules, "lerobot.common.robot_devices.robots", robots_mod)
+    monkeypatch.setitem(sys.modules, "lerobot.common.robot_devices.robots.factory", factory_mod)
+    return fake_robot, make_robot
+
+
+def test_open_calls_make_robot_then_connect(monkeypatch) -> None:
+    fake_robot, make_robot = _install_fake_lerobot(monkeypatch)
+    b = LerobotBackend()
+    b.open(_so_arm101_spec())
+
+    make_robot.assert_called_once()
+    cfg = make_robot.call_args[0][0]
+    assert cfg["port"] == "/dev/ttyACM0"
+    assert cfg["baud_rate"] == 1000000
+    assert len(cfg["motors"]) == 6
+    fake_robot.connect.assert_called_once()
+    assert b._robot is fake_robot
+
+
+def test_close_after_open_calls_disconnect(monkeypatch) -> None:
+    fake_robot, _ = _install_fake_lerobot(monkeypatch)
+    b = LerobotBackend()
+    b.open(_so_arm101_spec())
+    b.close()
+    fake_robot.disconnect.assert_called_once()
+    assert b._robot is None

--- a/cli/tests/backends/test_lerobot_backend_protocols.py
+++ b/cli/tests/backends/test_lerobot_backend_protocols.py
@@ -1,0 +1,16 @@
+"""Test LerobotBackend protocols and read-only capabilities."""
+
+from __future__ import annotations
+
+from robot_md.backends.lerobot import LerobotBackend
+
+
+def test_name_and_protocols() -> None:
+    b = LerobotBackend()
+    assert b.name == "lerobot"
+    assert b.protocols == frozenset({"feetech", "dynamixel"})
+
+
+def test_read_only_capabilities_marks_perception() -> None:
+    b = LerobotBackend()
+    assert b.read_only_capabilities == frozenset({"perceive.rgb", "perceive.depth"})

--- a/cli/tests/backends/test_lerobot_build_config_so_arm101.py
+++ b/cli/tests/backends/test_lerobot_build_config_so_arm101.py
@@ -1,0 +1,207 @@
+from __future__ import annotations
+
+import pytest
+
+from robot_md.backends.lerobot.config import build_lerobot_config
+from robot_md.robot_spec import (
+    DriverEntry,
+    MetadataBlock,
+    PhysicsBlock,
+    RobotSpec,
+    SafetyBlock,
+    VisionBlock,
+)
+
+
+def _so_arm101_kinematics() -> tuple[dict, ...]:
+    return (
+        {
+            "id": "shoulder_pan",
+            "axis": "z",
+            "limits_deg": [-180, 180],
+            "length_mm": 60,
+            "servo_id": 1,
+            "encoder_sign": 1,
+            "zero_pose_steps": 2048,
+        },
+        {
+            "id": "shoulder_lift",
+            "axis": "y",
+            "limits_deg": [-90, 90],
+            "length_mm": 125,
+            "servo_id": 2,
+            "encoder_sign": 1,
+            "zero_pose_steps": 2048,
+        },
+        {
+            "id": "elbow_flex",
+            "axis": "y",
+            "limits_deg": [-90, 90],
+            "length_mm": 125,
+            "servo_id": 3,
+            "encoder_sign": 1,
+            "zero_pose_steps": 2048,
+        },
+        {
+            "id": "wrist_flex",
+            "axis": "y",
+            "limits_deg": [-90, 90],
+            "length_mm": 60,
+            "servo_id": 4,
+            "encoder_sign": 1,
+            "zero_pose_steps": 2048,
+        },
+        {
+            "id": "wrist_roll",
+            "axis": "x",
+            "limits_deg": [-180, 180],
+            "length_mm": 30,
+            "servo_id": 5,
+            "encoder_sign": 1,
+            "zero_pose_steps": 2048,
+        },
+        {
+            "id": "gripper",
+            "axis": "y",
+            "limits_deg": [0, 90],
+            "length_mm": 40,
+            "servo_id": 6,
+            "encoder_sign": 1,
+            "zero_pose_steps": 1200,
+        },
+    )
+
+
+def _so_arm101_spec() -> RobotSpec:
+    return RobotSpec(
+        rcan_version="3.1",
+        metadata=MetadataBlock(
+            robot_name="bob",
+            rrn="RRN-test-so-arm101",
+            device_id=None,
+            manufacturer=None,
+            model=None,
+            version=None,
+            license=None,
+        ),
+        physics=PhysicsBlock(
+            type="arm",
+            dof=6,
+            kinematics=_so_arm101_kinematics(),
+            solver={},
+            cameras=(),
+            poses={},
+            workspace=None,
+        ),
+        drivers=(
+            DriverEntry(
+                id="arm_servos",
+                protocol="feetech",
+                port="/dev/ttyACM0",
+                baud_rate=1000000,
+                model="STS3215",
+                count=6,
+                backend="lerobot",
+                streams={},
+            ),
+        ),
+        safety=SafetyBlock(
+            max_joint_velocity_dps=None,
+            max_linear_velocity_ms=None,
+            payload_kg=None,
+            workspace_bounds_m=None,
+            failsafe_behavior=None,
+            estop_software=False,
+            estop_hardware=False,
+            estop_response_ms=0,
+            hitl_gates=(),
+        ),
+        capabilities=frozenset(),
+        brain=None,
+        raw_yaml="",
+        capability_contracts={},
+        vision=VisionBlock(object_descriptors=()),
+        learned_skills=(),
+    )
+
+
+def test_build_config_extracts_six_motors() -> None:
+    cfg = build_lerobot_config(_so_arm101_spec())
+    assert cfg["robot_type"] == "so_arm"
+    assert cfg["port"] == "/dev/ttyACM0"
+    assert cfg["baud_rate"] == 1000000
+    assert len(cfg["motors"]) == 6
+    assert {m["joint"] for m in cfg["motors"]} == {
+        "shoulder_pan",
+        "shoulder_lift",
+        "elbow_flex",
+        "wrist_flex",
+        "wrist_roll",
+        "gripper",
+    }
+    # Each motor should carry its servo_id from kinematics and the driver's model.
+    by_joint = {m["joint"]: m for m in cfg["motors"]}
+    assert by_joint["shoulder_pan"]["servo_id"] == 1
+    assert by_joint["gripper"]["servo_id"] == 6
+    assert all(m["model"] == "STS3215" for m in cfg["motors"])
+
+
+def test_build_config_no_arm_driver_raises() -> None:
+    spec = _so_arm101_spec()
+    # Replace the feetech driver with an unrelated one.
+    bad = RobotSpec(
+        rcan_version=spec.rcan_version,
+        metadata=spec.metadata,
+        physics=spec.physics,
+        drivers=(
+            DriverEntry(
+                id="cam",
+                protocol="usb",
+                port=None,
+                baud_rate=None,
+                model=None,
+                count=None,
+                backend=None,
+                streams={},
+            ),
+        ),
+        safety=spec.safety,
+        capabilities=spec.capabilities,
+        brain=spec.brain,
+        raw_yaml=spec.raw_yaml,
+        capability_contracts=spec.capability_contracts,
+        vision=spec.vision,
+        learned_skills=spec.learned_skills,
+    )
+    with pytest.raises(ValueError) as exc:
+        build_lerobot_config(bad)
+    assert "feetech" in str(exc.value).lower() or "dynamixel" in str(exc.value).lower()
+
+
+def test_build_config_no_kinematics_raises() -> None:
+    spec = _so_arm101_spec()
+    bad = RobotSpec(
+        rcan_version=spec.rcan_version,
+        metadata=spec.metadata,
+        physics=PhysicsBlock(
+            type=spec.physics.type,
+            dof=spec.physics.dof,
+            kinematics=(),  # empty
+            solver=spec.physics.solver,
+            cameras=spec.physics.cameras,
+            poses=spec.physics.poses,
+            workspace=spec.physics.workspace,
+        ),
+        drivers=spec.drivers,
+        safety=spec.safety,
+        capabilities=spec.capabilities,
+        brain=spec.brain,
+        raw_yaml=spec.raw_yaml,
+        capability_contracts=spec.capability_contracts,
+        vision=spec.vision,
+        learned_skills=spec.learned_skills,
+    )
+    with pytest.raises(ValueError) as exc:
+        build_lerobot_config(bad)
+    error_msg = str(exc.value).lower()
+    assert "kinematics" in error_msg or "joints" in error_msg or "motors" in error_msg

--- a/cli/tests/backends/test_lerobot_capabilities_schema_compliance.py
+++ b/cli/tests/backends/test_lerobot_capabilities_schema_compliance.py
@@ -1,0 +1,41 @@
+from __future__ import annotations
+
+import json
+from pathlib import Path
+
+import jsonschema
+
+from robot_md.backends.lerobot import LerobotBackend
+
+_SCHEMA_PATH = Path(__file__).parents[2] / "src" / "robot_md" / "schemas" / "capabilities.json"
+
+
+_MINIMAL_ARGS = {
+    "arm.pick": {"target": "red_lego"},
+    "arm.place": {"destination": "drop_zone"},
+    "arm.home": {},
+    "perceive.rgb": {},
+    "perceive.depth": {},
+    "gripper.open": {},
+    "gripper.close": {},
+}
+
+
+def test_minimal_valid_args_per_core_capability_pass_validation() -> None:
+    schema = json.loads(_SCHEMA_PATH.read_text())
+    defs = schema["definitions"]
+    backend_caps = LerobotBackend().capabilities()
+    validated: list[str] = []
+    for cap in backend_caps:
+        if cap not in defs:
+            continue  # vendor capability — not in capabilities.json
+        assert cap in _MINIMAL_ARGS, f"missing minimal-args fixture for core capability {cap!r}"
+        jsonschema.validate(_MINIMAL_ARGS[cap], defs[cap])
+        validated.append(cap)
+    # Sanity: we expect every core capability the backend declares to have been
+    # validated. If this number drifts low, something is silently being skipped.
+    expected_core_caps = backend_caps - frozenset({"lerobot.teleop"})
+    assert frozenset(validated) == expected_core_caps, (
+        f"core caps validated {sorted(validated)!r} differs from declared "
+        f"core caps {sorted(expected_core_caps)!r}"
+    )

--- a/cli/tests/backends/test_lerobot_dry_run.py
+++ b/cli/tests/backends/test_lerobot_dry_run.py
@@ -1,0 +1,36 @@
+from __future__ import annotations
+
+from unittest.mock import MagicMock
+
+from robot_md.backends.lerobot import LerobotBackend
+
+
+def test_dry_run_arm_pick_populates_trajectory_and_skips_writes() -> None:
+    b = LerobotBackend()
+    robot = MagicMock()
+    b._robot = robot
+    result = b.execute("arm.pick", {"target": "red_lego"}, dry_run=True, estop=None)
+    assert result.status == "ok"
+    assert isinstance(result.trajectory, list)
+    assert len(result.trajectory) >= 2  # at least approach + descend
+    robot.send_action.assert_not_called()
+
+
+def test_dry_run_arm_place_populates_trajectory() -> None:
+    b = LerobotBackend()
+    robot = MagicMock()
+    b._robot = robot
+    result = b.execute("arm.place", {"destination": "drop_zone"}, dry_run=True, estop=None)
+    assert result.status == "ok"
+    assert isinstance(result.trajectory, list)
+    robot.send_action.assert_not_called()
+
+
+def test_dry_run_arm_home_populates_trajectory() -> None:
+    b = LerobotBackend()
+    robot = MagicMock()
+    b._robot = robot
+    result = b.execute("arm.home", {}, dry_run=True, estop=None)
+    assert result.status == "ok"
+    assert isinstance(result.trajectory, list)
+    robot.send_action.assert_not_called()

--- a/cli/tests/backends/test_lerobot_execute_arm_pick_mocked.py
+++ b/cli/tests/backends/test_lerobot_execute_arm_pick_mocked.py
@@ -1,0 +1,46 @@
+from __future__ import annotations
+
+from unittest.mock import MagicMock
+
+from robot_md.backends.lerobot import LerobotBackend
+
+
+def _backend_with_robot() -> tuple[LerobotBackend, MagicMock]:
+    b = LerobotBackend()
+    robot = MagicMock(name="lerobot_robot")
+    b._robot = robot
+    return b, robot
+
+
+def test_arm_pick_dry_run_emits_trajectory_no_writes() -> None:
+    b, robot = _backend_with_robot()
+    result = b.execute("arm.pick", {"target": "red_lego"}, dry_run=True, estop=None)
+    assert result.status == "ok"
+    assert result.trajectory is not None
+    assert len(result.trajectory) >= 2
+    robot.send_action.assert_not_called()
+
+
+def test_arm_pick_live_invokes_send_action() -> None:
+    b, robot = _backend_with_robot()
+    result = b.execute("arm.pick", {"target": "red_lego"}, dry_run=False, estop=None)
+    assert result.status == "ok"
+    robot.send_action.assert_called()
+    # Loose-OR assertion: first call should mention "approach" via str() OR carry a "joints" key.
+    # (Reviewer note: intentionally loose so the test doesn't pin the exact phase keyword.)
+    first_call_args = robot.send_action.call_args_list[0].args[0]
+    assert "approach" in str(first_call_args).lower() or "joints" in first_call_args
+
+
+def test_arm_pick_missing_target_returns_error() -> None:
+    b, _ = _backend_with_robot()
+    result = b.execute("arm.pick", {}, dry_run=True, estop=None)
+    assert result.status == "error"
+    assert result.error["reason"] in {"missing_args", "schema_violation"}
+
+
+def test_arm_pick_non_string_target_returns_schema_violation() -> None:
+    b, _ = _backend_with_robot()
+    result = b.execute("arm.pick", {"target": 42}, dry_run=True, estop=None)
+    assert result.status == "error"
+    assert result.error["reason"] == "schema_violation"

--- a/cli/tests/backends/test_lerobot_execute_unknown_capability.py
+++ b/cli/tests/backends/test_lerobot_execute_unknown_capability.py
@@ -1,0 +1,21 @@
+from __future__ import annotations
+
+from unittest.mock import MagicMock
+
+from robot_md.backends.lerobot import LerobotBackend
+
+
+def test_unknown_capability_returns_not_implemented() -> None:
+    b = LerobotBackend()
+    b._robot = MagicMock()
+    result = b.execute("arm.dance", {}, dry_run=True, estop=None)
+    assert result.status == "error"
+    assert result.error["reason"] == "not_implemented"
+
+
+def test_misspelled_core_capability_also_returns_not_implemented() -> None:
+    b = LerobotBackend()
+    b._robot = MagicMock()
+    result = b.execute("gripper.opn", {}, dry_run=True, estop=None)
+    assert result.status == "error"
+    assert result.error["reason"] == "not_implemented"

--- a/cli/tests/backends/test_lerobot_gripper.py
+++ b/cli/tests/backends/test_lerobot_gripper.py
@@ -1,0 +1,44 @@
+from __future__ import annotations
+
+from unittest.mock import MagicMock
+
+from robot_md.backends.lerobot import LerobotBackend
+
+
+def _backend() -> tuple[LerobotBackend, MagicMock]:
+    b = LerobotBackend()
+    b._robot = MagicMock()
+    return b, b._robot
+
+
+def test_gripper_open_sends_open_command() -> None:
+    b, robot = _backend()
+    result = b.execute("gripper.open", {}, dry_run=False, estop=None)
+    assert result.status == "ok"
+    robot.send_action.assert_called_once()
+    sent = robot.send_action.call_args.args[0]
+    assert sent.get("gripper") == "open"
+
+
+def test_gripper_open_dry_run_skips_writes() -> None:
+    b, robot = _backend()
+    result = b.execute("gripper.open", {}, dry_run=True, estop=None)
+    assert result.status == "ok"
+    assert result.trajectory is not None
+    robot.send_action.assert_not_called()
+
+
+def test_gripper_close_sends_close_command() -> None:
+    b, robot = _backend()
+    result = b.execute("gripper.close", {}, dry_run=False, estop=None)
+    assert result.status == "ok"
+    sent = robot.send_action.call_args.args[0]
+    assert sent.get("gripper") == "close"
+
+
+def test_gripper_close_dry_run_skips_writes() -> None:
+    b, robot = _backend()
+    result = b.execute("gripper.close", {}, dry_run=True, estop=None)
+    assert result.status == "ok"
+    assert result.trajectory is not None
+    robot.send_action.assert_not_called()

--- a/cli/tests/backends/test_lerobot_perception.py
+++ b/cli/tests/backends/test_lerobot_perception.py
@@ -1,0 +1,62 @@
+from __future__ import annotations
+
+from unittest.mock import MagicMock
+
+from robot_md.backends.lerobot import LerobotBackend
+
+
+def test_perceive_rgb_pulls_from_robot_capture() -> None:
+    b = LerobotBackend()
+    robot = MagicMock()
+    robot.capture_observation.return_value = {
+        "observation.images.front": b"FRAME_RGB_BYTES",
+    }
+    b._robot = robot
+    result = b.execute("perceive.rgb", {}, dry_run=False, estop=None)
+    assert result.status == "ok"
+    payload = result.events[-1].data
+    assert payload["frame_bytes"] == b"FRAME_RGB_BYTES"
+    assert payload["source"] == "observation.images.front"
+
+
+def test_perceive_rgb_dry_run() -> None:
+    b = LerobotBackend()
+    b._robot = MagicMock()
+    result = b.execute("perceive.rgb", {}, dry_run=True, estop=None)
+    assert result.status == "ok"
+    b._robot.capture_observation.assert_not_called()
+
+
+def test_perceive_rgb_no_camera_returns_error() -> None:
+    b = LerobotBackend()
+    robot = MagicMock()
+    robot.capture_observation.return_value = {"observation.depth.front": b"DEPTH_ONLY"}
+    b._robot = robot
+    result = b.execute("perceive.rgb", {}, dry_run=False, estop=None)
+    assert result.status == "error"
+    assert result.error["reason"] == "no_camera"
+
+
+def test_perceive_depth_pulls_from_observation() -> None:
+    b = LerobotBackend()
+    robot = MagicMock()
+    robot.capture_observation.return_value = {
+        "observation.depth.front": b"DEPTH_BYTES",
+    }
+    b._robot = robot
+    result = b.execute("perceive.depth", {}, dry_run=False, estop=None)
+    assert result.status == "ok"
+    payload = result.events[-1].data
+    assert payload["frame_bytes"] == b"DEPTH_BYTES"
+
+
+def test_perceive_depth_returns_no_depth_when_camera_absent() -> None:
+    b = LerobotBackend()
+    robot = MagicMock()
+    robot.capture_observation.return_value = {
+        "observation.images.front": b"COLOR_ONLY",
+    }
+    b._robot = robot
+    result = b.execute("perceive.depth", {}, dry_run=False, estop=None)
+    assert result.status == "error"
+    assert result.error["reason"] == "no_depth_camera"

--- a/cli/tests/backends/test_lerobot_teleop.py
+++ b/cli/tests/backends/test_lerobot_teleop.py
@@ -1,0 +1,48 @@
+from __future__ import annotations
+
+from unittest.mock import MagicMock
+
+from robot_md.backends.lerobot import LerobotBackend
+
+
+def test_teleop_loop_streams_leader_to_follower() -> None:
+    b = LerobotBackend()
+    robot = MagicMock()
+    leader_states = [
+        {"joints": [0.1, 0.0, 0.0, 0.0, 0.0, 0.0]},
+        {"joints": [0.2, 0.0, 0.0, 0.0, 0.0, 0.0]},
+        None,  # sentinel — leader disconnected
+    ]
+    robot.read_leader_state.side_effect = leader_states
+    b._robot = robot
+    result = b.execute("lerobot.teleop", {"max_steps": 10}, dry_run=False, estop=None)
+    assert result.status == "ok"
+    assert robot.send_action.call_count == 2  # stops at None sentinel before max_steps
+
+
+def test_teleop_respects_max_steps() -> None:
+    b = LerobotBackend()
+    robot = MagicMock()
+    # Always returns a state — never the None sentinel.
+    robot.read_leader_state.return_value = {"joints": [0.1, 0.0, 0.0, 0.0, 0.0, 0.0]}
+    b._robot = robot
+    result = b.execute("lerobot.teleop", {"max_steps": 3}, dry_run=False, estop=None)
+    assert result.status == "ok"
+    assert robot.send_action.call_count == 3
+
+
+def test_teleop_dry_run_does_not_call_robot() -> None:
+    b = LerobotBackend()
+    b._robot = MagicMock()
+    result = b.execute("lerobot.teleop", {"max_steps": 5}, dry_run=True, estop=None)
+    assert result.status == "ok"
+    b._robot.send_action.assert_not_called()
+    b._robot.read_leader_state.assert_not_called()
+
+
+def test_teleop_default_max_steps_when_arg_missing() -> None:
+    b = LerobotBackend()
+    b._robot = MagicMock()
+    # Default should still be safe (finite); just verify a dry_run completes.
+    result = b.execute("lerobot.teleop", {}, dry_run=True, estop=None)
+    assert result.status == "ok"


### PR DESCRIPTION
## Summary

SP3 Phase C: ships `LerobotBackend` — the motion + camera adapter that wraps HuggingFace LeRobot. Mirrors the Phase B pattern (RealSense reference adapter), now with a full motion + perception + vendor capability suite.

- 9 tasks, one commit each (16: skeleton; 17: build_lerobot_config; 18: open(); 19-23: handlers; 24: contract tests).
- 8 capabilities live: `arm.pick`, `arm.place`, `arm.home`, `gripper.open`, `gripper.close`, `perceive.rgb`, `perceive.depth`, plus the `lerobot.teleop` vendor capability.
- 37 new tests; full backends suite 87/87 passing locally.
- No production code changes in Task 24 — the contract tests pass against the implementation built across Tasks 16-23, proving the dispatch + dry-run + schema-compliance contracts hold.
- Plan note: the plan's pseudocode imagined a `Driver(motors=[...])` shape that doesn't exist in the real `RobotSpec`. The adapter merges `DriverEntry` (port, baud_rate, model) with `physics.kinematics` (per-joint servo_id) to build LeRobot's per-motor config — the natural translation.

## Test plan
- [x] All 37 lerobot tests pass locally (`PYTHONPATH=src python -m pytest tests/backends/test_lerobot_*.py`)
- [x] Phase A + Phase B intact: 87/87 in `tests/backends/`
- [x] `ruff check src tests` + `ruff format --check src tests` clean
- [ ] CI matrix green across Python 3.10/3.11/3.12/3.13

🤖 Generated with [Claude Code](https://claude.com/claude-code)