### PR TITLE
SP3 Phase D — wire backend extras + entry-points + preset preference

### DIFF
--- a/cli/pyproject.toml
+++ b/cli/pyproject.toml
@@ -108,6 +108,8 @@ Spec = "https://robotmd.dev/spec/v1"
 
 [project.entry-points."robot_md.backends"]
 feetech_depthai = "robot_md.backends.feetech_depthai:FeetechDepthaiBackend"
+lerobot         = "robot_md.backends.lerobot:LerobotBackend"
+realsense       = "robot_md.backends.realsense:RealsenseBackend"
 
 [tool.hatch.build.targets.wheel]
 packages = ["src/robot_md"]

--- a/cli/pyproject.toml
+++ b/cli/pyproject.toml
@@ -64,10 +64,12 @@ feetech-depthai = [
     "numpy>=1.24",
     "feetech-servo-sdk>=1.0",
 ]
-# Meta-extra: pulls everything an operator needs for common hardware
-# (SO-ARM101 + OAK-D today; SP3 will extend with lerobot + realsense).
+# Meta-extra: pulls everything an operator needs for the curated baseline
+# hardware set (SO-ARM101 + OAK-D + Feetech bus + RealSense + LeRobot).
 # Operators run `pip install 'robot-md[hardware]'` for the recommended
 # all-in-one install.
+#
+# Pin set per simplification-revisions Rev 3.
 #
 # NOTE (SP6 spatial-eval): the execute track of `spatial_eval_*` MCP tools
 # needs `opencv-python` for color segmentation + frame differencing in
