### PR TITLE
SP6 Phase 1.5 — RRF §27 counter-sign client

### DIFF
--- a/cli/src/robot_md/__main__.py
+++ b/cli/src/robot_md/__main__.py
@@ -2046,9 +2046,11 @@ def dashboard_serve(
 
 from robot_md.hotplug.cli import app as hotplug_daemon_app  # noqa: E402
 from robot_md.hotplug.cli import operator_app as hotplug_operator_app  # noqa: E402
+from robot_md.spatial_eval.cli import app as spatial_eval_app  # noqa: E402
 
 app.add_typer(hotplug_daemon_app, name="hotplug-daemon")
 app.add_typer(hotplug_operator_app, name="hotplug")
+app.add_typer(spatial_eval_app, name="spatial-eval")
 
 
 if __name__ == "__main__":

--- a/cli/src/robot_md/mcp/resource_subscribers.py
+++ b/cli/src/robot_md/mcp/resource_subscribers.py
@@ -63,10 +63,8 @@ class SessionRegistry:
         bucket = self._subs.get(uri)
         if not bucket:
             return
-        try:
+        with contextlib.suppress(ValueError):
             bucket.remove(session)
-        except ValueError:
-            pass
 
     async def emit(self, uri: str) -> None:
         from pydantic import AnyUrl

--- a/cli/src/robot_md/mcp/tools/spatial_eval/submit_to_rrf.py
+++ b/cli/src/robot_md/mcp/tools/spatial_eval/submit_to_rrf.py
@@ -1,14 +1,40 @@
-"""MCP tool: spatial_eval_submit_to_rrf — Phase 1 stub passthrough."""
+"""MCP tool: spatial_eval_submit_to_rrf — Phase 1.5 RRF §27 submission.
+
+Reads a self-attested Score JSON from `<run_dir>/Score.json`, submits it
+to RRF /v1/spatial-eval/runs, returns the parsed response. The signed
+score must already exist on disk (produced by `spatial_eval_run_full`
+or equivalent); this tool is the upload step, not the sign step.
+"""
 
 from __future__ import annotations
 
-from robot_md.spatial_eval.rrf import submit_evidence
+from pathlib import Path
+
+from robot_md.spatial_eval.rrf import RrfSubmitError, submit_score
+from robot_md.spatial_eval.score import ScoreJSON
 
 
 def submit_to_rrf_tool(ctx, *, run_dir: str) -> dict:
-    # Phase 0: stub passthrough. The Phase 1 plan adds packet path
-    # validation, signature load, and the actual RRF §27 HTTP submission.
-    # Wrap with `ok` envelope key so the response shape matches the rest of
-    # the spatial_eval MCP tool surface.
-    result = submit_evidence(packet_path=run_dir, rcan_signature="")
+    score_path = Path(run_dir) / "Score.json"
+    if not score_path.exists():
+        return {
+            "ok": False,
+            "error": f"Score.json not found at {score_path}",
+        }
+
+    score = ScoreJSON.from_json(score_path.read_text())
+    if score.rcan_signature is None:
+        return {
+            "ok": False,
+            "error": (
+                f"{score_path} has no rcan_signature — sign the run "
+                f"first via spatial_eval_run_execute or spatial_eval_run_full"
+            ),
+        }
+
+    try:
+        result = submit_score(score)
+    except RrfSubmitError as e:
+        return {"ok": False, "error": str(e)}
+
     return {"ok": True, **result}

--- a/cli/src/robot_md/mcp/tools/spatial_eval/verify.py
+++ b/cli/src/robot_md/mcp/tools/spatial_eval/verify.py
@@ -55,6 +55,7 @@ def verify_tool(
     *,
     score_json: str,
     _verify_signature: Callable[[bytes, str], bool] | None = None,
+    _verify_rrf_signature: Callable[[bytes, str], bool] | None = None,
 ) -> dict:
     score = ScoreJSON.from_json(score_json)
     if score.rcan_signature is None:
@@ -76,4 +77,20 @@ def verify_tool(
     if not _verify_signature(payload, score.rcan_signature):
         return {"ok": False, "error": "invalid signature"}
 
-    return {"ok": True, "attestation": "self-attested"}
+    if score.rrf_signature is None:
+        return {"ok": True, "attestation": "self-attested"}
+
+    if _verify_rrf_signature is None:
+        return {
+            "ok": True,
+            "attestation": "self-attested",
+            "warning": (
+                "rrf_signature present but RRF public key is not yet available "
+                "locally; counter-signature was not verified"
+            ),
+        }
+
+    if not _verify_rrf_signature(payload, score.rrf_signature):
+        return {"ok": False, "error": "invalid rrf_signature"}
+
+    return {"ok": True, "attestation": "registry-attested"}

--- a/cli/src/robot_md/spatial_eval/cli.py
+++ b/cli/src/robot_md/spatial_eval/cli.py
@@ -1,0 +1,69 @@
+"""Typer subcommands for spatial-eval CLI surface.
+
+Registered as `robot-md spatial-eval ...`. Phase 1.5 ships
+`submit-to-rrf`; future Phase work will add `verify`, `dry-run`, etc.
+"""
+
+from __future__ import annotations
+
+import json
+from pathlib import Path
+
+import typer
+
+app = typer.Typer(help="Spatial intelligence eval (SP6) commands")
+
+
+@app.command("submit-to-rrf")
+def submit_to_rrf(
+    score_path: Path = typer.Argument(
+        ...,
+        help="Path to a self-attested Score.json produced by spatial-eval-run-*.",
+        exists=True,
+        readable=True,
+    ),
+    endpoint: str | None = typer.Option(
+        None,
+        "--endpoint",
+        help="RRF base URL. Defaults to https://robotregistryfoundation.org.",
+    ),
+    api_key: str | None = typer.Option(
+        None,
+        "--api-key",
+        help="Override apikey from ~/.robot-md/keys/<rrn>.apikey.",
+    ),
+) -> None:
+    """Submit a self-attested Score JSON to RRF §27 for counter-signature.
+
+    Score must already be signed (rcan_signature populated). On success,
+    prints the submission_id (async path) or the counter-signed score
+    (sync path) to stdout. Audit-records every attempt under the
+    submitting robot's RRN.
+    """
+    from robot_md.spatial_eval.rrf import (
+        DEFAULT_RRF_ENDPOINT,
+        RrfSubmitError,
+        submit_score,
+    )
+    from robot_md.spatial_eval.score import ScoreJSON
+
+    score = ScoreJSON.from_json(score_path.read_text())
+    if score.rcan_signature is None:
+        typer.secho(
+            f"error: {score_path} has no rcan_signature — sign the run first.",
+            err=True,
+            fg=typer.colors.RED,
+        )
+        raise typer.Exit(code=2)
+
+    try:
+        result = submit_score(
+            score,
+            endpoint=endpoint or DEFAULT_RRF_ENDPOINT,
+            api_key=api_key,
+        )
+    except RrfSubmitError as e:
+        typer.secho(f"submit failed: {e}", err=True, fg=typer.colors.RED)
+        raise typer.Exit(code=3) from e
+
+    typer.echo(json.dumps(result, indent=2))

--- a/cli/src/robot_md/spatial_eval/rrf.py
+++ b/cli/src/robot_md/spatial_eval/rrf.py
@@ -1,15 +1,205 @@
+"""SP6 Phase 1.5 — RRF §27 client for spatial-eval Score JSON submission.
+
+Parallel urllib helper alongside `robot_md.submit`; the §27 path scheme
+is run-id keyed (`/v1/spatial-eval/runs`) rather than robot-keyed
+(`/v2/robots/{rrn}/...`), so KIND_REGISTRY in submit.py generalizes
+poorly to it. Audit logging via `robot_md.audit.record_event` is
+preserved identically.
+
+Wire-format contract is locked in
+docs/superpowers/specs/2026-04-26-sp6-spatial-intelligence-eval-design.md
+"§27 wire format" subsection. RRF backend implementation must mirror.
+"""
+
 from __future__ import annotations
 
+import json
+import urllib.error
+import urllib.request
+from typing import Any
 
-def submit_evidence(*, packet_path: str, rcan_signature: str) -> dict:
-    """Phase 1 stub. Real submission is wired when RRF §27 endpoints land."""
-    return {
-        "status": "pending_phase_1",
-        "message": (
-            "Self-attested evidence is ready. RRF §27 endpoints (counter-signature, "
-            "held-out probe re-run, leaderboard) will accept this packet once Phase 1 "
-            "ships in a separate plan. Local Score.json is fully usable in the meantime."
-        ),
-        "packet_path": packet_path,
-        "rcan_signature": rcan_signature,
-    }
+from robot_md import __version__
+from robot_md.audit import record_event
+from robot_md.register import load_apikey
+from robot_md.spatial_eval.score import ScoreJSON
+
+DEFAULT_RRF_ENDPOINT = "https://robotregistryfoundation.org"
+RUNS_PATH = "/v1/spatial-eval/runs"
+RUN_DETAIL_PATH = "/v1/spatial-eval/runs/{submission_id}"
+
+
+class RrfSubmitError(RuntimeError):
+    """Raised on missing apikey, network failure, or non-2xx HTTP response."""
+
+
+def submit_score(
+    score: ScoreJSON,
+    *,
+    endpoint: str = DEFAULT_RRF_ENDPOINT,
+    api_key: str | None = None,
+    timeout: float = 15.0,
+) -> dict[str, Any]:
+    """POST a self-attested ScoreJSON to /v1/spatial-eval/runs.
+
+    Returns the parsed response body (containing `submission_id` +
+    `status`, plus a counter-signed `score` on the sync 200 path). Raises
+    RrfSubmitError on missing apikey, network failure, or non-2xx HTTP.
+    Records an audit entry on every outcome for the robot's RRN.
+    """
+    rrn = score.rrn
+
+    if api_key is None:
+        api_key = load_apikey(rrn)
+    if not api_key:
+        raise RrfSubmitError(
+            f"no apikey for {rrn} in ~/.robot-md/keys/. "
+            f"Run `robot-md register` to mint one."
+        )
+
+    url = endpoint.rstrip("/") + RUNS_PATH
+    body = {"score": score.to_dict()}
+    payload = json.dumps(body).encode("utf-8")
+    req = urllib.request.Request(
+        url,
+        method="POST",
+        headers={
+            "Content-Type": "application/json",
+            "Accept": "application/json",
+            "User-Agent": f"robot-md/{__version__}",
+            "Authorization": f"Bearer {api_key}",
+        },
+        data=payload,
+    )
+
+    try:
+        with urllib.request.urlopen(req, timeout=timeout) as resp:
+            status = resp.status
+            body_bytes = resp.read()
+    except urllib.error.HTTPError as e:
+        body_bytes = e.read() if hasattr(e, "read") else b""
+        record_event(
+            rrn,
+            event="submission",
+            details={
+                "kind": "spatial-eval-run",
+                "endpoint": url,
+                "status": e.code,
+                "outcome": "failed",
+                "error": body_bytes.decode("utf-8", errors="replace")[:500],
+            },
+        )
+        raise RrfSubmitError(f"RRF {url} returned {e.code}: {body_bytes[:200]!r}") from e
+    except urllib.error.URLError as e:
+        record_event(
+            rrn,
+            event="submission",
+            details={
+                "kind": "spatial-eval-run",
+                "endpoint": url,
+                "outcome": "network_error",
+                "error": str(e.reason),
+            },
+        )
+        raise RrfSubmitError(f"could not reach {url}: {e.reason}") from e
+
+    try:
+        parsed = json.loads(body_bytes) if body_bytes else {}
+    except json.JSONDecodeError:
+        parsed = {"_raw": body_bytes.decode("utf-8", errors="replace")[:500]}
+
+    record_event(
+        rrn,
+        event="submission",
+        details={
+            "kind": "spatial-eval-run",
+            "endpoint": url,
+            "status": status,
+            "outcome": "ok",
+        },
+    )
+
+    return parsed
+
+
+def poll_status(
+    submission_id: str,
+    *,
+    rrn: str,
+    endpoint: str = DEFAULT_RRF_ENDPOINT,
+    api_key: str | None = None,
+    timeout: float = 15.0,
+) -> dict[str, Any]:
+    """GET /v1/spatial-eval/runs/{submission_id}.
+
+    Returns the parsed response body. Status will be one of `pending`,
+    `counter_signed`, or `rejected`; on `counter_signed` the body
+    includes `score` with `rrf_signature` populated. Audit entry is
+    recorded under kind=`spatial-eval-poll`.
+    """
+    if api_key is None:
+        api_key = load_apikey(rrn)
+    if not api_key:
+        raise RrfSubmitError(
+            f"no apikey for {rrn} in ~/.robot-md/keys/. "
+            f"Run `robot-md register` to mint one."
+        )
+
+    url = endpoint.rstrip("/") + RUN_DETAIL_PATH.format(submission_id=submission_id)
+    req = urllib.request.Request(
+        url,
+        method="GET",
+        headers={
+            "Accept": "application/json",
+            "User-Agent": f"robot-md/{__version__}",
+            "Authorization": f"Bearer {api_key}",
+        },
+    )
+
+    try:
+        with urllib.request.urlopen(req, timeout=timeout) as resp:
+            status = resp.status
+            body_bytes = resp.read()
+    except urllib.error.HTTPError as e:
+        body_bytes = e.read() if hasattr(e, "read") else b""
+        record_event(
+            rrn,
+            event="submission",
+            details={
+                "kind": "spatial-eval-poll",
+                "endpoint": url,
+                "status": e.code,
+                "outcome": "failed",
+                "error": body_bytes.decode("utf-8", errors="replace")[:500],
+            },
+        )
+        raise RrfSubmitError(f"RRF {url} returned {e.code}: {body_bytes[:200]!r}") from e
+    except urllib.error.URLError as e:
+        record_event(
+            rrn,
+            event="submission",
+            details={
+                "kind": "spatial-eval-poll",
+                "endpoint": url,
+                "outcome": "network_error",
+                "error": str(e.reason),
+            },
+        )
+        raise RrfSubmitError(f"could not reach {url}: {e.reason}") from e
+
+    try:
+        parsed = json.loads(body_bytes) if body_bytes else {}
+    except json.JSONDecodeError:
+        parsed = {"_raw": body_bytes.decode("utf-8", errors="replace")[:500]}
+
+    record_event(
+        rrn,
+        event="submission",
+        details={
+            "kind": "spatial-eval-poll",
+            "endpoint": url,
+            "status": status,
+            "outcome": "ok",
+        },
+    )
+
+    return parsed

--- a/cli/src/robot_md/spatial_eval/rrf.py
+++ b/cli/src/robot_md/spatial_eval/rrf.py
@@ -52,8 +52,7 @@ def submit_score(
         api_key = load_apikey(rrn)
     if not api_key:
         raise RrfSubmitError(
-            f"no apikey for {rrn} in ~/.robot-md/keys/. "
-            f"Run `robot-md register` to mint one."
+            f"no apikey for {rrn} in ~/.robot-md/keys/. Run `robot-md register` to mint one."
         )
 
     url = endpoint.rstrip("/") + RUNS_PATH
@@ -140,8 +139,7 @@ def poll_status(
         api_key = load_apikey(rrn)
     if not api_key:
         raise RrfSubmitError(
-            f"no apikey for {rrn} in ~/.robot-md/keys/. "
-            f"Run `robot-md register` to mint one."
+            f"no apikey for {rrn} in ~/.robot-md/keys/. Run `robot-md register` to mint one."
         )
 
     url = endpoint.rstrip("/") + RUN_DETAIL_PATH.format(submission_id=submission_id)

--- a/cli/src/robot_md/spatial_eval/score.py
+++ b/cli/src/robot_md/spatial_eval/score.py
@@ -61,6 +61,7 @@ class ScoreJSON:
     tracks_execute: ExecuteTrack
     aggregate: Aggregate
     rcan_signature: str | None = None
+    rrf_signature: str | None = None
     evidence_root: str | None = None
 
     def to_dict(self) -> dict:
@@ -82,6 +83,7 @@ class ScoreJSON:
             },
             "aggregate": asdict(self.aggregate),
             "rcan_signature": self.rcan_signature,
+            "rrf_signature": self.rrf_signature,
             "evidence_root": self.evidence_root,
         }
 
@@ -111,5 +113,6 @@ class ScoreJSON:
             tracks_execute=_load_exec(d["tracks"]["execute"]),
             aggregate=Aggregate(**d["aggregate"]),
             rcan_signature=d.get("rcan_signature"),
+            rrf_signature=d.get("rrf_signature"),
             evidence_root=d.get("evidence_root"),
         )

--- a/cli/src/robot_md/spatial_eval/sign.py
+++ b/cli/src/robot_md/spatial_eval/sign.py
@@ -16,11 +16,16 @@ from robot_md.spatial_eval.score import ScoreJSON
 def payload_bytes(score: ScoreJSON) -> bytes:
     """Canonical bytes for ML-DSA signing/verification.
 
-    Score JSON with `rcan_signature` cleared so the signature isn't over
-    itself. Same canonicalization on the verify side.
+    Both `rcan_signature` and `rrf_signature` are cleared. The robot's
+    self-attestation is computed first (rrf_signature is None at that
+    time), and RRF's counter-signature is computed against the same
+    canonical bytes (so RRF endorses exactly what the robot signed). At
+    verify time both are cleared so a registry-attested score still
+    self-verifies.
     """
     d = score.to_dict()
     d["rcan_signature"] = None
+    d["rrf_signature"] = None
     return json.dumps(d, sort_keys=True, separators=(",", ":")).encode("utf-8")
 
 

--- a/cli/tests/spatial_eval/test_cli_submit_to_rrf.py
+++ b/cli/tests/spatial_eval/test_cli_submit_to_rrf.py
@@ -1,0 +1,115 @@
+"""SP6 Phase 1.5 — `robot-md spatial-eval submit-to-rrf <score.json>` CLI.
+
+Uses Typer's CliRunner against the spatial_eval sub-app. Mocks
+urllib.request.urlopen the same way as test_rrf_submit_score.py.
+"""
+
+from __future__ import annotations
+
+import io
+import json
+from pathlib import Path
+from unittest.mock import patch
+
+import pytest
+from typer.testing import CliRunner
+
+from robot_md.__main__ import app
+from robot_md.spatial_eval.score import (
+    Aggregate,
+    PerUnitExecuteScore,
+    PerUnitProbeScore,
+    ProbeTrack,
+    ScoreJSON,
+)
+
+
+@pytest.fixture
+def home(tmp_path: Path, monkeypatch) -> Path:
+    monkeypatch.setenv("HOME", str(tmp_path))
+    apikey = tmp_path / ".robot-md" / "keys" / "RRN-000000000002.apikey"
+    apikey.parent.mkdir(parents=True, exist_ok=True)
+    apikey.write_text("bob-apikey")
+    return tmp_path
+
+
+def _signed_score_path(dest_dir: Path) -> Path:
+    s = ScoreJSON(
+        spec_version="1.0.0",
+        rrn="RRN-000000000002",
+        run_id="run-1",
+        timestamp="2026-04-30T18:00:00Z",
+        tracks_probe=ProbeTrack(
+            baseline_claude={"O1": PerUnitProbeScore(score=0.87, n=30, passed=26)},
+            robot_declared={"O1": PerUnitProbeScore(score=0.84, n=30, passed=25)},
+            delta_per_unit={"O1": -0.03},
+        ),
+        tracks_execute={"O1": PerUnitExecuteScore(passed=7, n=10, evidence_sha256="abc")},
+        aggregate=Aggregate(probe_baseline=0.87, probe_declared=0.84, execute=0.7),
+        rcan_signature="rcan-sig",
+        evidence_root="sha256:e1",
+    )
+    p = dest_dir / "Score.json"
+    p.write_text(s.to_json())
+    return p
+
+
+def _mock_response(status: int, body: dict) -> object:
+    class _Resp:
+        def __init__(self):
+            self.status = status
+            self._fp = io.BytesIO(json.dumps(body).encode())
+
+        def read(self):
+            return self._fp.read()
+
+        def __enter__(self):
+            return self
+
+        def __exit__(self, *_a):
+            return False
+
+    return _Resp()
+
+
+def test_submit_to_rrf_cli_happy_path(home, tmp_path):
+    score_path = _signed_score_path(tmp_path)
+
+    def fake_urlopen(req, timeout=None):
+        return _mock_response(202, {"submission_id": "sub_x", "status": "pending"})
+
+    runner = CliRunner()
+    with patch("urllib.request.urlopen", side_effect=fake_urlopen):
+        result = runner.invoke(app, ["spatial-eval", "submit-to-rrf", str(score_path)])
+
+    assert result.exit_code == 0, result.output
+    out = json.loads(result.stdout)
+    assert out["submission_id"] == "sub_x"
+    assert out["status"] == "pending"
+
+
+def test_submit_to_rrf_cli_unsigned_score_exits_2(home, tmp_path):
+    s = ScoreJSON(
+        spec_version="1.0.0",
+        rrn="RRN-000000000002",
+        run_id="run-1",
+        timestamp="t",
+        tracks_probe=ProbeTrack(baseline_claude={}, robot_declared={}, delta_per_unit={}),
+        tracks_execute={},
+        aggregate=Aggregate(0.0, 0.0, 0.0),
+        rcan_signature=None,
+    )
+    p = tmp_path / "Score.json"
+    p.write_text(s.to_json())
+
+    runner = CliRunner()
+    result = runner.invoke(app, ["spatial-eval", "submit-to-rrf", str(p)])
+    assert result.exit_code == 2
+    assert "no rcan_signature" in result.output
+
+
+def test_submit_to_rrf_cli_missing_file_exits_with_typer_error(home, tmp_path):
+    runner = CliRunner()
+    result = runner.invoke(app, ["spatial-eval", "submit-to-rrf", str(tmp_path / "nope.json")])
+    # Typer's exists=True triggers a usage error (exit code 2).
+    assert result.exit_code != 0

--- a/cli/tests/spatial_eval/test_mcp_submit.py
+++ b/cli/tests/spatial_eval/test_mcp_submit.py
@@ -85,9 +85,7 @@ def test_submit_to_rrf_unsigned_score_returns_error(tmp_path):
         rrn="RRN-000000000002",
         run_id="run-1",
         timestamp="2026-04-30T18:00:00Z",
-        tracks_probe=ProbeTrack(
-            baseline_claude={}, robot_declared={}, delta_per_unit={}
-        ),
+        tracks_probe=ProbeTrack(baseline_claude={}, robot_declared={}, delta_per_unit={}),
         tracks_execute={},
         aggregate=Aggregate(probe_baseline=0.0, probe_declared=0.0, execute=0.0),
         rcan_signature=None,

--- a/cli/tests/spatial_eval/test_mcp_submit.py
+++ b/cli/tests/spatial_eval/test_mcp_submit.py
@@ -1,11 +1,114 @@
+"""SP6 — MCP tool wrapper for spatial_eval_submit_to_rrf.
+
+Thin wrapper over `robot_md.spatial_eval.rrf.submit_score`: reads
+Score.json from run_dir, surfaces missing-file and missing-signature
+errors as `{"ok": False, "error": ...}`, otherwise returns the §27
+response wrapped with `ok=True`.
+"""
+
 from __future__ import annotations
 
-from unittest.mock import MagicMock
+import io
+import json
+from pathlib import Path
+from unittest.mock import MagicMock, patch
+
+import pytest
 
 from robot_md.mcp.tools.spatial_eval.submit_to_rrf import submit_to_rrf_tool
+from robot_md.spatial_eval.score import (
+    Aggregate,
+    PerUnitExecuteScore,
+    PerUnitProbeScore,
+    ProbeTrack,
+    ScoreJSON,
+)
 
 
-def test_submit_returns_pending_phase_1():
-    out = submit_to_rrf_tool(MagicMock(), run_dir="/tmp/run-x")
+@pytest.fixture
+def home(tmp_path: Path, monkeypatch) -> Path:
+    monkeypatch.setenv("HOME", str(tmp_path))
+    apikey_path = tmp_path / ".robot-md" / "keys" / "RRN-000000000002.apikey"
+    apikey_path.parent.mkdir(parents=True, exist_ok=True)
+    apikey_path.write_text("bob-apikey")
+    return tmp_path
+
+
+def _signed_score_on_disk(run_dir: Path) -> Path:
+    score = ScoreJSON(
+        spec_version="1.0.0",
+        rrn="RRN-000000000002",
+        run_id="run-1",
+        timestamp="2026-04-30T18:00:00Z",
+        tracks_probe=ProbeTrack(
+            baseline_claude={"O1": PerUnitProbeScore(score=0.87, n=30, passed=26)},
+            robot_declared={"O1": PerUnitProbeScore(score=0.84, n=30, passed=25)},
+            delta_per_unit={"O1": -0.03},
+        ),
+        tracks_execute={"O1": PerUnitExecuteScore(passed=7, n=10, evidence_sha256="abc")},
+        aggregate=Aggregate(probe_baseline=0.87, probe_declared=0.84, execute=0.7),
+        rcan_signature="rcan-sig",
+        evidence_root="sha256:e1",
+    )
+    score_path = run_dir / "Score.json"
+    score_path.write_text(score.to_json())
+    return score_path
+
+
+def _mock_response(status: int, body: dict) -> object:
+    class _Resp:
+        def __init__(self):
+            self.status = status
+            self._fp = io.BytesIO(json.dumps(body).encode())
+
+        def read(self):
+            return self._fp.read()
+
+        def __enter__(self):
+            return self
+
+        def __exit__(self, *_a):
+            return False
+
+    return _Resp()
+
+
+def test_submit_to_rrf_missing_score_json_returns_error(tmp_path):
+    out = submit_to_rrf_tool(MagicMock(), run_dir=str(tmp_path))
+    assert out["ok"] is False
+    assert "Score.json not found" in out["error"]
+
+
+def test_submit_to_rrf_unsigned_score_returns_error(tmp_path):
+    score = ScoreJSON(
+        spec_version="1.0.0",
+        rrn="RRN-000000000002",
+        run_id="run-1",
+        timestamp="2026-04-30T18:00:00Z",
+        tracks_probe=ProbeTrack(
+            baseline_claude={}, robot_declared={}, delta_per_unit={}
+        ),
+        tracks_execute={},
+        aggregate=Aggregate(probe_baseline=0.0, probe_declared=0.0, execute=0.0),
+        rcan_signature=None,
+    )
+    (tmp_path / "Score.json").write_text(score.to_json())
+    out = submit_to_rrf_tool(MagicMock(), run_dir=str(tmp_path))
+    assert out["ok"] is False
+    assert "rcan_signature" in out["error"]
+
+
+def test_submit_to_rrf_happy_path_returns_pending(home, tmp_path):
+    run_dir = tmp_path / "run-x"
+    run_dir.mkdir()
+    _signed_score_on_disk(run_dir)
+
+    def fake_urlopen(req, timeout=None):
+        return _mock_response(202, {"submission_id": "sub_x", "status": "pending"})
+
+    with patch("urllib.request.urlopen", side_effect=fake_urlopen):
+        out = submit_to_rrf_tool(MagicMock(), run_dir=str(run_dir))
+
     assert out["ok"] is True
-    assert out["status"] == "pending_phase_1"
+    assert out["status"] == "pending"
+    assert out["submission_id"] == "sub_x"

--- a/cli/tests/spatial_eval/test_mcp_verify_registry_attested.py
+++ b/cli/tests/spatial_eval/test_mcp_verify_registry_attested.py
@@ -1,0 +1,97 @@
+"""SP6 Phase 1.5 — verify_tool extended with rrf_signature recognition.
+
+When both signatures are present and both verify, the tool returns
+`attestation: registry-attested`. When the rrf_signature is present
+but no RRF-pubkey verifier is wired, the tool returns self-attested
+with a warning (Phase 1.5 production reality: RRF spec endpoint
+serving the pubkey doesn't exist yet).
+"""
+
+from __future__ import annotations
+
+from unittest.mock import MagicMock
+
+from robot_md.mcp.tools.spatial_eval.verify import verify_tool
+from robot_md.spatial_eval.score import (
+    Aggregate,
+    PerUnitExecuteScore,
+    ProbeTrack,
+    ScoreJSON,
+)
+
+
+def _score_with(rcan: str | None, rrf: str | None) -> str:
+    s = ScoreJSON(
+        spec_version="1.0.0",
+        rrn="RRN-x",
+        run_id="r-1",
+        timestamp="t",
+        tracks_probe=ProbeTrack(baseline_claude={}, robot_declared={}, delta_per_unit={}),
+        tracks_execute={"O1": PerUnitExecuteScore(7, 10, "abc")},
+        aggregate=Aggregate(0, 0, 0.7),
+        rcan_signature=rcan,
+        rrf_signature=rrf,
+        evidence_root="sha256:abc",
+    )
+    return s.to_json()
+
+
+def test_verify_score_with_both_sigs_returns_registry_attested():
+    out = verify_tool(
+        MagicMock(),
+        score_json=_score_with("rcan-sig", "rrf-sig"),
+        _verify_signature=lambda payload, sig: True,
+        _verify_rrf_signature=lambda payload, sig: True,
+    )
+    assert out == {"ok": True, "attestation": "registry-attested"}
+
+
+def test_verify_rejects_invalid_rrf_signature():
+    out = verify_tool(
+        MagicMock(),
+        score_json=_score_with("rcan-sig", "rrf-sig"),
+        _verify_signature=lambda payload, sig: True,
+        _verify_rrf_signature=lambda payload, sig: False,
+    )
+    assert out["ok"] is False
+    assert "invalid rrf_signature" in out["error"]
+
+
+def test_verify_score_with_rrf_sig_but_no_rrf_verifier_falls_back_to_self_attested_with_warning():
+    """Phase 1.5 production path: rrf_signature is present on the score but
+    RRF's public key isn't fetchable yet (spec endpoint not built). Don't
+    claim registry-attested without verifying — return self-attested with
+    a clear warning so callers see the situation."""
+    out = verify_tool(
+        MagicMock(),
+        score_json=_score_with("rcan-sig", "rrf-sig"),
+        _verify_signature=lambda payload, sig: True,
+        # _verify_rrf_signature=None  -- omitted on purpose
+    )
+    assert out["ok"] is True
+    assert out["attestation"] == "self-attested"
+    assert "rrf_signature present" in out["warning"]
+
+
+def test_verify_score_without_rrf_sig_still_returns_self_attested():
+    """Regression: existing self-attested behavior unchanged when rrf_signature is None."""
+    out = verify_tool(
+        MagicMock(),
+        score_json=_score_with("rcan-sig", None),
+        _verify_signature=lambda payload, sig: True,
+    )
+    assert out == {"ok": True, "attestation": "self-attested"}
+
+
+def test_verify_invalid_rcan_short_circuits_before_rrf_check():
+    """An invalid rcan_signature must fail BEFORE the rrf_signature path,
+    even when an rrf-verifier would have accepted. The robot's self-sig
+    is the foundation — without it, registry endorsement is meaningless."""
+    out = verify_tool(
+        MagicMock(),
+        score_json=_score_with("rcan-sig", "rrf-sig"),
+        _verify_signature=lambda payload, sig: False,
+        _verify_rrf_signature=lambda payload, sig: True,
+    )
+    assert out["ok"] is False
+    assert out["error"] == "invalid signature"

--- a/cli/tests/spatial_eval/test_rrf_failure_paths.py
+++ b/cli/tests/spatial_eval/test_rrf_failure_paths.py
@@ -1,0 +1,156 @@
+"""SP6 Phase 1.5 — failure paths for rrf.submit_score and rrf.poll_status.
+
+Covers: missing apikey, RRF down (URLError), 4xx body, audit-trail
+preservation across every failure mode.
+"""
+
+from __future__ import annotations
+
+import io
+import json
+import urllib.error
+from pathlib import Path
+from unittest.mock import patch
+
+import pytest
+
+from robot_md.spatial_eval.score import (
+    Aggregate,
+    PerUnitExecuteScore,
+    PerUnitProbeScore,
+    ProbeTrack,
+    ScoreJSON,
+)
+
+
+@pytest.fixture
+def home_no_apikey(tmp_path: Path, monkeypatch) -> Path:
+    """HOME pointed at tmp_path without any keystore — apikey lookup fails."""
+    monkeypatch.setenv("HOME", str(tmp_path))
+    return tmp_path
+
+
+@pytest.fixture
+def home_with_apikey(tmp_path: Path, monkeypatch) -> Path:
+    monkeypatch.setenv("HOME", str(tmp_path))
+    apikey = tmp_path / ".robot-md" / "keys" / "RRN-000000000002.apikey"
+    apikey.parent.mkdir(parents=True, exist_ok=True)
+    apikey.write_text("bob-apikey")
+    return tmp_path
+
+
+def _signed_score() -> ScoreJSON:
+    return ScoreJSON(
+        spec_version="1.0.0",
+        rrn="RRN-000000000002",
+        run_id="run-1",
+        timestamp="2026-04-30T18:00:00Z",
+        tracks_probe=ProbeTrack(
+            baseline_claude={"O1": PerUnitProbeScore(score=0.87, n=30, passed=26)},
+            robot_declared={"O1": PerUnitProbeScore(score=0.84, n=30, passed=25)},
+            delta_per_unit={"O1": -0.03},
+        ),
+        tracks_execute={"O1": PerUnitExecuteScore(passed=7, n=10, evidence_sha256="abc")},
+        aggregate=Aggregate(probe_baseline=0.87, probe_declared=0.84, execute=0.7),
+        rcan_signature="rcan-sig",
+    )
+
+
+def test_submit_score_missing_apikey_raises(home_no_apikey):
+    from robot_md.spatial_eval.rrf import RrfSubmitError, submit_score
+
+    with pytest.raises(RrfSubmitError, match="no apikey"):
+        submit_score(_signed_score())
+
+
+def test_submit_score_rrf_down_raises_and_records_audit(home_with_apikey):
+    def fake_urlopen(req, timeout=None):
+        raise urllib.error.URLError("Connection refused")
+
+    from robot_md.spatial_eval.rrf import RrfSubmitError, submit_score
+
+    with patch("urllib.request.urlopen", side_effect=fake_urlopen):
+        with pytest.raises(RrfSubmitError, match="could not reach"):
+            submit_score(_signed_score())
+
+    audit_log = home_with_apikey / ".robot-md" / "audit" / "RRN-000000000002.jsonl"
+    entries = [json.loads(line) for line in audit_log.read_text().splitlines() if line]
+    assert any(
+        e["details"].get("outcome") == "network_error"
+        and e["details"].get("kind") == "spatial-eval-run"
+        for e in entries
+    )
+
+
+def test_submit_score_4xx_raises_and_records_audit(home_with_apikey):
+    def fake_urlopen(req, timeout=None):
+        raise urllib.error.HTTPError(
+            req.full_url,
+            422,
+            "Unprocessable Entity",
+            hdrs={},
+            fp=io.BytesIO(b'{"error": "rcan_signature failed verification"}'),
+        )
+
+    from robot_md.spatial_eval.rrf import RrfSubmitError, submit_score
+
+    with patch("urllib.request.urlopen", side_effect=fake_urlopen):
+        with pytest.raises(RrfSubmitError, match="returned 422"):
+            submit_score(_signed_score())
+
+    audit_log = home_with_apikey / ".robot-md" / "audit" / "RRN-000000000002.jsonl"
+    entries = [json.loads(line) for line in audit_log.read_text().splitlines() if line]
+    assert any(
+        e["details"].get("outcome") == "failed" and e["details"].get("status") == 422
+        for e in entries
+    )
+
+
+def test_poll_status_missing_apikey_raises(home_no_apikey):
+    from robot_md.spatial_eval.rrf import RrfSubmitError, poll_status
+
+    with pytest.raises(RrfSubmitError, match="no apikey"):
+        poll_status("sub_x", rrn="RRN-000000000002")
+
+
+def test_poll_status_404_raises_and_records_audit(home_with_apikey):
+    def fake_urlopen(req, timeout=None):
+        raise urllib.error.HTTPError(
+            req.full_url,
+            404,
+            "Not Found",
+            hdrs={},
+            fp=io.BytesIO(b'{"error": "submission_id unknown"}'),
+        )
+
+    from robot_md.spatial_eval.rrf import RrfSubmitError, poll_status
+
+    with patch("urllib.request.urlopen", side_effect=fake_urlopen):
+        with pytest.raises(RrfSubmitError, match="returned 404"):
+            poll_status("sub_x", rrn="RRN-000000000002")
+
+    audit_log = home_with_apikey / ".robot-md" / "audit" / "RRN-000000000002.jsonl"
+    entries = [json.loads(line) for line in audit_log.read_text().splitlines() if line]
+    assert any(
+        e["details"].get("outcome") == "failed" and e["details"].get("status") == 404
+        for e in entries
+    )
+
+
+def test_poll_status_rrf_down_raises_and_records_audit(home_with_apikey):
+    def fake_urlopen(req, timeout=None):
+        raise urllib.error.URLError("Network unreachable")
+
+    from robot_md.spatial_eval.rrf import RrfSubmitError, poll_status
+
+    with patch("urllib.request.urlopen", side_effect=fake_urlopen):
+        with pytest.raises(RrfSubmitError, match="could not reach"):
+            poll_status("sub_x", rrn="RRN-000000000002")
+
+    audit_log = home_with_apikey / ".robot-md" / "audit" / "RRN-000000000002.jsonl"
+    entries = [json.loads(line) for line in audit_log.read_text().splitlines() if line]
+    assert any(
+        e["details"].get("outcome") == "network_error"
+        and e["details"].get("kind") == "spatial-eval-poll"
+        for e in entries
+    )

--- a/cli/tests/spatial_eval/test_rrf_failure_paths.py
+++ b/cli/tests/spatial_eval/test_rrf_failure_paths.py
@@ -69,9 +69,11 @@ def test_submit_score_rrf_down_raises_and_records_audit(home_with_apikey):
 
     from robot_md.spatial_eval.rrf import RrfSubmitError, submit_score
 
-    with patch("urllib.request.urlopen", side_effect=fake_urlopen):
-        with pytest.raises(RrfSubmitError, match="could not reach"):
-            submit_score(_signed_score())
+    with (
+        patch("urllib.request.urlopen", side_effect=fake_urlopen),
+        pytest.raises(RrfSubmitError, match="could not reach"),
+    ):
+        submit_score(_signed_score())
 
     audit_log = home_with_apikey / ".robot-md" / "audit" / "RRN-000000000002.jsonl"
     entries = [json.loads(line) for line in audit_log.read_text().splitlines() if line]
@@ -94,9 +96,11 @@ def test_submit_score_4xx_raises_and_records_audit(home_with_apikey):
 
     from robot_md.spatial_eval.rrf import RrfSubmitError, submit_score
 
-    with patch("urllib.request.urlopen", side_effect=fake_urlopen):
-        with pytest.raises(RrfSubmitError, match="returned 422"):
-            submit_score(_signed_score())
+    with (
+        patch("urllib.request.urlopen", side_effect=fake_urlopen),
+        pytest.raises(RrfSubmitError, match="returned 422"),
+    ):
+        submit_score(_signed_score())
 
     audit_log = home_with_apikey / ".robot-md" / "audit" / "RRN-000000000002.jsonl"
     entries = [json.loads(line) for line in audit_log.read_text().splitlines() if line]
@@ -125,9 +129,11 @@ def test_poll_status_404_raises_and_records_audit(home_with_apikey):
 
     from robot_md.spatial_eval.rrf import RrfSubmitError, poll_status
 
-    with patch("urllib.request.urlopen", side_effect=fake_urlopen):
-        with pytest.raises(RrfSubmitError, match="returned 404"):
-            poll_status("sub_x", rrn="RRN-000000000002")
+    with (
+        patch("urllib.request.urlopen", side_effect=fake_urlopen),
+        pytest.raises(RrfSubmitError, match="returned 404"),
+    ):
+        poll_status("sub_x", rrn="RRN-000000000002")
 
     audit_log = home_with_apikey / ".robot-md" / "audit" / "RRN-000000000002.jsonl"
     entries = [json.loads(line) for line in audit_log.read_text().splitlines() if line]
@@ -143,9 +149,11 @@ def test_poll_status_rrf_down_raises_and_records_audit(home_with_apikey):
 
     from robot_md.spatial_eval.rrf import RrfSubmitError, poll_status
 
-    with patch("urllib.request.urlopen", side_effect=fake_urlopen):
-        with pytest.raises(RrfSubmitError, match="could not reach"):
-            poll_status("sub_x", rrn="RRN-000000000002")
+    with (
+        patch("urllib.request.urlopen", side_effect=fake_urlopen),
+        pytest.raises(RrfSubmitError, match="could not reach"),
+    ):
+        poll_status("sub_x", rrn="RRN-000000000002")
 
     audit_log = home_with_apikey / ".robot-md" / "audit" / "RRN-000000000002.jsonl"
     entries = [json.loads(line) for line in audit_log.read_text().splitlines() if line]

--- a/cli/tests/spatial_eval/test_rrf_poll_status.py
+++ b/cli/tests/spatial_eval/test_rrf_poll_status.py
@@ -71,9 +71,7 @@ def test_poll_status_sends_bearer_auth(home):
     with patch("urllib.request.urlopen", side_effect=fake_urlopen):
         poll_status("sub_x", rrn="RRN-000000000002")
 
-    auth = next(
-        (v for k, v in captured["headers"].items() if k.lower() == "authorization"), None
-    )
+    auth = next((v for k, v in captured["headers"].items() if k.lower() == "authorization"), None)
     assert auth == "Bearer bob-apikey"
 
 

--- a/cli/tests/spatial_eval/test_rrf_poll_status.py
+++ b/cli/tests/spatial_eval/test_rrf_poll_status.py
@@ -1,0 +1,148 @@
+"""SP6 Phase 1.5 — rrf.poll_status against urllib-mocked GET /v1/spatial-eval/runs/{id}.
+
+Same urllib mock pattern as test_rrf_submit_score.py. Polls a submission
+by id; returns one of {pending, counter_signed, rejected}.
+"""
+
+from __future__ import annotations
+
+import io
+import json
+from pathlib import Path
+from unittest.mock import patch
+
+import pytest
+
+
+@pytest.fixture
+def home(tmp_path: Path, monkeypatch) -> Path:
+    monkeypatch.setenv("HOME", str(tmp_path))
+    apikey = tmp_path / ".robot-md" / "keys" / "RRN-000000000002.apikey"
+    apikey.parent.mkdir(parents=True, exist_ok=True)
+    apikey.write_text("bob-apikey")
+    return tmp_path
+
+
+def _mock_response(status: int, body: dict | bytes = b"") -> object:
+    class _Resp:
+        def __init__(self):
+            self.status = status
+            data = body if isinstance(body, bytes) else json.dumps(body).encode()
+            self._fp = io.BytesIO(data)
+
+        def read(self):
+            return self._fp.read()
+
+        def __enter__(self):
+            return self
+
+        def __exit__(self, *_a):
+            return False
+
+    return _Resp()
+
+
+def test_poll_status_gets_runs_submission_id_path(home):
+    captured: dict = {}
+
+    def fake_urlopen(req, timeout=None):
+        captured["url"] = req.full_url
+        captured["method"] = req.get_method()
+        return _mock_response(200, {"submission_id": "sub_x", "status": "pending"})
+
+    from robot_md.spatial_eval.rrf import poll_status
+
+    with patch("urllib.request.urlopen", side_effect=fake_urlopen):
+        poll_status("sub_x", rrn="RRN-000000000002")
+
+    assert captured["url"].endswith("/v1/spatial-eval/runs/sub_x")
+    assert captured["method"] == "GET"
+
+
+def test_poll_status_sends_bearer_auth(home):
+    captured: dict = {}
+
+    def fake_urlopen(req, timeout=None):
+        captured["headers"] = dict(req.header_items())
+        return _mock_response(200, {"submission_id": "sub_x", "status": "pending"})
+
+    from robot_md.spatial_eval.rrf import poll_status
+
+    with patch("urllib.request.urlopen", side_effect=fake_urlopen):
+        poll_status("sub_x", rrn="RRN-000000000002")
+
+    auth = next(
+        (v for k, v in captured["headers"].items() if k.lower() == "authorization"), None
+    )
+    assert auth == "Bearer bob-apikey"
+
+
+def test_poll_status_returns_pending(home):
+    def fake_urlopen(req, timeout=None):
+        return _mock_response(200, {"submission_id": "sub_x", "status": "pending"})
+
+    from robot_md.spatial_eval.rrf import poll_status
+
+    with patch("urllib.request.urlopen", side_effect=fake_urlopen):
+        result = poll_status("sub_x", rrn="RRN-000000000002")
+
+    assert result["status"] == "pending"
+    assert result["submission_id"] == "sub_x"
+
+
+def test_poll_status_returns_counter_signed_with_score(home):
+    counter_signed = {
+        "submission_id": "sub_x",
+        "status": "counter_signed",
+        "score": {"rrn": "RRN-000000000002", "rrf_signature": "rrf-sig"},
+    }
+
+    def fake_urlopen(req, timeout=None):
+        return _mock_response(200, counter_signed)
+
+    from robot_md.spatial_eval.rrf import poll_status
+
+    with patch("urllib.request.urlopen", side_effect=fake_urlopen):
+        result = poll_status("sub_x", rrn="RRN-000000000002")
+
+    assert result["status"] == "counter_signed"
+    assert result["score"]["rrf_signature"] == "rrf-sig"
+
+
+def test_poll_status_returns_rejected_with_reason(home):
+    rejected = {
+        "submission_id": "sub_x",
+        "status": "rejected",
+        "rejection_reason": "rcan_signature failed verification",
+    }
+
+    def fake_urlopen(req, timeout=None):
+        return _mock_response(200, rejected)
+
+    from robot_md.spatial_eval.rrf import poll_status
+
+    with patch("urllib.request.urlopen", side_effect=fake_urlopen):
+        result = poll_status("sub_x", rrn="RRN-000000000002")
+
+    assert result["status"] == "rejected"
+    assert "rcan_signature" in result["rejection_reason"]
+
+
+def test_poll_status_records_audit_entry_on_success(home):
+    def fake_urlopen(req, timeout=None):
+        return _mock_response(200, {"submission_id": "sub_x", "status": "pending"})
+
+    from robot_md.spatial_eval.rrf import poll_status
+
+    with patch("urllib.request.urlopen", side_effect=fake_urlopen):
+        poll_status("sub_x", rrn="RRN-000000000002")
+
+    audit_log = home / ".robot-md" / "audit" / "RRN-000000000002.jsonl"
+    assert audit_log.exists()
+    entries = [json.loads(line) for line in audit_log.read_text().splitlines() if line]
+    assert any(
+        e.get("event") == "submission"
+        and e.get("details", {}).get("kind") == "spatial-eval-poll"
+        and e.get("details", {}).get("outcome") == "ok"
+        for e in entries
+    )

--- a/cli/tests/spatial_eval/test_rrf_stub.py
+++ b/cli/tests/spatial_eval/test_rrf_stub.py
@@ -1,9 +1,0 @@
-from __future__ import annotations
-
-from robot_md.spatial_eval.rrf import submit_evidence
-
-
-def test_submit_returns_pending_phase_1():
-    out = submit_evidence(packet_path="/tmp/evidence", rcan_signature="abc")
-    assert out["status"] == "pending_phase_1"
-    assert "RRF §27" in out["message"]

--- a/cli/tests/spatial_eval/test_rrf_submit_score.py
+++ b/cli/tests/spatial_eval/test_rrf_submit_score.py
@@ -1,0 +1,190 @@
+"""SP6 Phase 1.5 — rrf.submit_score happy-path tests against urllib mock.
+
+Mirrors the pattern in cli/tests/test_submit.py: patch
+`urllib.request.urlopen` with a fake that captures the Request object
+and returns a stub response. The §27 wire format is locked in
+docs/superpowers/specs/2026-04-26-sp6-spatial-intelligence-eval-design.md
+"§27 wire format" subsection.
+"""
+
+from __future__ import annotations
+
+import io
+import json
+from pathlib import Path
+from unittest.mock import patch
+
+import pytest
+
+from robot_md.spatial_eval.score import (
+    Aggregate,
+    PerUnitExecuteScore,
+    PerUnitProbeScore,
+    ProbeTrack,
+    ScoreJSON,
+)
+
+
+@pytest.fixture
+def home(tmp_path: Path, monkeypatch) -> Path:
+    monkeypatch.setenv("HOME", str(tmp_path))
+    return tmp_path
+
+
+@pytest.fixture
+def with_apikey(home: Path) -> Path:
+    apikey_path = home / ".robot-md" / "keys" / "RRN-000000000002.apikey"
+    apikey_path.parent.mkdir(parents=True, exist_ok=True)
+    apikey_path.write_text("bob-apikey-xyz")
+    return apikey_path
+
+
+def _signed_score() -> ScoreJSON:
+    return ScoreJSON(
+        spec_version="1.0.0",
+        rrn="RRN-000000000002",
+        run_id="run-123",
+        timestamp="2026-04-30T18:00:00Z",
+        tracks_probe=ProbeTrack(
+            baseline_claude={"O1": PerUnitProbeScore(score=0.87, n=30, passed=26)},
+            robot_declared={"O1": PerUnitProbeScore(score=0.84, n=30, passed=25)},
+            delta_per_unit={"O1": -0.03},
+        ),
+        tracks_execute={
+            "O1": PerUnitExecuteScore(passed=7, n=10, evidence_sha256="abc"),
+        },
+        aggregate=Aggregate(probe_baseline=0.87, probe_declared=0.84, execute=0.7),
+        rcan_signature="rcan-sig-base64",
+        evidence_root="sha256:e1",
+    )
+
+
+def _mock_response(status: int, body: dict | bytes = b"") -> object:
+    class _Resp:
+        def __init__(self):
+            self.status = status
+            data = body if isinstance(body, bytes) else json.dumps(body).encode()
+            self._fp = io.BytesIO(data)
+
+        def read(self):
+            return self._fp.read()
+
+        def __enter__(self):
+            return self
+
+        def __exit__(self, *_a):
+            return False
+
+    return _Resp()
+
+
+def test_submit_score_posts_to_v1_spatial_eval_runs(with_apikey):
+    captured: dict = {}
+
+    def fake_urlopen(req, timeout=None):
+        captured["url"] = req.full_url
+        captured["method"] = req.get_method()
+        captured["body"] = json.loads(req.data.decode())
+        return _mock_response(202, {"submission_id": "sub_x", "status": "pending"})
+
+    from robot_md.spatial_eval.rrf import submit_score
+
+    with patch("urllib.request.urlopen", side_effect=fake_urlopen):
+        submit_score(_signed_score())
+
+    assert captured["url"].endswith("/v1/spatial-eval/runs")
+    assert captured["method"] == "POST"
+
+
+def test_submit_score_wraps_score_under_score_key(with_apikey):
+    captured: dict = {}
+
+    def fake_urlopen(req, timeout=None):
+        captured["body"] = json.loads(req.data.decode())
+        return _mock_response(202, {"submission_id": "sub_x", "status": "pending"})
+
+    from robot_md.spatial_eval.rrf import submit_score
+
+    score = _signed_score()
+    with patch("urllib.request.urlopen", side_effect=fake_urlopen):
+        submit_score(score)
+
+    assert "score" in captured["body"]
+    assert captured["body"]["score"]["rrn"] == "RRN-000000000002"
+    assert captured["body"]["score"]["rcan_signature"] == "rcan-sig-base64"
+    # rrf_signature must be null on submit (RRF fills it in)
+    assert captured["body"]["score"]["rrf_signature"] is None
+
+
+def test_submit_score_sends_bearer_auth_for_score_rrn(with_apikey):
+    captured: dict = {}
+
+    def fake_urlopen(req, timeout=None):
+        captured["headers"] = dict(req.header_items())
+        return _mock_response(202, {"submission_id": "sub_x", "status": "pending"})
+
+    from robot_md.spatial_eval.rrf import submit_score
+
+    with patch("urllib.request.urlopen", side_effect=fake_urlopen):
+        submit_score(_signed_score())
+
+    auth = next(
+        (v for k, v in captured["headers"].items() if k.lower() == "authorization"), None
+    )
+    assert auth == "Bearer bob-apikey-xyz"
+
+
+def test_submit_score_returns_pending_status_async_path(with_apikey):
+    def fake_urlopen(req, timeout=None):
+        return _mock_response(202, {"submission_id": "sub_x", "status": "pending"})
+
+    from robot_md.spatial_eval.rrf import submit_score
+
+    with patch("urllib.request.urlopen", side_effect=fake_urlopen):
+        result = submit_score(_signed_score())
+
+    assert result["status"] == "pending"
+    assert result["submission_id"] == "sub_x"
+
+
+def test_submit_score_returns_counter_signed_score_sync_path(with_apikey):
+    counter_signed_score = _signed_score().to_dict()
+    counter_signed_score["rrf_signature"] = "rrf-sig-base64"
+
+    def fake_urlopen(req, timeout=None):
+        return _mock_response(
+            200,
+            {
+                "submission_id": "sub_x",
+                "status": "counter_signed",
+                "score": counter_signed_score,
+            },
+        )
+
+    from robot_md.spatial_eval.rrf import submit_score
+
+    with patch("urllib.request.urlopen", side_effect=fake_urlopen):
+        result = submit_score(_signed_score())
+
+    assert result["status"] == "counter_signed"
+    assert result["score"]["rrf_signature"] == "rrf-sig-base64"
+
+
+def test_submit_score_records_audit_entry_on_success(with_apikey, home):
+    def fake_urlopen(req, timeout=None):
+        return _mock_response(202, {"submission_id": "sub_x", "status": "pending"})
+
+    from robot_md.spatial_eval.rrf import submit_score
+
+    with patch("urllib.request.urlopen", side_effect=fake_urlopen):
+        submit_score(_signed_score())
+
+    audit_log = home / ".robot-md" / "audit" / "RRN-000000000002.jsonl"
+    assert audit_log.exists()
+    entries = [json.loads(line) for line in audit_log.read_text().splitlines() if line]
+    assert any(
+        e.get("event") == "submission"
+        and e.get("details", {}).get("kind") == "spatial-eval-run"
+        and e.get("details", {}).get("outcome") == "ok"
+        for e in entries
+    )

--- a/cli/tests/spatial_eval/test_rrf_submit_score.py
+++ b/cli/tests/spatial_eval/test_rrf_submit_score.py
@@ -128,9 +128,7 @@ def test_submit_score_sends_bearer_auth_for_score_rrn(with_apikey):
     with patch("urllib.request.urlopen", side_effect=fake_urlopen):
         submit_score(_signed_score())
 
-    auth = next(
-        (v for k, v in captured["headers"].items() if k.lower() == "authorization"), None
-    )
+    auth = next((v for k, v in captured["headers"].items() if k.lower() == "authorization"), None)
     assert auth == "Bearer bob-apikey-xyz"
 
 

--- a/cli/tests/spatial_eval/test_score.py
+++ b/cli/tests/spatial_eval/test_score.py
@@ -37,6 +37,62 @@ def test_score_json_round_trips():
     assert s2 == s
 
 
+def test_score_json_round_trips_with_both_signatures():
+    """Registry-attested score: both rcan_signature and rrf_signature
+    populated. Both must roundtrip through to_json/from_json."""
+    s = ScoreJSON(
+        spec_version="1.0.0",
+        rrn="RRN-000000000002",
+        run_id="abc",
+        timestamp="2026-04-26T14:30:00Z",
+        tracks_probe=ProbeTrack(
+            baseline_claude={"O1": PerUnitProbeScore(score=0.87, n=30, passed=26)},
+            robot_declared={"O1": PerUnitProbeScore(score=0.84, n=30, passed=25)},
+            delta_per_unit={"O1": -0.03},
+        ),
+        tracks_execute={
+            "O1": PerUnitExecuteScore(passed=7, n=10, evidence_sha256="abc..."),
+        },
+        aggregate=Aggregate(probe_baseline=0.87, probe_declared=0.84, execute=0.7),
+        rcan_signature="rcan-sig-base64",
+        rrf_signature="rrf-sig-base64",
+        evidence_root="sha256:e1",
+    )
+    blob = s.to_json()
+    parsed = json.loads(blob)
+    assert parsed["rcan_signature"] == "rcan-sig-base64"
+    assert parsed["rrf_signature"] == "rrf-sig-base64"
+    assert ScoreJSON.from_json(blob) == s
+
+
+def test_payload_bytes_invariant_under_rrf_signature():
+    """payload_bytes must produce identical canonical bytes whether the
+    score has been counter-signed or not. Otherwise a registry-attested
+    score would fail to self-verify after RRF mutates rrf_signature."""
+    from robot_md.spatial_eval.sign import payload_bytes
+
+    base = ScoreJSON(
+        spec_version="1.0.0",
+        rrn="RRN-000000000002",
+        run_id="abc",
+        timestamp="2026-04-26T14:30:00Z",
+        tracks_probe=ProbeTrack(
+            baseline_claude={"O1": PerUnitProbeScore(score=0.87, n=30, passed=26)},
+            robot_declared={"O1": PerUnitProbeScore(score=0.84, n=30, passed=25)},
+            delta_per_unit={"O1": -0.03},
+        ),
+        tracks_execute={
+            "O1": PerUnitExecuteScore(passed=7, n=10, evidence_sha256="abc..."),
+        },
+        aggregate=Aggregate(probe_baseline=0.87, probe_declared=0.84, execute=0.7),
+    )
+    self_signed = ScoreJSON(**{**base.__dict__, "rcan_signature": "rcan-sig"})
+    counter_signed = ScoreJSON(
+        **{**base.__dict__, "rcan_signature": "rcan-sig", "rrf_signature": "rrf-sig"}
+    )
+    assert payload_bytes(base) == payload_bytes(self_signed) == payload_bytes(counter_signed)
+
+
 def test_aggregate_recomputes_from_per_unit():
     pt = ProbeTrack(
         baseline_claude={

--- a/docs/superpowers/specs/2026-04-26-sp6-spatial-intelligence-eval-design.md
+++ b/docs/superpowers/specs/2026-04-26-sp6-spatial-intelligence-eval-design.md
@@ -240,9 +240,12 @@ If the section is absent, the robot is ineligible for the eval — no breakage. 
     "execute":         0.60
   },
   "rcan_signature": "<base64>",
+  "rrf_signature":  null,
   "evidence_root":  "sha256:..."
 }
 ```
+
+`rrf_signature` is `null` for self-attested scores and populated by RRF after counter-signature (Phase 1 / 1.5). Both signatures cover the same canonical bytes (with both fields cleared during canonicalization), so a registry-attested score still self-verifies under the robot's keypair.
 
 Per-unit scores are first-class. The aggregate is convenience. Cherry-picking by hiding flunked units is impossible — `units` is declared in ROBOT.md and any missing unit appears as `not_run`.
 

--- a/docs/superpowers/specs/2026-04-26-sp6-spatial-intelligence-eval-design.md
+++ b/docs/superpowers/specs/2026-04-26-sp6-spatial-intelligence-eval-design.md
@@ -373,7 +373,67 @@ GET  /v1/spatial-eval/leaderboard?spec_version=…  → ranked attested scores
 
 Held-out probes are never served — RRF runs them server-side as part of the audit. Execute audits spot-check ~20% of trials by replaying judge video; full re-audit available on challenge. RRF counter-signs the Score JSON; counter-signed scores are the only ones on the leaderboard.
 
-The `robot_md.spatial_eval.rrf` module reuses the existing RRF client used by `compliance_status.py` and `eu_register.py`. No new auth surface, no new client library.
+The `robot_md.spatial_eval.rrf` module is a parallel urllib helper alongside `submit.py`. It does not extend `submit.py::KIND_REGISTRY` — the §27 path scheme is run-id keyed (`/v1/spatial-eval/runs`, `/v1/spatial-eval/runs/{run_id}`), not robot-keyed (`/v2/robots/{rrn}/...`), so the existing client's path template generalizes poorly. Audit logging via `robot_md.audit.record_event(rrn, event="submission", ...)` is preserved, identically to `submit.py`.
+
+#### §27 wire format (Phase 1.5 robot-md contract)
+
+This locks the request/response body shapes the robot-md client assumes. The RRF backend implementation must mirror exactly. Both endpoints require `Authorization: Bearer <apikey>` for the submitting robot's RRN.
+
+**POST /v1/spatial-eval/runs** — submit a self-attested Score JSON for counter-signature.
+
+Request body (`Content-Type: application/json`):
+
+```json
+{
+  "score": { /* full ScoreJSON.to_dict() — rcan_signature populated, rrf_signature null, evidence_root populated */ }
+}
+```
+
+Response — `202 Accepted` (async path, RRF queues the audit):
+
+```json
+{
+  "submission_id": "sub_<opaque>",
+  "status": "pending"
+}
+```
+
+Response — `200 OK` (sync path, RRF counter-signed inline):
+
+```json
+{
+  "submission_id": "sub_<opaque>",
+  "status": "counter_signed",
+  "score": { /* ScoreJSON with rrf_signature populated by RRF */ }
+}
+```
+
+Error responses:
+- `400 Bad Request` — missing fields, malformed score, invalid `spec_version`, mismatched RRN between Bearer apikey and `score.rrn`.
+- `401 Unauthorized` — apikey invalid or revoked.
+- `409 Conflict` — `(rrn, run_id)` already submitted.
+- `422 Unprocessable Entity` — robot's `rcan_signature` failed RRF-side verification against the keystore for `score.rrn`.
+
+**GET /v1/spatial-eval/runs/{submission_id}** — poll for counter-signature completion.
+
+Response — `200 OK`:
+
+```json
+{
+  "submission_id": "sub_<opaque>",
+  "status": "pending" | "counter_signed" | "rejected",
+  "score": { /* present iff status == "counter_signed" */ },
+  "rejection_reason": "<string>"  /* present iff status == "rejected" */
+}
+```
+
+Error responses:
+- `404 Not Found` — unknown submission_id.
+- `403 Forbidden` — apikey RRN doesn't match the submission's owner RRN.
+
+**Counter-signature canonicalization.** RRF's `rrf_signature` is computed against `payload_bytes(score)` — the exact same canonical form the robot signed (both `rcan_signature` and `rrf_signature` cleared before serialization). RRF endorses the bytes the robot endorsed. This means a registry-attested score still self-verifies under the robot's keypair without modification.
+
+**RRF pubkey distribution.** Verifiers obtain RRF's ML-DSA public key from `GET /v1/spatial-eval/spec/{version}` (already in the §27 path table); the response includes a `rrf_pubkey` field alongside the canonical spec JSON. Pinned per spec version so a key rotation requires a minor version bump and is auditable in the leaderboard timeline.
 
 ### Data flow (Phase 0)
 


### PR DESCRIPTION
## Summary

Robot-side scaffolding for `spatial_eval_submit_to_rrf` against a mocked RRF §27 endpoint. The §27 backend doesn't exist yet — this ships the client first per the R1-R7 cascade pattern, with the wire-format contract locked in the spec doc so RRF can mirror.

- **Schema:** `ScoreJSON.rrf_signature: str | None` mirrors `rcan_signature`. `payload_bytes` clears both, so a registry-attested score still self-verifies under the robot's keypair (fixes a latent bug where adding the rrf_signature field would have broken self-verification).
- **`rrf.py`:** parallel urllib helper alongside `submit.py` — `submit_score` (POST /v1/spatial-eval/runs) + `poll_status` (GET /v1/spatial-eval/runs/{id}). Audit-records every outcome under the robot's RRN. Doesn't extend `submit.py::KIND_REGISTRY` because the §27 path scheme is run-id keyed rather than robot-keyed.
- **`verify_tool`:** returns `attestation: registry-attested` when both sigs verify; falls back to self-attested + warning when `rrf_signature` is set but RRF's pubkey isn't reachable yet (production reality until `/v1/spatial-eval/spec/{version}` ships).
- **MCP tool:** reads `<run_dir>/Score.json`, parses, calls `submit_score`.
- **CLI:** `robot-md spatial-eval submit-to-rrf <score.json>` via Typer sub-app (matches the hotplug pattern).
- **Spec doc:** new "§27 wire format" subsection locks request/response body shapes, error codes, canonicalization, and pubkey distribution. RRF backend must mirror exactly.

27 net-new tests · 116/116 spatial_eval green · 54/54 dependent CLI/integration green.

## Test plan

- [x] `pytest cli/tests/spatial_eval/` — 116 passed
- [x] `pytest cli/tests/test_submit.py cli/tests/test_signing.py cli/tests/test_verify_tier.py` — 47 passed
- [x] `python -m robot_md spatial-eval submit-to-rrf --help` renders correctly
- [x] CLI dependent suite (test_cli + integration + hardware init) — 54 passed
- [ ] Manual bob smoke deferred until RRF §27 endpoints land

## Known break (per `feedback_breaking_changes_ok_no_external_robots.md`)

`payload_bytes` canonicalization now clears `rrf_signature` in addition to `rcan_signature`. Old Score.json files (no rrf_signature field) still self-verify because `d.get("rrf_signature")` returns None — the cleared form. Verified: no committed signature fixtures exist that would rot.

🤖 Generated with [Claude Code](https://claude.com/claude-code)