### PR TITLE
feat(sp6): wire production RRF pubkey fetcher into verify_tool

### DIFF
--- a/cli/src/robot_md/mcp/tools/spatial_eval/verify.py
+++ b/cli/src/robot_md/mcp/tools/spatial_eval/verify.py
@@ -50,12 +50,52 @@ def _make_apikey_verifier(rrn: str) -> Callable[[bytes, str], bool] | None:
     return verify
 
 
+def _make_rrf_verifier(
+    spec_version: str,
+    *,
+    endpoint: str | None = None,
+) -> Callable[[bytes, str], bool] | None:
+    """Build a (payload, sig_b64) -> bool verifier bound to RRF's ML-DSA
+    public key for `spec_version`. Fetches the key from
+    GET /v1/spatial-eval/spec/{version}. Returns None if the fetch
+    fails (network down, 404, malformed response) — callers should treat
+    None as "RRF pubkey unavailable, fall back to self-attested with
+    warning".
+    """
+    from rcan.crypto import verify_ml_dsa
+
+    from robot_md.spatial_eval.rrf import (
+        DEFAULT_RRF_ENDPOINT,
+        RrfFetchError,
+        fetch_rrf_pubkey,
+    )
+
+    try:
+        rrf_pub = fetch_rrf_pubkey(spec_version, endpoint=endpoint or DEFAULT_RRF_ENDPOINT)
+    except RrfFetchError:
+        return None
+
+    def verify(payload: bytes, sig_b64: str) -> bool:
+        try:
+            sig_bytes = base64.b64decode(sig_b64)
+        except (ValueError, binascii.Error):
+            return False
+        try:
+            verify_ml_dsa(rrf_pub, payload, sig_bytes)
+        except Exception:
+            return False
+        return True
+
+    return verify
+
+
 def verify_tool(
     ctx,
     *,
     score_json: str,
     _verify_signature: Callable[[bytes, str], bool] | None = None,
     _verify_rrf_signature: Callable[[bytes, str], bool] | None = None,
+    rrf_endpoint: str | None = None,
 ) -> dict:
     score = ScoreJSON.from_json(score_json)
     if score.rcan_signature is None:
@@ -81,14 +121,17 @@ def verify_tool(
         return {"ok": True, "attestation": "self-attested"}
 
     if _verify_rrf_signature is None:
-        return {
-            "ok": True,
-            "attestation": "self-attested",
-            "warning": (
-                "rrf_signature present but RRF public key is not yet available "
-                "locally; counter-signature was not verified"
-            ),
-        }
+        _verify_rrf_signature = _make_rrf_verifier(score.spec_version, endpoint=rrf_endpoint)
+        if _verify_rrf_signature is None:
+            return {
+                "ok": True,
+                "attestation": "self-attested",
+                "warning": (
+                    "rrf_signature present but RRF public key could not be "
+                    "fetched (network down, spec endpoint missing, or "
+                    "malformed response); counter-signature was not verified"
+                ),
+            }
 
     if not _verify_rrf_signature(payload, score.rrf_signature):
         return {"ok": False, "error": "invalid rrf_signature"}

--- a/cli/src/robot_md/spatial_eval/rrf.py
+++ b/cli/src/robot_md/spatial_eval/rrf.py
@@ -26,10 +26,63 @@ from robot_md.spatial_eval.score import ScoreJSON
 DEFAULT_RRF_ENDPOINT = "https://robotregistryfoundation.org"
 RUNS_PATH = "/v1/spatial-eval/runs"
 RUN_DETAIL_PATH = "/v1/spatial-eval/runs/{submission_id}"
+SPEC_PATH = "/v1/spatial-eval/spec/{version}"
 
 
 class RrfSubmitError(RuntimeError):
     """Raised on missing apikey, network failure, or non-2xx HTTP response."""
+
+
+class RrfFetchError(RuntimeError):
+    """Raised when the spec endpoint can't serve the requested data
+    (network down, 404, malformed response). Verifiers should treat this
+    as a soft failure — fall back to self-attested rather than raising.
+    """
+
+
+def fetch_rrf_pubkey(
+    spec_version: str,
+    *,
+    endpoint: str = DEFAULT_RRF_ENDPOINT,
+    timeout: float = 5.0,
+) -> bytes:
+    """GET /v1/spatial-eval/spec/{version} and return the raw RRF ML-DSA
+    public key bytes (base64-decoded). Raises RrfFetchError on any
+    non-success path.
+
+    No audit logging here — pubkey fetches are read-only and frequent;
+    spamming the audit chain with every verify call would be noise.
+    """
+    import base64
+    import binascii
+
+    url = endpoint.rstrip("/") + SPEC_PATH.format(version=spec_version)
+    req = urllib.request.Request(
+        url,
+        method="GET",
+        headers={
+            "Accept": "application/json",
+            "User-Agent": f"robot-md/{__version__}",
+        },
+    )
+    try:
+        with urllib.request.urlopen(req, timeout=timeout) as resp:
+            body_bytes = resp.read()
+    except (urllib.error.HTTPError, urllib.error.URLError, OSError) as e:
+        raise RrfFetchError(f"could not fetch RRF spec from {url}: {e}") from e
+
+    try:
+        body = json.loads(body_bytes)
+    except json.JSONDecodeError as e:
+        raise RrfFetchError(f"RRF spec returned non-JSON: {e}") from e
+
+    pubkey_b64 = body.get("rrf_pubkey")
+    if not isinstance(pubkey_b64, str) or not pubkey_b64:
+        raise RrfFetchError(f"RRF spec response missing rrf_pubkey: {body!r}")
+    try:
+        return base64.b64decode(pubkey_b64)
+    except (ValueError, binascii.Error) as e:
+        raise RrfFetchError(f"RRF spec rrf_pubkey is not valid base64: {e}") from e
 
 
 def submit_score(

--- a/cli/tests/spatial_eval/test_mcp_verify_production_rrf.py
+++ b/cli/tests/spatial_eval/test_mcp_verify_production_rrf.py
@@ -1,0 +1,168 @@
+"""SP6 Phase 1.5+ — verify_tool production wiring for the RRF counter-signature.
+
+When `_verify_rrf_signature` is not injected and the score has an
+rrf_signature, verify_tool now fetches the RRF pubkey from
+GET /v1/spatial-eval/spec/{spec_version} and verifies. Network failures
+fall back to self-attested with a warning rather than failing the score.
+"""
+
+from __future__ import annotations
+
+import base64
+import io
+import json
+import urllib.error
+from pathlib import Path
+from unittest.mock import patch
+
+from rcan.crypto import sign_ml_dsa
+
+from robot_md.mcp.tools.spatial_eval.verify import verify_tool
+from robot_md.signing import generate_keypair, save_keypair
+from robot_md.spatial_eval.score import (
+    Aggregate,
+    PerUnitExecuteScore,
+    ProbeTrack,
+    ScoreJSON,
+)
+from robot_md.spatial_eval.sign import payload_bytes
+
+
+def _mock_response(status: int, body: dict | bytes = b"") -> object:
+    class _Resp:
+        def __init__(self):
+            self.status = status
+            data = body if isinstance(body, bytes) else json.dumps(body).encode()
+            self._fp = io.BytesIO(data)
+
+        def read(self):
+            return self._fp.read()
+
+        def __enter__(self):
+            return self
+
+        def __exit__(self, *_a):
+            return False
+
+    return _Resp()
+
+
+def _registry_attested_score(monkeypatch, tmp_path: Path):
+    """Build a Score JSON with both rcan_signature (real, against a robot
+    keypair saved to keystore) and rrf_signature (real, against a
+    test RRF keypair). Returns (score_json_str, rrf_keypair) where
+    rrf_keypair is whatever generate_keypair() produces."""
+    monkeypatch.setenv("HOME", str(tmp_path))
+
+    rrn = "RRN-test-rrf-001"
+    robot_kp = generate_keypair()
+    save_keypair(rrn, robot_kp)
+
+    score = ScoreJSON(
+        spec_version="1.0.0",
+        rrn=rrn,
+        run_id="r-1",
+        timestamp="2026-04-30T00:00:00Z",
+        tracks_probe=ProbeTrack(baseline_claude={}, robot_declared={}, delta_per_unit={}),
+        tracks_execute={"O1": PerUnitExecuteScore(7, 10, "abc")},
+        aggregate=Aggregate(0.0, 0.0, 0.7),
+        rcan_signature=None,
+        rrf_signature=None,
+        evidence_root="sha256:abc",
+    )
+    payload = payload_bytes(score)
+    score.rcan_signature = base64.b64encode(sign_ml_dsa(robot_kp.ml_dsa, payload)).decode("ascii")
+
+    # Test RRF keypair
+    rrf_kp = generate_keypair()
+    score.rrf_signature = base64.b64encode(sign_ml_dsa(rrf_kp.ml_dsa, payload)).decode("ascii")
+
+    return score.to_json(), rrf_kp
+
+
+def test_verify_returns_registry_attested_when_spec_endpoint_serves_pubkey(
+    monkeypatch, tmp_path: Path
+):
+    score_json, rrf_kp = _registry_attested_score(monkeypatch, tmp_path)
+    rrf_pubkey_b64 = base64.b64encode(rrf_kp.ml_dsa.public_key_bytes).decode("ascii")
+
+    def fake_urlopen(req, timeout=None):
+        return _mock_response(
+            200,
+            {
+                "spec_version": "1.0.0",
+                "rrf_pubkey": rrf_pubkey_b64,
+                "rrf_pubkey_alg": "ml-dsa-65",
+            },
+        )
+
+    with patch("urllib.request.urlopen", side_effect=fake_urlopen):
+        out = verify_tool(None, score_json=score_json)
+
+    assert out == {"ok": True, "attestation": "registry-attested"}
+
+
+def test_verify_falls_back_to_self_attested_when_spec_endpoint_unreachable(
+    monkeypatch, tmp_path: Path
+):
+    score_json, _rrf_kp = _registry_attested_score(monkeypatch, tmp_path)
+
+    def fake_urlopen(req, timeout=None):
+        raise urllib.error.URLError("Network unreachable")
+
+    with patch("urllib.request.urlopen", side_effect=fake_urlopen):
+        out = verify_tool(None, score_json=score_json)
+
+    assert out["ok"] is True
+    assert out["attestation"] == "self-attested"
+    assert "RRF public key could not be fetched" in out["warning"]
+
+
+def test_verify_falls_back_to_self_attested_when_spec_endpoint_404(monkeypatch, tmp_path: Path):
+    score_json, _rrf_kp = _registry_attested_score(monkeypatch, tmp_path)
+
+    def fake_urlopen(req, timeout=None):
+        raise urllib.error.HTTPError(req.full_url, 404, "Not Found", hdrs={}, fp=io.BytesIO(b"{}"))
+
+    with patch("urllib.request.urlopen", side_effect=fake_urlopen):
+        out = verify_tool(None, score_json=score_json)
+
+    assert out["ok"] is True
+    assert out["attestation"] == "self-attested"
+    assert "RRF public key could not be fetched" in out["warning"]
+
+
+def test_verify_rejects_when_pubkey_returned_but_rrf_sig_invalid(monkeypatch, tmp_path: Path):
+    """RRF endpoint returns a (different) pubkey that doesn't match the
+    rrf_signature on the score. Must be a hard fail, not a soft fallback —
+    a serving-but-wrong pubkey is more concerning than an unreachable one."""
+    score_json, _rrf_kp = _registry_attested_score(monkeypatch, tmp_path)
+
+    # Use a completely different RRF keypair for the fetched pubkey
+    other_rrf = generate_keypair()
+    bad_pubkey_b64 = base64.b64encode(other_rrf.ml_dsa.public_key_bytes).decode("ascii")
+
+    def fake_urlopen(req, timeout=None):
+        return _mock_response(200, {"rrf_pubkey": bad_pubkey_b64})
+
+    with patch("urllib.request.urlopen", side_effect=fake_urlopen):
+        out = verify_tool(None, score_json=score_json)
+
+    assert out["ok"] is False
+    assert "invalid rrf_signature" in out["error"]
+
+
+def test_verify_uses_custom_rrf_endpoint(monkeypatch, tmp_path: Path):
+    score_json, rrf_kp = _registry_attested_score(monkeypatch, tmp_path)
+    rrf_pubkey_b64 = base64.b64encode(rrf_kp.ml_dsa.public_key_bytes).decode("ascii")
+
+    captured = {}
+
+    def fake_urlopen(req, timeout=None):
+        captured["url"] = req.full_url
+        return _mock_response(200, {"rrf_pubkey": rrf_pubkey_b64})
+
+    with patch("urllib.request.urlopen", side_effect=fake_urlopen):
+        verify_tool(None, score_json=score_json, rrf_endpoint="http://localhost:8765")
+
+    assert captured["url"].startswith("http://localhost:8765")

--- a/cli/tests/spatial_eval/test_mcp_verify_registry_attested.py
+++ b/cli/tests/spatial_eval/test_mcp_verify_registry_attested.py
@@ -58,19 +58,28 @@ def test_verify_rejects_invalid_rrf_signature():
 
 
 def test_verify_score_with_rrf_sig_but_no_rrf_verifier_falls_back_to_self_attested_with_warning():
-    """Phase 1.5 production path: rrf_signature is present on the score but
-    RRF's public key isn't fetchable yet (spec endpoint not built). Don't
-    claim registry-attested without verifying — return self-attested with
-    a clear warning so callers see the situation."""
-    out = verify_tool(
-        MagicMock(),
-        score_json=_score_with("rcan-sig", "rrf-sig"),
-        _verify_signature=lambda payload, sig: True,
-        # _verify_rrf_signature=None  -- omitted on purpose
-    )
+    """When rrf_signature is present but the production fetcher can't
+    reach the spec endpoint (offline / unbuilt), don't claim
+    registry-attested without verifying — return self-attested with a
+    clear warning so callers see the situation. Mocks urllib to simulate
+    network failure, since the default path would otherwise hit the
+    real internet."""
+    import urllib.error
+    from unittest.mock import patch
+
+    def _no_network(req, timeout=None):
+        raise urllib.error.URLError("network disabled in test")
+
+    with patch("urllib.request.urlopen", side_effect=_no_network):
+        out = verify_tool(
+            MagicMock(),
+            score_json=_score_with("rcan-sig", "rrf-sig"),
+            _verify_signature=lambda payload, sig: True,
+            # _verify_rrf_signature=None  -- omitted on purpose
+        )
     assert out["ok"] is True
     assert out["attestation"] == "self-attested"
-    assert "rrf_signature present" in out["warning"]
+    assert "RRF public key could not be fetched" in out["warning"]
 
 
 def test_verify_score_without_rrf_sig_still_returns_self_attested():

--- a/cli/tests/spatial_eval/test_rrf_fetch_pubkey.py
+++ b/cli/tests/spatial_eval/test_rrf_fetch_pubkey.py
@@ -1,0 +1,133 @@
+"""SP6 Phase 1.5+ — fetch_rrf_pubkey against urllib-mocked GET /v1/spatial-eval/spec/{version}.
+
+Used by verify_tool's production wiring to fetch the RRF ML-DSA public
+key for `spec_version` and verify the rrf_signature on counter-signed
+scores. Failures are soft — verify_tool falls back to self-attested
+with a warning when fetch fails.
+"""
+
+from __future__ import annotations
+
+import base64
+import io
+import json
+import urllib.error
+from unittest.mock import patch
+
+import pytest
+
+
+def _mock_response(status: int, body: dict | bytes = b"") -> object:
+    class _Resp:
+        def __init__(self):
+            self.status = status
+            data = body if isinstance(body, bytes) else json.dumps(body).encode()
+            self._fp = io.BytesIO(data)
+
+        def read(self):
+            return self._fp.read()
+
+        def __enter__(self):
+            return self
+
+        def __exit__(self, *_a):
+            return False
+
+    return _Resp()
+
+
+def test_fetch_rrf_pubkey_returns_decoded_bytes():
+    fake_pubkey = b"\x01\x02\x03\x04" * 488  # ml-dsa-65 pubkey size
+    fake_pubkey_b64 = base64.b64encode(fake_pubkey).decode("ascii")
+
+    captured = {}
+
+    def fake_urlopen(req, timeout=None):
+        captured["url"] = req.full_url
+        captured["method"] = req.get_method()
+        return _mock_response(
+            200,
+            {
+                "spec_version": "1.0.0",
+                "rrf_pubkey": fake_pubkey_b64,
+                "rrf_pubkey_alg": "ml-dsa-65",
+            },
+        )
+
+    from robot_md.spatial_eval.rrf import fetch_rrf_pubkey
+
+    with patch("urllib.request.urlopen", side_effect=fake_urlopen):
+        result = fetch_rrf_pubkey("1.0.0")
+
+    assert result == fake_pubkey
+    assert captured["url"].endswith("/v1/spatial-eval/spec/1.0.0")
+    assert captured["method"] == "GET"
+
+
+def test_fetch_rrf_pubkey_raises_on_network_error():
+    def fake_urlopen(req, timeout=None):
+        raise urllib.error.URLError("Connection refused")
+
+    from robot_md.spatial_eval.rrf import RrfFetchError, fetch_rrf_pubkey
+
+    with (
+        patch("urllib.request.urlopen", side_effect=fake_urlopen),
+        pytest.raises(RrfFetchError, match="could not fetch"),
+    ):
+        fetch_rrf_pubkey("1.0.0")
+
+
+def test_fetch_rrf_pubkey_raises_on_404():
+    def fake_urlopen(req, timeout=None):
+        raise urllib.error.HTTPError(req.full_url, 404, "Not Found", hdrs={}, fp=io.BytesIO(b"{}"))
+
+    from robot_md.spatial_eval.rrf import RrfFetchError, fetch_rrf_pubkey
+
+    with (
+        patch("urllib.request.urlopen", side_effect=fake_urlopen),
+        pytest.raises(RrfFetchError, match="could not fetch"),
+    ):
+        fetch_rrf_pubkey("9.9.9")
+
+
+def test_fetch_rrf_pubkey_raises_on_missing_rrf_pubkey_field():
+    def fake_urlopen(req, timeout=None):
+        return _mock_response(200, {"spec_version": "1.0.0"})  # no rrf_pubkey
+
+    from robot_md.spatial_eval.rrf import RrfFetchError, fetch_rrf_pubkey
+
+    with (
+        patch("urllib.request.urlopen", side_effect=fake_urlopen),
+        pytest.raises(RrfFetchError, match="missing rrf_pubkey"),
+    ):
+        fetch_rrf_pubkey("1.0.0")
+
+
+def test_fetch_rrf_pubkey_raises_on_malformed_base64():
+    def fake_urlopen(req, timeout=None):
+        return _mock_response(200, {"spec_version": "1.0.0", "rrf_pubkey": "!!!not-b64"})
+
+    from robot_md.spatial_eval.rrf import RrfFetchError, fetch_rrf_pubkey
+
+    with (
+        patch("urllib.request.urlopen", side_effect=fake_urlopen),
+        pytest.raises(RrfFetchError, match="not valid base64"),
+    ):
+        fetch_rrf_pubkey("1.0.0")
+
+
+def test_fetch_rrf_pubkey_uses_custom_endpoint():
+    captured = {}
+    fake_pubkey = b"x" * 1952
+    fake_pubkey_b64 = base64.b64encode(fake_pubkey).decode("ascii")
+
+    def fake_urlopen(req, timeout=None):
+        captured["url"] = req.full_url
+        return _mock_response(200, {"rrf_pubkey": fake_pubkey_b64})
+
+    from robot_md.spatial_eval.rrf import fetch_rrf_pubkey
+
+    with patch("urllib.request.urlopen", side_effect=fake_urlopen):
+        fetch_rrf_pubkey("1.0.0", endpoint="http://localhost:8765")
+
+    assert captured["url"] == "http://localhost:8765/v1/spatial-eval/spec/1.0.0"

--- a/docs/superpowers/specs/2026-04-26-sp6-spatial-intelligence-eval-design.md
+++ b/docs/superpowers/specs/2026-04-26-sp6-spatial-intelligence-eval-design.md
@@ -431,8 +431,11 @@ Response — `200 OK`:
 ```
 
 Error responses:
+- `400 Bad Request` — malformed submission_id.
+- `401 Unauthorized` — missing Bearer header.
 - `404 Not Found` — unknown submission_id.
-- `403 Forbidden` — apikey RRN doesn't match the submission's owner RRN.
+
+**Bearer is opaque on GET** (matches §22-26): any holder of a valid Bearer token can fetch by submission_id. Submission ids are unguessable (uuid4-class) so they're effectively the auth token. Tightening to per-RRN authorization waits on a stable apikey→RRN reverse-lookup store.
 
 **Counter-signature canonicalization.** RRF's `rrf_signature` is computed against `payload_bytes(score)` — the exact same canonical form the robot signed (both `rcan_signature` and `rrf_signature` cleared before serialization). RRF endorses the bytes the robot endorsed. This means a registry-attested score still self-verifies under the robot's keypair without modification.
 


### PR DESCRIPTION
## Summary

Pairs with RRF PR #73 (§27 backend). Once the RRF spec endpoint is live at \`GET /v1/spatial-eval/spec/{version}\`, \`verify_tool\` can produce registry-attested verdicts in production without callers needing to inject \`_verify_rrf_signature\`.

- **\`rrf.fetch_rrf_pubkey(spec_version, endpoint, timeout)\`** — returns base64-decoded ML-DSA pubkey bytes; raises \`RrfFetchError\` on any non-success path. No audit logging — pubkey fetches are read-only and frequent.
- **\`verify._make_rrf_verifier(spec_version, endpoint)\`** — builds a payload-bytes → bool verifier or returns None on fetch failure.
- **\`verify_tool\`** — when score has \`rrf_signature\` and \`_verify_rrf_signature\` isn't injected, calls \`_make_rrf_verifier\` with \`score.spec_version\`. Three outcomes:
  - Fetch ok + sig verifies → \`attestation: registry-attested\`.
  - Fetch ok + sig fails → \`ok=False, \"invalid rrf_signature\"\` (a serving-but-wrong pubkey is hard-fail, not soft).
  - Fetch fails → self-attested + clear "RRF public key could not be fetched" warning. Offline / pre-deploy verification still works.
- **New \`rrf_endpoint\` kwarg** on \`verify_tool\` for tests + local-dev RRFs.

Spec doc loose-Bearer correction on \`GET /runs/{id}\`: matches §22-26 pattern and the actual RRF implementation. Submission ids are uuid-class so they effectively are the auth token; tightening to per-RRN auth waits on an apikey→RRN reverse-lookup store.

## Test plan

- [x] 11 net-new tests across \`test_rrf_fetch_pubkey.py\` + \`test_mcp_verify_production_rrf.py\`. Cover registry-attested happy path against mock spec endpoint, network unreachable → soft fallback, 404 → soft fallback, wrong-pubkey-served → hard fail, custom endpoint kwarg.
- [x] Updated existing \`test_verify_score_with_rrf_sig_but_no_rrf_verifier_falls_back_to_self_attested_with_warning\` to mock urllib (it now exercises the new fetch path).
- [x] 127/127 spatial_eval tests pass (116 prior + 11 new).
- [x] ruff lint + format clean.
- [ ] End-to-end smoke against deployed RRF \`/v1/spatial-eval/spec/1.0.0\` once that ships (gated on RRF PR #73 merge + secret set).

🤖 Generated with [Claude Code](https://claude.com/claude-code)