@@ -76,11 +78,22 @@ feetech-depthai = [
 # a separate `[spatial-eval]` extra. Probe-only operation needs only core
 # dependencies (anthropic + numpy are already declared at top level).
 hardware = [
-    "pyserial>=3.5",
+    "lerobot>=0.5,<0.8",
+    "pyrealsense2>=2.55",
     "depthai>=2.24",
-    "opencv-python>=4.8",
-    "numpy>=1.24",
     "feetech-servo-sdk>=1.0",
+    "pyserial>=3.5",
+    "opencv-python>=4.8",
+]
+# SP3: granular per-backend extras for advanced / minimal installs. Operators
+# on disk-constrained systems can pick one backend without pulling the full
+# `[hardware]` set (lerobot brings ~1.5 GB of PyTorch).
+lerobot = [
+    "lerobot>=0.5,<0.8",
+    "pyserial>=3.5",
+]
+realsense = [
+    "pyrealsense2>=2.55",
 ]
 
 [project.scripts]

--- a/cli/src/robot_md/presets/aloha2.yaml
+++ b/cli/src/robot_md/presets/aloha2.yaml
@@ -158,12 +158,14 @@ physics:
 drivers:
   - id: left_arm
     protocol: dynamixel
+    preferred_backend: lerobot       # SP3 Rev 6: preset-internal hint, NOT copied to manifest
     port: /dev/ttyUSB0
     baud_rate: 1000000
     model: XM540/XM430               # ViperX-300s mixed chain
     count: 8                         # 6 joints + 2 (shoulder + elbow dual servos)
   - id: right_arm
     protocol: dynamixel
+    preferred_backend: lerobot
     port: /dev/ttyUSB1
     baud_rate: 1000000
     model: XM540/XM430

--- a/cli/src/robot_md/presets/koch_arm.yaml
+++ b/cli/src/robot_md/presets/koch_arm.yaml
@@ -84,6 +84,7 @@ physics:
 drivers:
   - id: arm_servos
     protocol: dynamixel
+    preferred_backend: lerobot       # SP3 Rev 6: preset-internal hint, NOT copied to manifest
     port: /dev/ttyUSB0               # U2D2 default — operator overrides
     baud_rate: 1000000
     model: XL-330-M077-T

--- a/cli/src/robot_md/presets/so_arm101.yaml
+++ b/cli/src/robot_md/presets/so_arm101.yaml
@@ -122,6 +122,7 @@ physics:
 drivers:
   - id: arm_servos
     protocol: feetech
+    preferred_backend: lerobot   # SP3 Rev 6: preset-internal hint, NOT copied to manifest
     port: /dev/ttyACM0           # autodetect overrides if different
     baud_rate: 1000000
     model: STS3215

--- a/cli/src/robot_md/presets/so_arm101_leader.yaml
+++ b/cli/src/robot_md/presets/so_arm101_leader.yaml
@@ -32,6 +32,7 @@ physics:
 drivers:
   - id: arm_servos
     protocol: feetech
+    preferred_backend: lerobot   # SP3 Rev 6: preset-internal hint, NOT copied to manifest
     port: /dev/ttyACM0
     baud_rate: 1000000
     model: STS3215

--- a/cli/tests/backends/test_entry_points_register_sp3_backends.py
+++ b/cli/tests/backends/test_entry_points_register_sp3_backends.py
@@ -1,0 +1,11 @@
+from __future__ import annotations
+
+from importlib.metadata import entry_points
+
+
+def test_lerobot_and_realsense_entry_points_registered() -> None:
+    eps = entry_points(group="robot_md.backends")
+    names = {ep.name for ep in eps}
+    assert "feetech_depthai" in names  # baseline
+    assert "lerobot" in names
+    assert "realsense" in names

--- a/cli/tests/backends/test_presets_preferred_backend_lerobot.py
+++ b/cli/tests/backends/test_presets_preferred_backend_lerobot.py
@@ -1,0 +1,28 @@
+from __future__ import annotations
+
+from pathlib import Path
+
+import yaml
+
+_PRESETS_DIR = Path(__file__).parents[2] / "src" / "robot_md" / "presets"
+
+
+def _load(preset: str) -> dict:
+    return yaml.safe_load((_PRESETS_DIR / preset).read_text())
+
+
+def _arm_driver_of(data: dict) -> dict:
+    for drv in data.get("drivers", []):
+        if drv.get("protocol") in {"feetech", "dynamixel"}:
+            return drv
+    raise AssertionError(f"no arm driver in preset: {data}")
+
+
+def test_so_arm_presets_prefer_lerobot() -> None:
+    for preset in ("so_arm101.yaml", "so_arm101_leader.yaml", "koch_arm.yaml", "aloha2.yaml"):
+        data = _load(preset)
+        arm = _arm_driver_of(data)
+        assert arm.get("preferred_backend") == "lerobot", (
+            f"{preset} arm driver missing or wrong preferred_backend "
+            f"(got {arm.get('preferred_backend')!r})"
+        )


### PR DESCRIPTION
## Summary
- **Task 25**: extend `[hardware]` extra with `lerobot>=0.5,<0.8` + `pyrealsense2>=2.55`; add granular `[lerobot]` and `[realsense]` extras for advanced/minimal installs (per simplification-revisions Rev 3).
- **Task 26**: register `lerobot` + `realsense` backends via `[project.entry-points."robot_md.backends"]` so they're discoverable through `importlib.metadata`. `robot-md describe-capabilities` now surfaces all three backends end-to-end.
- **Task 27**: declare `preferred_backend: lerobot` in the four arm presets (`so_arm101`, `so_arm101_leader`, `koch_arm`, `aloha2`). Field is preset-internal (Rev 6) — NOT copied to the operator-visible manifest.

Closes Phase D of the SP3 SDK adapter plan. Phases A+B+C already shipped in v1.3.0; this wiring is what makes the LeRobot/RealSense backends runtime-discoverable rather than import-only.

## Test plan
- [x] `tests/backends/test_entry_points_register_sp3_backends.py` — asserts `lerobot` + `realsense` in `entry_points(group="robot_md.backends")`.
- [x] `tests/backends/test_presets_preferred_backend_lerobot.py` — asserts the four arm presets declare `preferred_backend: lerobot`.
- [x] Manual smoke: `python -m robot_md describe-capabilities` lists `feetech_depthai`, `lerobot`, `realsense` with their full capability sets.
- [x] 149 tests across `tests/backends`, `tests/test_init.py`, `tests/test_compliance_status.py` pass — no regression in preset loaders or manifest writers.

🤖 Generated with [Claude Code](https://claude.com/claude-code)