### PR TITLE
feat(site): follow-ups — spec generator + agents hub + Amazon Q surface

### DIFF
--- a/.github/workflows/deploy-site.yml
+++ b/.github/workflows/deploy-site.yml
@@ -31,6 +31,11 @@ jobs:
         with:
           node-version: "20"
 
+      - name: Render spec from markdown
+        run: |
+          pip install --user markdown
+          python3 site/scripts/render-spec.py
+
       - name: Inject build-time stats
         run: node site/scripts/inject-stats.js
         env:

--- a/site/agents/chatgpt/index.html
+++ b/site/agents/chatgpt/index.html
@@ -201,7 +201,7 @@
       </a>
       <nav aria-label="Site navigation">
         <a href="/spec/">Spec</a>
-        <a href="/agents/claude-code/" class="current" aria-current="page">Agents</a>
+        <a href="/agents/" class="current" aria-current="page">Agents</a>
         <a href="/mcp/">MCP</a>
         <a href="/registry/">Registry</a>
         <a href="/compliance/">Compliance</a>
@@ -233,6 +233,7 @@
         <a href="/agents/gemini/">Gemini CLI</a>
         <a href="/agents/codex/">Codex CLI</a>
         <a href="/agents/chatgpt/" class="current" aria-current="page">ChatGPT</a>
+        <a href="/agents/q/">Amazon Q</a>
       </nav>
     </div>
   </header>

--- a/site/agents/claude-code/index.html
+++ b/site/agents/claude-code/index.html
@@ -164,7 +164,7 @@
       </a>
       <nav aria-label="Site navigation">
         <a href="/spec/">Spec</a>
-        <a href="/agents/claude-code/" class="current" aria-current="page">Agents</a>
+        <a href="/agents/" class="current" aria-current="page">Agents</a>
         <a href="/mcp/">MCP</a>
         <a href="/registry/">Registry</a>
         <a href="/compliance/">Compliance</a>
@@ -197,6 +197,7 @@
         <a href="/agents/gemini/">Gemini CLI</a>
         <a href="/agents/codex/">Codex CLI</a>
         <a href="/agents/chatgpt/">ChatGPT</a>
+        <a href="/agents/q/">Amazon Q</a>
       </nav>
     </div>
   </header>

--- a/site/agents/codex/index.html
+++ b/site/agents/codex/index.html
@@ -144,7 +144,7 @@
       </a>
       <nav aria-label="Site navigation">
         <a href="/spec/">Spec</a>
-        <a href="/agents/claude-code/" class="current" aria-current="page">Agents</a>
+        <a href="/agents/" class="current" aria-current="page">Agents</a>
         <a href="/mcp/">MCP</a>
         <a href="/registry/">Registry</a>
         <a href="/compliance/">Compliance</a>
@@ -176,6 +176,7 @@
         <a href="/agents/gemini/">Gemini CLI</a>
         <a href="/agents/codex/" class="current" aria-current="page">Codex CLI</a>
         <a href="/agents/chatgpt/">ChatGPT</a>
+        <a href="/agents/q/">Amazon Q</a>
       </nav>
     </div>
   </header>

--- a/site/agents/gemini/index.html
+++ b/site/agents/gemini/index.html
@@ -133,7 +133,7 @@
       </a>
       <nav aria-label="Site navigation">
         <a href="/spec/">Spec</a>
-        <a href="/agents/claude-code/" class="current" aria-current="page">Agents</a>
+        <a href="/agents/" class="current" aria-current="page">Agents</a>
         <a href="/mcp/">MCP</a>
         <a href="/registry/">Registry</a>
         <a href="/compliance/">Compliance</a>
@@ -165,6 +165,7 @@
         <a href="/agents/gemini/" class="current" aria-current="page">Gemini CLI</a>
         <a href="/agents/codex/">Codex CLI</a>
         <a href="/agents/chatgpt/">ChatGPT</a>
+        <a href="/agents/q/">Amazon Q</a>
       </nav>
     </div>
   </header>

--- a/site/agents/index.html
+++ b/site/agents/index.html
@@ -1,0 +1,348 @@
+<!doctype html>
+<html lang="en">
+
+<head>
+  <meta charset="utf-8">
+  <meta name="viewport" content="width=device-width,initial-scale=1">
+  <title>Agent Surfaces — ROBOT.md</title>
+  <meta name="description"
+    content="Run ROBOT.md from any AI agent surface. Claude Code, Gemini CLI, OpenAI Codex, ChatGPT, and Amazon Q — one MCP server, every surface.">
+  <meta name="theme-color" content="#F4EFE6">
+
+  <meta property="og:title" content="Agent Surfaces — ROBOT.md">
+  <meta property="og:description"
+    content="Install robot-md-mcp once per surface and talk to your robot from Claude Code, Gemini CLI, Codex, ChatGPT, or Amazon Q.">
+  <meta property="og:url" content="https://robotmd.dev/agents/">
+  <meta property="og:type" content="website">
+  <meta name="twitter:card" content="summary_large_image">
+
+  <link rel="canonical" href="https://robotmd.dev/agents/">
+
+  <link rel="preconnect" href="https://fonts.googleapis.com">
+  <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>
+  <link
+    href="https://fonts.googleapis.com/css2?family=Inter+Tight:wght@300;400;500;600;700&family=JetBrains+Mono:wght@400;500;600&family=Fraunces:ital,wght@1,400;1,600&display=swap"
+    rel="stylesheet">
+
+  <link rel="stylesheet" href="/css/design.css">
+
+  <style>
+    /* ---- surface cards grid (shared with homepage, duplicated here for standalone page) ---- */
+    .surface-grid {
+      display: grid;
+      grid-template-columns: repeat(5, 1fr);
+      gap: 0;
+      border: 1px solid var(--rule);
+      overflow: hidden;
+      margin-top: 28px;
+    }
+    @media (max-width: 1000px) {
+      .surface-grid { grid-template-columns: repeat(3, 1fr) }
+    }
+    @media (max-width: 600px) {
+      .surface-grid { grid-template-columns: 1fr }
+    }
+
+    .surface-card {
+      padding: 24px 22px;
+      border-right: 1px solid var(--rule);
+      display: flex;
+      flex-direction: column;
+      gap: 10px;
+      background: var(--paper);
+      transition: background .12s;
+    }
+    .surface-card:last-child { border-right: none }
+    .surface-card:hover { background: var(--paper-2) }
+
+    .surface-card .surf-name {
+      font-family: var(--sans);
+      font-weight: 600;
+      font-size: 15px;
+      color: var(--ink);
+      margin: 0;
+    }
+
+    .surface-card .surf-desc {
+      font-size: 13px;
+      color: var(--ink-3);
+      line-height: 1.55;
+      margin: 0;
+    }
+
+    .surface-card .surf-status {
+      font-family: var(--mono);
+      font-size: 10px;
+      letter-spacing: .1em;
+      text-transform: uppercase;
+      padding: 2px 7px;
+      border-radius: 2px;
+      width: fit-content;
+    }
+    .surf-status.live    { background: var(--ok);        color: var(--paper) }
+    .surf-status.wip     { background: var(--paper-3);   color: var(--ink-2); border: 1px solid var(--rule) }
+    .surf-status.prerel  { background: var(--accent-wash); color: var(--accent-ink); border: 1px solid var(--accent) }
+
+    .surface-card pre.surf-cmd {
+      margin: 0;
+      font-family: var(--mono);
+      font-size: 11px;
+      color: var(--accent-ink);
+      background: var(--paper-2);
+      padding: 8px 10px;
+      border-radius: 2px;
+      overflow-x: auto;
+      white-space: pre;
+      border: 1px solid var(--rule);
+      line-height: 1.55;
+    }
+
+    .surface-card .surf-link {
+      font-family: var(--mono);
+      font-size: 11px;
+      letter-spacing: .06em;
+      color: var(--accent);
+      border-bottom: none;
+      margin-top: auto;
+    }
+    .surface-card .surf-link:hover { color: var(--accent-ink) }
+
+    @media (max-width: 1000px) {
+      .surface-card:nth-child(3) { border-right: none }
+      .surface-card:nth-child(-n+3) { border-bottom: 1px solid var(--rule) }
+    }
+    @media (max-width: 600px) {
+      .surface-card { border-right: none; border-bottom: 1px solid var(--rule) }
+      .surface-card:last-child { border-bottom: none }
+    }
+
+    /* ---- "Don't see your surface?" block ---- */
+    .request-block {
+      margin-top: 48px;
+      padding: 24px 28px;
+      border: 1px solid var(--rule);
+      background: var(--paper-2);
+      display: flex;
+      gap: 24px;
+      align-items: flex-start;
+      flex-wrap: wrap;
+    }
+    .request-block .req-label {
+      font-family: var(--mono);
+      font-size: 10px;
+      letter-spacing: .15em;
+      text-transform: uppercase;
+      color: var(--accent);
+      margin-bottom: 6px;
+    }
+    .request-block .req-title {
+      font-family: var(--sans);
+      font-weight: 600;
+      font-size: 16px;
+      color: var(--ink);
+      margin: 0 0 8px;
+    }
+    .request-block .req-body {
+      font-size: 14px;
+      color: var(--ink-3);
+      line-height: 1.6;
+      margin: 0;
+    }
+    .request-block .req-cta {
+      font-family: var(--mono);
+      font-size: 12px;
+      letter-spacing: .1em;
+      text-transform: uppercase;
+      padding: 9px 20px;
+      border: 1px solid var(--rule);
+      color: var(--ink);
+      white-space: nowrap;
+      margin-top: 16px;
+      display: inline-block;
+      transition: background .12s, color .12s;
+    }
+    .request-block .req-cta:hover { background: var(--ink); color: var(--paper); border-color: var(--ink) }
+  </style>
+</head>
+
+<body>
+
+  <!-- ===== SITE NAV ===== -->
+  <header class="site-nav" role="banner">
+    <div class="wrap site-nav-inner">
+      <a class="wordmark" href="/" aria-label="ROBOT.md home">
+        ROBOT<span class="dot">.</span><span class="md">md</span>
+      </a>
+      <nav aria-label="Site navigation">
+        <a href="/spec/">Spec</a>
+        <a href="/agents/" class="current" aria-current="page">Agents</a>
+        <a href="/mcp/">MCP</a>
+        <a href="/registry/">Registry</a>
+        <a href="/compliance/">Compliance</a>
+        <a href="/managed-agents/">Managed Agents</a>
+        <a href="/robots">Robots</a>
+        <a href="https://github.com/RobotRegistryFoundation/robot-md" aria-label="GitHub repository">GitHub</a>
+      </nav>
+    </div>
+  </header>
+
+  <!-- ===== PAGE HEADER ===== -->
+  <header class="page-header">
+    <div class="wrap">
+      <div class="page-eyebrow">
+        <span>Agent surfaces</span>
+        <span class="rule-line" aria-hidden="true"></span>
+        <span>5 surfaces · 3 live · 2 pre-release</span>
+      </div>
+      <h1 class="page-heading">
+        Run robot-md from <span style="font-family:var(--serif);font-weight:400;font-style:italic;color:var(--ink-3)">any</span> AI agent surface.
+      </h1>
+      <p class="page-lede">
+        One MCP server — <code style="font-family:var(--mono);font-size:15px;background:var(--paper-2);padding:2px 7px;border-radius:2px;">robot-md-mcp</code> — runs behind every surface.
+        Install once per agent, then ask your robot anything in plain language.
+      </p>
+    </div>
+  </header>
+
+  <!-- ===== SURFACE CARDS ===== -->
+  <section class="sec" id="surfaces">
+    <div class="wrap">
+
+      <div class="sec-eyebrow">
+        <span>§ 01 — Surfaces</span>
+        <span class="rule-line" aria-hidden="true"></span>
+      </div>
+      <h2 class="sec-title">Five surfaces. One manifest file.</h2>
+      <p class="sec-lede" style="max-width:640px;">
+        Purpose-built for Anthropic surfaces; open to any MCP-aware agent.
+        Each surface page has a full install walkthrough, a capabilities table,
+        and worked examples.
+      </p>
+
+      <div class="surface-grid">
+
+        <!-- Claude Code -->
+        <div class="surface-card">
+          <div class="surf-status live">● Live</div>
+          <p class="surf-name">Claude Code</p>
+          <p class="surf-desc">The primary surface. Native MCP stdio — read capabilities, validate, run compliance commands from any Claude session.</p>
+          <pre class="surf-cmd">pip install robot-md
+robot-md init
+claude</pre>
+          <a class="surf-link" href="/agents/claude-code/">Full guide →</a>
+        </div>
+
+        <!-- Gemini CLI -->
+        <div class="surface-card">
+          <div class="surf-status live">● Live</div>
+          <p class="surf-name">Gemini CLI</p>
+          <p class="surf-desc">Google Gemini CLI via MCP. Add one config line and your robot manifest is readable from every Gemini session.</p>
+          <pre class="surf-cmd">gemini mcp add robot-md \
+  npx -- --yes \
+  robot-md-mcp ./ROBOT.md</pre>
+          <a class="surf-link" href="/agents/gemini/">Full guide →</a>
+        </div>
+
+        <!-- OpenAI Codex -->
+        <div class="surface-card">
+          <div class="surf-status live">● Live</div>
+          <p class="surf-name">OpenAI Codex</p>
+          <p class="surf-desc">Codex CLI via MCP stdio. Requires <code style="font-family:var(--mono);font-size:10.5px;background:rgba(0,0,0,.06);padding:1px 4px;border-radius:2px;">--dangerously-bypass</code> to unlock tool calls in the Codex sandbox.</p>
+          <pre class="surf-cmd">codex --mcp-server \
+  "npx --yes robot-md-mcp \
+  ./ROBOT.md" \
+  --dangerously-bypass</pre>
+          <a class="surf-link" href="/agents/codex/">Full guide →</a>
+        </div>
+
+        <!-- ChatGPT -->
+        <div class="surface-card">
+          <div class="surf-status prerel">○ Pre-release</div>
+          <p class="surf-name">ChatGPT</p>
+          <p class="surf-desc">OpenAPI bridge via <code style="font-family:var(--mono);font-size:10.5px;background:rgba(0,0,0,.06);padding:1px 4px;border-radius:2px;">robot-md-http</code>. Expose your manifest as a Custom GPT Action endpoint.</p>
+          <pre class="surf-cmd">npx -y robot-md-http
+# OpenAPI bridge for
+# Custom GPT Actions</pre>
+          <a class="surf-link" href="/agents/chatgpt/">Full guide →</a>
+        </div>
+
+        <!-- Amazon Q -->
+        <div class="surface-card">
+          <div class="surf-status wip">◌ Pre-release</div>
+          <p class="surf-name">Amazon Q</p>
+          <p class="surf-desc">Q CLI MCP support is currently x86-only. aarch64 (RPi) support is tracked upstream. Falls back to the OpenAPI bridge today.</p>
+          <pre class="surf-cmd"># MCP: pending aarch64
+# Use robot-md-http
+# as fallback today</pre>
+          <a class="surf-link" href="/agents/q/">Full guide →</a>
+        </div>
+
+      </div>
+
+      <!-- Don't see your surface? -->
+      <div class="request-block">
+        <div style="flex:1;min-width:200px;">
+          <div class="req-label">Requests</div>
+          <p class="req-title">Don't see your surface?</p>
+          <p class="req-body">
+            New agent surface adapters are tracked as GitHub issues.
+            If you need robot-md on a surface not listed here — an IDE extension,
+            a custom orchestrator, or a new CLI — open a request and we'll add it
+            to the roadmap.
+          </p>
+          <a class="req-cta"
+             href="https://github.com/RobotRegistryFoundation/robot-md/issues/new?labels=surface-request&title=Surface+request%3A+">
+            Request a surface →
+          </a>
+        </div>
+      </div>
+
+    </div>
+  </section>
+
+  <!-- ===== HOW IT WORKS ===== -->
+  <section class="sec" id="how">
+    <div class="wrap">
+      <div class="sec-eyebrow">
+        <span>§ 02 — Architecture</span>
+        <span class="rule-line" aria-hidden="true"></span>
+      </div>
+      <h2 class="sec-title">One server, every surface.</h2>
+      <p style="font-size:15px;color:var(--ink-2);line-height:1.65;max-width:640px;margin-bottom:24px;">
+        Every surface above runs the same <code style="font-family:var(--mono);font-size:13px;background:var(--paper-2);padding:1px 5px;border-radius:2px;">robot-md-mcp</code> stdio server.
+        The server reads your <code style="font-family:var(--mono);font-size:13px;background:var(--paper-2);padding:1px 5px;border-radius:2px;">ROBOT.md</code> at startup and exposes
+        capabilities, safety metadata, and compliance fields as MCP resources and tools.
+        Surface-specific wiring is a one-line config change per agent — the manifest file
+        and the MCP server stay identical.
+      </p>
+      <div style="display:flex;gap:12px;flex-wrap:wrap;">
+        <a href="/mcp/"
+           style="font-family:var(--mono);font-size:12px;letter-spacing:.1em;text-transform:uppercase;padding:9px 20px;background:var(--ink);color:var(--paper);border:1px solid var(--ink);border-bottom:1px solid var(--ink);transition:background .12s;">
+          MCP server docs →
+        </a>
+        <a href="/spec/"
+           style="font-family:var(--mono);font-size:12px;letter-spacing:.1em;text-transform:uppercase;padding:9px 20px;border:1px solid var(--rule);color:var(--ink);border-bottom:1px solid var(--rule);transition:background .12s,color .12s;">
+          ROBOT.md spec →
+        </a>
+      </div>
+    </div>
+  </section>
+
+  <!-- ===== FOOTER ===== -->
+  <footer class="wrap foot">
+    <div>ROBOT.md · © 2026 Craig Merry · <a href="https://www.craigmerry.com">craigmerry.com</a></div>
+    <div>
+      <a href="/">Home</a> ·
+      <a href="/spec/">Spec</a> ·
+      <a href="/registry/">Registry</a> ·
+      <a href="/compliance/">Compliance</a> ·
+      <a href="/robots">Robots</a> ·
+      <a href="/status">Status</a> ·
+      <a href="/report.html">Report issue</a> ·
+      <a href="https://github.com/RobotRegistryFoundation/robot-md">GitHub</a>
+    </div>
+  </footer>
+
+</body>
+
+</html>

--- a/site/agents/q/index.html
+++ b/site/agents/q/index.html
@@ -1,0 +1,411 @@
+<!doctype html>
+<html lang="en">
+
+<head>
+  <meta charset="utf-8">
+  <meta name="viewport" content="width=device-width,initial-scale=1">
+  <title>Amazon Q — ROBOT.md Agents</title>
+  <meta name="description"
+    content="ROBOT.md + Amazon Q: MCP integration is pending aarch64 support in Q CLI. Use the robot-md-http OpenAPI bridge as a fallback today.">
+  <meta name="theme-color" content="#F4EFE6">
+
+  <meta property="og:title" content="Amazon Q — ROBOT.md Agents">
+  <meta property="og:url" content="https://robotmd.dev/agents/q/">
+  <meta property="og:type" content="website">
+  <meta name="twitter:card" content="summary_large_image">
+
+  <link rel="canonical" href="https://robotmd.dev/agents/q/">
+
+  <link rel="preconnect" href="https://fonts.googleapis.com">
+  <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>
+  <link
+    href="https://fonts.googleapis.com/css2?family=Inter+Tight:wght@300;400;500;600;700&family=JetBrains+Mono:wght@400;500;600&family=Fraunces:ital,wght@1,400;1,600&display=swap"
+    rel="stylesheet">
+
+  <link rel="stylesheet" href="/css/design.css">
+
+  <style>
+    .agent-nav {
+      display: flex;
+      gap: 0;
+      border: 1px solid var(--rule);
+      background: var(--paper-2);
+      font-family: var(--mono);
+      font-size: 11px;
+      letter-spacing: .08em;
+      text-transform: uppercase;
+      overflow: hidden;
+      margin-top: 28px;
+    }
+    .agent-nav a {
+      padding: 8px 18px;
+      border-right: 1px solid var(--rule);
+      color: var(--ink-3);
+      border-bottom: none;
+      transition: background .12s;
+      white-space: nowrap;
+    }
+    .agent-nav a:last-child { border-right: none }
+    .agent-nav a:hover { background: var(--paper-3); color: var(--ink) }
+    .agent-nav a.current { background: var(--ink); color: var(--paper) }
+    @media (max-width: 720px) {
+      .agent-nav { flex-wrap: wrap }
+      .agent-nav a { flex: 1 1 auto; text-align: center }
+    }
+
+    .code-example {
+      background: var(--ink);
+      color: #E8E3D3;
+      font-family: var(--mono);
+      font-size: 13px;
+      line-height: 1.6;
+      padding: 18px 20px;
+      margin: 12px 0 20px;
+      overflow-x: auto;
+      border-radius: 2px;
+      border: 1px solid var(--rule);
+    }
+    .code-example .cm { color: #6a9966 }
+    .code-example .kw { color: #ffb88c }
+    .code-example .st { color: #b8d9a1 }
+
+    .info-block {
+      background: var(--paper-2);
+      border-left: 3px solid var(--ink-3);
+      padding: 14px 18px;
+      margin: 16px 0;
+      font-size: 14px;
+      color: var(--ink-2);
+      line-height: 1.55;
+    }
+    .info-block strong { color: var(--ink) }
+
+    .warn-block {
+      background: var(--accent-wash);
+      border-left: 3px solid var(--accent);
+      padding: 14px 18px;
+      margin: 16px 0;
+      font-size: 14px;
+      color: var(--ink-2);
+      line-height: 1.55;
+    }
+    .warn-block strong { color: var(--accent-ink) }
+
+    .future-block {
+      background: var(--paper-2);
+      border: 1px dashed var(--rule);
+      padding: 18px 20px;
+      margin: 12px 0 20px;
+    }
+    .future-block .future-label {
+      font-family: var(--mono);
+      font-size: 10px;
+      letter-spacing: .15em;
+      text-transform: uppercase;
+      color: var(--ink-4);
+      margin-bottom: 8px;
+    }
+    .future-block pre {
+      background: var(--ink);
+      color: #E8E3D3;
+      font-family: var(--mono);
+      font-size: 13px;
+      line-height: 1.6;
+      padding: 14px 18px;
+      margin: 0;
+      overflow-x: auto;
+      border-radius: 2px;
+      opacity: .65;
+    }
+
+    .caps-table {
+      width: 100%;
+      border-collapse: collapse;
+      margin-top: 20px;
+      font-size: 13.5px;
+    }
+    .caps-table th {
+      font-family: var(--mono);
+      font-size: 10px;
+      letter-spacing: .12em;
+      text-transform: uppercase;
+      text-align: left;
+      padding: 8px 12px;
+      background: var(--paper-2);
+      border-bottom: 2px solid var(--rule);
+      color: var(--ink-3);
+    }
+    .caps-table td {
+      padding: 8px 12px;
+      border-bottom: 1px solid var(--rule);
+      color: var(--ink-2);
+      vertical-align: middle;
+    }
+    .caps-table tr:last-child td { border-bottom: none }
+    .caps-table td:first-child { font-family: var(--mono); font-size: 12.5px; color: var(--ink) }
+    .cap-native  { color: var(--ok);         font-family: var(--mono); font-size: 11px }
+    .cap-bridge  { color: var(--accent-ink); font-family: var(--mono); font-size: 11px }
+    .cap-blocked { color: var(--danger);     font-family: var(--mono); font-size: 11px }
+    .cap-na      { color: var(--ink-4);      font-family: var(--mono); font-size: 11px }
+
+    .cta-strip {
+      display: flex;
+      gap: 12px;
+      flex-wrap: wrap;
+      margin-top: 32px;
+      padding-top: 28px;
+      border-top: 1px solid var(--rule);
+    }
+    .cta-strip a {
+      font-family: var(--mono);
+      font-size: 12px;
+      letter-spacing: .1em;
+      text-transform: uppercase;
+      padding: 9px 20px;
+      border: 1px solid var(--rule);
+      color: var(--ink);
+      border-bottom: 1px solid var(--rule);
+      transition: background .12s, color .12s;
+    }
+    .cta-strip a:hover { background: var(--ink); color: var(--paper) }
+    .cta-strip a.primary { background: var(--ink); color: var(--paper); border-color: var(--ink) }
+    .cta-strip a.primary:hover { background: var(--accent); border-color: var(--accent) }
+  </style>
+</head>
+
+<body>
+
+  <!-- ===== SITE NAV ===== -->
+  <header class="site-nav" role="banner">
+    <div class="wrap site-nav-inner">
+      <a class="wordmark" href="/" aria-label="ROBOT.md home">
+        ROBOT<span class="dot">.</span><span class="md">md</span>
+      </a>
+      <nav aria-label="Site navigation">
+        <a href="/spec/">Spec</a>
+        <a href="/agents/" class="current" aria-current="page">Agents</a>
+        <a href="/mcp/">MCP</a>
+        <a href="/registry/">Registry</a>
+        <a href="/compliance/">Compliance</a>
+        <a href="/managed-agents/">Managed Agents</a>
+        <a href="/robots">Robots</a>
+        <a href="https://github.com/RobotRegistryFoundation/robot-md" aria-label="GitHub repository">GitHub</a>
+      </nav>
+    </div>
+  </header>
+
+  <!-- ===== PAGE HEADER ===== -->
+  <header class="page-header">
+    <div class="wrap">
+      <div class="page-eyebrow">
+        <span>Agents · Amazon Q</span>
+        <span class="rule-line" aria-hidden="true"></span>
+        <span class="badge badge-wip">Pre-release · aarch64 blocked</span>
+      </div>
+      <h1 class="page-heading">
+        ROBOT<span style="color:var(--accent)">.</span><span style="font-family:var(--serif);font-weight:400;font-style:italic;color:var(--ink-3)">md</span>
+        + <b>Amazon Q</b>
+      </h1>
+      <p class="page-lede">
+        When Q's MCP CLI support catches up to aarch64, robot-md-mcp wires in with one config line.
+        Until then, the <code style="font-family:var(--mono);font-size:15px;background:var(--paper-2);padding:2px 7px;border-radius:2px;">robot-md-http</code>
+        OpenAPI bridge is the fallback path.
+      </p>
+      <nav class="agent-nav" aria-label="Agent surfaces">
+        <a href="/agents/claude-code/">Claude Code</a>
+        <a href="/agents/gemini/">Gemini CLI</a>
+        <a href="/agents/codex/">Codex CLI</a>
+        <a href="/agents/chatgpt/">ChatGPT</a>
+        <a href="/agents/q/" class="current" aria-current="page">Amazon Q</a>
+      </nav>
+    </div>
+  </header>
+
+  <!-- ===== WHAT'S BLOCKED ===== -->
+  <section class="sec" id="blocked">
+    <div class="wrap">
+      <div class="sec-eyebrow">
+        <span>§ 01 — Status</span>
+        <span class="rule-line" aria-hidden="true"></span>
+      </div>
+      <h2 class="sec-title">What's blocked today.</h2>
+
+      <div class="warn-block">
+        <strong>aarch64 not supported:</strong> Amazon Q CLI's MCP integration currently requires an
+        x86 host. The reference robot (<em>bob</em>) runs on a Raspberry Pi 5 (aarch64), so the native
+        MCP path is blocked until AWS ships aarch64 support. Tracking:
+        <a href="https://github.com/aws/amazon-q-developer-cli/issues"
+           style="font-family:var(--mono);font-size:12px;">aws/amazon-q-developer-cli issues →</a>
+      </div>
+
+      <p style="font-size:15px;color:var(--ink-2);line-height:1.65;max-width:640px;margin-top:12px;">
+        The blocker is architectural — Q CLI's MCP stdio transport is compiled for x86 only as of
+        2026-04-29. There is no workaround on aarch64 hardware short of cross-architecture emulation
+        (not recommended for production robotics). When AWS ships a universal binary or aarch64 build,
+        the integration is a one-line config change identical to the Codex and Gemini setups.
+      </p>
+    </div>
+  </section>
+
+  <!-- ===== WHAT WORKS TODAY ===== -->
+  <section class="sec" id="today">
+    <div class="wrap">
+      <div class="sec-eyebrow">
+        <span>§ 02 — What works today</span>
+        <span class="rule-line" aria-hidden="true"></span>
+      </div>
+      <h2 class="sec-title">OpenAPI bridge fallback.</h2>
+
+      <p style="font-size:15px;color:var(--ink-2);line-height:1.65;max-width:640px;margin-bottom:16px;">
+        The same <code style="font-family:var(--mono);font-size:13px;background:var(--paper-2);padding:1px 5px;border-radius:2px;">robot-md-http</code>
+        bridge used by ChatGPT Custom GPT Actions works with Q's web and chat surfaces.
+        It exposes your robot manifest as an OpenAPI endpoint that any HTTP-capable agent can call.
+      </p>
+
+      <div class="info-block">
+        <strong>Fallback path:</strong> Start <code style="font-family:var(--mono);font-size:12.5px;background:rgba(0,0,0,.06);padding:1px 5px;border-radius:2px;">robot-md-http</code>
+        as a local server, then point Q's custom tool configuration at
+        <code style="font-family:var(--mono);font-size:12.5px;background:rgba(0,0,0,.06);padding:1px 5px;border-radius:2px;">http://localhost:4000/openapi.json</code>.
+        Capability reads and safety queries work; tool-call execution requires the full MCP path.
+      </div>
+
+      <p style="font-size:14px;color:var(--ink-3);font-family:var(--mono);letter-spacing:.06em;text-transform:uppercase;margin:20px 0 8px;">
+        Start the HTTP bridge
+      </p>
+      <pre class="code-example" aria-label="robot-md-http bridge command"><span class="cm"># Install and start the OpenAPI bridge:</span>
+$ npx -y robot-md-http ./ROBOT.md
+
+<span class="cm"># Bridge starts at http://localhost:4000</span>
+<span class="cm"># OpenAPI schema: http://localhost:4000/openapi.json</span>
+<span class="cm"># Point Amazon Q's plugin/tool config at this endpoint.</span></pre>
+
+      <p style="font-size:15px;color:var(--ink-2);line-height:1.65;max-width:640px;margin-bottom:0;">
+        Full walkthrough for the HTTP bridge (including custom GPT Action wiring) is on the
+        <a href="/agents/chatgpt/">ChatGPT page</a> — the setup is identical.
+      </p>
+    </div>
+  </section>
+
+  <!-- ===== FUTURE MCP INSTALL ===== -->
+  <section class="sec" id="future">
+    <div class="wrap">
+      <div class="sec-eyebrow">
+        <span>§ 03 — Future MCP install</span>
+        <span class="rule-line" aria-hidden="true"></span>
+      </div>
+      <h2 class="sec-title">When aarch64 support ships.</h2>
+
+      <p style="font-size:15px;color:var(--ink-2);line-height:1.65;max-width:640px;margin-bottom:16px;">
+        Once Q CLI ships aarch64 support, the install is one command — identical in shape
+        to the Gemini and Codex setups. The block below shows the expected form.
+        Do not run it today; the command will fail on aarch64 hosts.
+      </p>
+
+      <div class="future-block">
+        <div class="future-label">Future — not yet functional on aarch64</div>
+        <!-- No copy button intentionally: this command does not work today -->
+        <pre aria-label="Future Amazon Q MCP install (not yet functional)"># When Q CLI supports aarch64:
+q mcp add robot-md \
+  -- npx --yes robot-md-mcp ./ROBOT.md
+
+# Then start Q and ask:
+q chat
+&gt; what can this robot do?</pre>
+      </div>
+
+      <p style="font-size:13.5px;color:var(--ink-3);line-height:1.55;max-width:540px;margin-top:8px;">
+        This page will be updated and the copy button enabled once the integration is verified
+        on aarch64 hardware. Watch
+        <a href="https://github.com/RobotRegistryFoundation/robot-md/issues"
+           style="font-family:var(--mono);font-size:12px;">robot-md issues</a>
+        or
+        <a href="https://github.com/aws/amazon-q-developer-cli/issues"
+           style="font-family:var(--mono);font-size:12px;">aws/amazon-q-developer-cli issues</a>
+        for status.
+      </p>
+    </div>
+  </section>
+
+  <!-- ===== CAPABILITIES ===== -->
+  <section class="sec" id="capabilities">
+    <div class="wrap">
+      <div class="sec-eyebrow">
+        <span>§ 04 — Capabilities</span>
+        <span class="rule-line" aria-hidden="true"></span>
+      </div>
+      <h2 class="sec-title">What works via Amazon Q.</h2>
+
+      <table class="caps-table">
+        <thead>
+          <tr>
+            <th>Feature</th>
+            <th>Q CLI (MCP)</th>
+            <th>Q via HTTP bridge</th>
+            <th>Notes</th>
+          </tr>
+        </thead>
+        <tbody>
+          <tr>
+            <td>Read capabilities / safety / frontmatter</td>
+            <td><span class="cap-blocked">✗ aarch64 blocked</span></td>
+            <td><span class="cap-bridge">→ Bridge</span></td>
+            <td>HTTP bridge reads MCP resources via REST</td>
+          </tr>
+          <tr>
+            <td>Validate ROBOT.md</td>
+            <td><span class="cap-blocked">✗ aarch64 blocked</span></td>
+            <td><span class="cap-bridge">→ Bridge</span></td>
+            <td>OpenAPI <code style="font-family:var(--mono);font-size:12px;background:var(--paper-2);padding:1px 4px;border-radius:2px;">POST /validate</code></td>
+          </tr>
+          <tr>
+            <td>Render canonical YAML</td>
+            <td><span class="cap-blocked">✗ aarch64 blocked</span></td>
+            <td><span class="cap-bridge">→ Bridge</span></td>
+            <td>Via HTTP bridge</td>
+          </tr>
+          <tr>
+            <td>Compliance filing commands</td>
+            <td><span class="cap-na">— Not via Q</span></td>
+            <td><span class="cap-na">— CLI only</span></td>
+            <td>Run <code style="font-family:var(--mono);font-size:12px;background:var(--paper-2);padding:1px 4px;border-radius:2px;">robot-md emit-fria</code> directly from shell</td>
+          </tr>
+          <tr>
+            <td>Native MCP (all features)</td>
+            <td><span class="cap-blocked">✗ Future (aarch64)</span></td>
+            <td><span class="cap-na">— N/A</span></td>
+            <td>Will match Codex/Gemini feature set once unblocked</td>
+          </tr>
+        </tbody>
+      </table>
+    </div>
+  </section>
+
+  <!-- ===== CTA ===== -->
+  <section class="sec" id="next" style="border-bottom:none;">
+    <div class="wrap">
+      <div class="cta-strip">
+        <a class="primary" href="/mcp/">MCP server docs →</a>
+        <a href="/agents/">All surfaces →</a>
+        <a href="/agents/chatgpt/">ChatGPT (HTTP bridge) →</a>
+      </div>
+    </div>
+  </section>
+
+  <!-- ===== FOOTER ===== -->
+  <footer class="wrap foot">
+    <div>ROBOT.md · © 2026 Craig Merry · <a href="https://www.craigmerry.com">craigmerry.com</a></div>
+    <div>
+      <a href="/">Home</a> ·
+      <a href="/spec/">Spec</a> ·
+      <a href="/registry/">Registry</a> ·
+      <a href="/compliance/">Compliance</a> ·
+      <a href="/robots">Robots</a> ·
+      <a href="/status">Status</a> ·
+      <a href="/report.html">Report issue</a> ·
+      <a href="https://github.com/RobotRegistryFoundation/robot-md">GitHub</a>
+    </div>
+  </footer>
+
+</body>
+
+</html>

--- a/site/index.html
+++ b/site/index.html
@@ -886,7 +886,7 @@
       </a>
       <nav aria-label="Site navigation">
         <a href="/spec/">Spec</a>
-        <a href="/agents/claude-code/">Agents</a>
+        <a href="/agents/">Agents</a>
         <a href="/mcp/">MCP</a>
         <a href="/registry/">Registry</a>
         <a href="/compliance/">Compliance</a>
@@ -1116,11 +1116,12 @@ claude</pre>
         </div>
 
         <div class="surface-card">
-          <div class="surf-status wip">◌ Planned</div>
+          <div class="surf-status wip">◌ Pre-release</div>
           <div class="surf-name">Amazon Q</div>
-          <pre class="surf-cmd"># MCP integration in progress
-# tracking: issue #3</pre>
-          <a class="surf-link" href="https://github.com/RobotRegistryFoundation/robot-md/issues/3">Track progress →</a>
+          <pre class="surf-cmd"># MCP: pending aarch64
+# robot-md-http bridge
+# available today</pre>
+          <a class="surf-link" href="/agents/q/">Full install guide →</a>
         </div>
 
       </div>

--- a/site/scripts/render-spec.py
+++ b/site/scripts/render-spec.py
@@ -542,6 +542,7 @@ def render(md_path: Path, html_path: Path) -> None:
                 TocExtension(permalink=False, toc_depth="2-3"),
                 "tables",
                 "fenced_code",
+                "attr_list",
             ]
         )
         body_html = md.convert(body_md)

--- a/site/scripts/render-spec.py
+++ b/site/scripts/render-spec.py
@@ -1,0 +1,670 @@
+#!/usr/bin/env python3
+"""
+render-spec.py — regenerate site/spec/index.html from site/spec/v1.md.
+
+Usage:
+    python3 site/scripts/render-spec.py
+
+The committed site/spec/index.html is always the output of the most recent
+run of this script. CI also runs this script before every deploy, so the
+live HTML is at most one deploy cycle behind the markdown source.
+
+Design notes:
+- The first `# ` heading in v1.md is extracted as the page title; it is NOT
+  fed into the markdown renderer (it renders as the page-header H1 instead).
+- A sticky TOC sidebar is auto-generated from the h2/h3 headings found in the
+  rendered body after markdown conversion.
+- markdown.extensions.toc adds id attributes to headings automatically.
+- Output must be idempotent: no timestamps, no random data.
+"""
+
+import re
+import sys
+from pathlib import Path
+
+try:
+    import markdown
+    from markdown.extensions.toc import TocExtension
+    HAS_MARKDOWN = True
+except ImportError:
+    HAS_MARKDOWN = False
+
+# ── paths ────────────────────────────────────────────────────────────────────
+REPO_ROOT = Path(__file__).resolve().parent.parent.parent
+MD_SRC    = REPO_ROOT / "site" / "spec" / "v1.md"
+HTML_OUT  = REPO_ROOT / "site" / "spec" / "index.html"
+
+
+# ── hand-rolled fallback (used only if `markdown` is not importable) ─────────
+def _escape_html(s: str) -> str:
+    return (s
+            .replace("&", "&amp;")
+            .replace("<", "&lt;")
+            .replace(">", "&gt;")
+            .replace('"', "&quot;"))
+
+
+def _inline(text: str) -> str:
+    """Apply inline markdown: **bold**, *italic*, `code`, [text](url)."""
+    # links first so we don't double-escape
+    text = re.sub(r'\[([^\]]+)\]\(([^)]+)\)',
+                  lambda m: f'<a href="{m.group(2)}">{m.group(1)}</a>', text)
+    text = re.sub(r'\*\*(.+?)\*\*', r'<strong>\1</strong>', text)
+    text = re.sub(r'\*(.+?)\*',     r'<em>\1</em>', text)
+    text = re.sub(r'`([^`]+)`',     lambda m: f'<code>{_escape_html(m.group(1))}</code>', text)
+    return text
+
+
+def _slugify(text: str) -> str:
+    """Simple slug: lowercase, alphanumeric + hyphens."""
+    text = re.sub(r'[^a-z0-9 -]', '', text.lower())
+    return re.sub(r'\s+', '-', text.strip())
+
+
+def _render_fallback(body_md: str) -> str:
+    """Hand-rolled renderer for the feature subset used in v1.md."""
+    lines   = body_md.splitlines()
+    out     = []
+    i       = 0
+    in_pre  = False
+    pre_buf = []
+    in_table = False
+    in_list  = None   # 'ul' or 'ol'
+    in_para  = False
+    para_buf = []
+
+    def flush_para():
+        nonlocal in_para, para_buf
+        if in_para and para_buf:
+            combined = " ".join(para_buf)
+            out.append(f"<p>{_inline(combined)}</p>")
+        in_para = False
+        para_buf = []
+
+    def flush_list():
+        nonlocal in_list
+        if in_list:
+            out.append(f"</{in_list}>")
+            in_list = None
+
+    while i < len(lines):
+        line = lines[i]
+
+        # fenced code block
+        if line.strip().startswith("```"):
+            flush_para()
+            flush_list()
+            if not in_pre:
+                in_pre = True
+                pre_buf = []
+            else:
+                content = _escape_html("\n".join(pre_buf))
+                out.append(f"<pre><code>{content}</code></pre>")
+                in_pre = False
+            i += 1
+            continue
+
+        if in_pre:
+            pre_buf.append(line)
+            i += 1
+            continue
+
+        # headings
+        m = re.match(r'^(#{2,3})\s+(.*)', line)
+        if m:
+            flush_para()
+            flush_list()
+            level  = len(m.group(1))
+            title  = m.group(2)
+            slug   = _slugify(re.sub(r'`([^`]*)`', r'\1', title))
+            tag    = f"h{level}"
+            out.append(f'<{tag} id="{slug}">{_inline(title)}</{tag}>')
+            i += 1
+            continue
+
+        # table (pipe rows)
+        if line.startswith("|"):
+            flush_para()
+            flush_list()
+            if not in_table:
+                in_table = True
+                out.append('<table>')
+                # parse header row
+                cells = [c.strip() for c in line.strip().strip("|").split("|")]
+                out.append("<thead><tr>")
+                for c in cells:
+                    out.append(f"<th>{_inline(c)}</th>")
+                out.append("</tr></thead><tbody>")
+                i += 1
+                # skip separator row
+                if i < len(lines) and re.match(r'^\|[-:| ]+\|', lines[i]):
+                    i += 1
+            else:
+                cells = [c.strip() for c in line.strip().strip("|").split("|")]
+                out.append("<tr>")
+                for c in cells:
+                    out.append(f"<td>{_inline(c)}</td>")
+                out.append("</tr>")
+                i += 1
+            continue
+        elif in_table:
+            out.append("</tbody></table>")
+            in_table = False
+            # fall through to process current line
+
+        # unordered list
+        m = re.match(r'^[-*]\s+(.*)', line)
+        if m:
+            flush_para()
+            if in_list == 'ol':
+                out.append("</ol>")
+                in_list = None
+            if in_list != 'ul':
+                out.append("<ul>")
+                in_list = 'ul'
+            out.append(f"<li>{_inline(m.group(1))}</li>")
+            i += 1
+            continue
+
+        # ordered list
+        m = re.match(r'^\d+\.\s+(.*)', line)
+        if m:
+            flush_para()
+            if in_list == 'ul':
+                out.append("</ul>")
+                in_list = None
+            if in_list != 'ol':
+                out.append("<ol>")
+                in_list = 'ol'
+            out.append(f"<li>{_inline(m.group(1))}</li>")
+            i += 1
+            continue
+
+        # blank line
+        if not line.strip():
+            flush_para()
+            flush_list()
+            if in_table:
+                out.append("</tbody></table>")
+                in_table = False
+            i += 1
+            continue
+
+        # paragraph accumulation
+        flush_list()
+        in_para = True
+        para_buf.append(line)
+        i += 1
+
+    flush_para()
+    flush_list()
+    if in_table:
+        out.append("</tbody></table>")
+    if in_pre:
+        content = _escape_html("\n".join(pre_buf))
+        out.append(f"<pre><code>{content}</code></pre>")
+
+    return "\n".join(out)
+
+
+# ── TOC extraction ────────────────────────────────────────────────────────────
+def _extract_toc(html_body: str) -> list[dict]:
+    """
+    Return list of {'level': 2|3, 'id': str, 'text': str} from rendered HTML.
+    Only h2 and h3 are included.
+    """
+    toc = []
+    for m in re.finditer(r'<h([23])[^>]*id="([^"]+)"[^>]*>(.*?)</h\1>',
+                         html_body, re.DOTALL):
+        level = int(m.group(1))
+        slug  = m.group(2)
+        text  = re.sub(r'<[^>]+>', '', m.group(3))   # strip inner tags for display
+        toc.append({'level': level, 'id': slug, 'text': text})
+    return toc
+
+
+# ── HTML template ─────────────────────────────────────────────────────────────
+NAV_HTML = """\
+  <header class="site-nav" role="banner">
+    <div class="wrap site-nav-inner">
+      <a class="wordmark" href="/" aria-label="ROBOT.md home">
+        ROBOT<span class="dot">.</span><span class="md">md</span>
+      </a>
+      <nav aria-label="Site navigation">
+        <a href="/spec/" class="current" aria-current="page">Spec</a>
+        <a href="/agents/">Agents</a>
+        <a href="/mcp/">MCP</a>
+        <a href="/registry/">Registry</a>
+        <a href="/compliance/">Compliance</a>
+        <a href="/managed-agents/">Managed Agents</a>
+        <a href="/robots">Robots</a>
+        <a href="https://github.com/RobotRegistryFoundation/robot-md" aria-label="GitHub repository">GitHub</a>
+      </nav>
+    </div>
+  </header>"""
+
+FOOTER_HTML = """\
+  <footer class="wrap foot">
+    <div>ROBOT.md · © 2026 Craig Merry · <a href="https://www.craigmerry.com">craigmerry.com</a></div>
+    <div>
+      <a href="/">Home</a> ·
+      <a href="/spec/">Spec</a> ·
+      <a href="/registry/">Registry</a> ·
+      <a href="/compliance/">Compliance</a> ·
+      <a href="/robots">Robots</a> ·
+      <a href="/status">Status</a> ·
+      <a href="/report.html">Report issue</a> ·
+      <a href="https://github.com/RobotRegistryFoundation/robot-md">GitHub</a>
+    </div>
+  </footer>"""
+
+PAGE_STYLES = """\
+  <style>
+    /* ============================================================
+       SPEC PAGE — two-column layout with sidebar
+       ============================================================ */
+    .spec-layout {
+      display: grid;
+      grid-template-columns: 220px 1fr;
+      gap: 48px;
+      padding: 48px 0 80px;
+      align-items: start;
+    }
+    @media (max-width: 900px) {
+      .spec-layout { grid-template-columns: 1fr; gap: 32px }
+    }
+
+    /* ---- Sidebar ---- */
+    .spec-sidebar {
+      position: sticky;
+      top: 72px;
+    }
+    @media (max-width: 900px) {
+      .spec-sidebar { position: static }
+    }
+
+    .spec-sidebar .sidebar-label {
+      font-family: var(--mono);
+      font-size: 10px;
+      letter-spacing: .18em;
+      text-transform: uppercase;
+      color: var(--accent);
+      margin-bottom: 12px;
+    }
+
+    .spec-sidebar .ver-block {
+      border: 1px solid var(--rule);
+      background: var(--paper-2);
+      padding: 16px;
+      margin-bottom: 24px;
+    }
+
+    .spec-sidebar .ver-block .ver-current {
+      font-family: var(--mono);
+      font-size: 13px;
+      font-weight: 600;
+      color: var(--ink);
+      display: flex;
+      align-items: center;
+      gap: 8px;
+      margin-bottom: 8px;
+    }
+    .spec-sidebar .ver-block .ver-badge {
+      font-size: 9px;
+      letter-spacing: .12em;
+      text-transform: uppercase;
+      background: var(--ok);
+      color: var(--paper);
+      padding: 2px 6px;
+      border-radius: 2px;
+    }
+
+    .spec-sidebar .ver-block ul {
+      margin: 0;
+      padding: 0;
+      list-style: none;
+    }
+    .spec-sidebar .ver-block ul li {
+      font-family: var(--mono);
+      font-size: 12px;
+      color: var(--ink-3);
+      padding: 3px 0;
+      border-top: 1px solid var(--rule);
+    }
+    .spec-sidebar .ver-block ul li a {
+      color: var(--ink-3);
+      border: none;
+    }
+    .spec-sidebar .ver-block ul li a:hover { color: var(--accent) }
+
+    .spec-sidebar nav.toc ul {
+      margin: 0;
+      padding: 0;
+      list-style: none;
+      display: flex;
+      flex-direction: column;
+      gap: 2px;
+    }
+    .spec-sidebar nav.toc ul li a {
+      font-family: var(--mono);
+      font-size: 11.5px;
+      color: var(--ink-3);
+      border: none;
+      padding: 3px 0;
+      display: block;
+    }
+    .spec-sidebar nav.toc ul li a:hover { color: var(--accent) }
+    .spec-sidebar nav.toc ul li.toc-sub a {
+      padding-left: 14px;
+      font-size: 11px;
+      color: var(--ink-4);
+    }
+
+    .spec-sidebar .schema-link {
+      display: block;
+      font-family: var(--mono);
+      font-size: 11px;
+      letter-spacing: .06em;
+      background: var(--ink);
+      color: var(--paper);
+      text-align: center;
+      padding: 9px 12px;
+      border: none;
+      margin-top: 20px;
+      transition: background .15s;
+    }
+    .spec-sidebar .schema-link:hover { background: var(--accent) }
+
+    .spec-sidebar .validate-hint {
+      margin-top: 12px;
+      font-family: var(--mono);
+      font-size: 11px;
+      color: var(--ink-4);
+      background: var(--paper-2);
+      border: 1px solid var(--rule);
+      padding: 10px 12px;
+      line-height: 1.5;
+    }
+    .spec-sidebar .validate-hint code {
+      color: var(--accent-ink);
+      background: none;
+    }
+
+    /* ---- Spec body ---- */
+    .spec-body h2 {
+      font-family: var(--sans);
+      font-weight: 600;
+      font-size: clamp(20px, 2.4vw, 28px);
+      letter-spacing: -0.018em;
+      line-height: 1.15;
+      margin: 48px 0 12px;
+      padding-top: 8px;
+      border-top: 2px solid var(--rule);
+      color: var(--ink);
+    }
+    .spec-body h2:first-child { margin-top: 0; border-top: none }
+
+    .spec-body h3 {
+      font-family: var(--mono);
+      font-size: 14px;
+      font-weight: 600;
+      letter-spacing: .04em;
+      margin: 28px 0 8px;
+      color: var(--ink);
+    }
+    .spec-body h3 code {
+      font-family: var(--mono);
+      font-size: 14px;
+      background: var(--paper-2);
+      padding: 2px 7px;
+      border-radius: 2px;
+    }
+
+    .spec-body p {
+      font-size: 15px;
+      color: var(--ink-2);
+      line-height: 1.65;
+      margin: 0 0 14px;
+    }
+
+    .spec-body ul, .spec-body ol {
+      margin: 0 0 14px;
+      padding-left: 22px;
+    }
+    .spec-body li {
+      font-size: 14.5px;
+      color: var(--ink-2);
+      line-height: 1.6;
+      margin-bottom: 4px;
+    }
+    .spec-body li code {
+      font-family: var(--mono);
+      font-size: 12.5px;
+      background: var(--paper-2);
+      padding: 1px 5px;
+      border-radius: 2px;
+    }
+
+    .spec-body code {
+      font-family: var(--mono);
+      font-size: 13px;
+      background: var(--paper-2);
+      padding: 1px 5px;
+      border-radius: 2px;
+    }
+
+    .spec-body pre {
+      background: var(--ink);
+      color: #E8E3D3;
+      font-family: var(--mono);
+      font-size: 13px;
+      line-height: 1.6;
+      padding: 18px 20px;
+      margin: 8px 0 20px;
+      overflow-x: auto;
+      border-radius: 2px;
+      border: 1px solid var(--rule);
+    }
+    .spec-body pre code {
+      background: none;
+      padding: 0;
+      font-size: 13px;
+      color: inherit;
+    }
+
+    .spec-body table {
+      width: 100%;
+      border-collapse: collapse;
+      margin: 12px 0 20px;
+      font-size: 13.5px;
+    }
+    .spec-body th {
+      font-family: var(--mono);
+      font-size: 11px;
+      letter-spacing: .1em;
+      text-transform: uppercase;
+      color: var(--ink-3);
+      text-align: left;
+      padding: 8px 12px;
+      border-bottom: 2px solid var(--rule);
+      background: var(--paper-2);
+    }
+    .spec-body td {
+      padding: 8px 12px;
+      border-bottom: 1px solid var(--rule);
+      color: var(--ink-2);
+      vertical-align: top;
+      line-height: 1.5;
+    }
+    .spec-body td code {
+      font-family: var(--mono);
+      font-size: 12px;
+      background: var(--paper-2);
+      padding: 1px 4px;
+      border-radius: 2px;
+    }
+    .spec-body tr:last-child td { border-bottom: none }
+  </style>"""
+
+
+def _build_toc_html(toc: list[dict]) -> str:
+    items = []
+    for entry in toc:
+        cls = ' class="toc-sub"' if entry['level'] == 3 else ''
+        items.append(
+            f'            <li{cls}><a href="#{entry["id"]}">{entry["text"]}</a></li>'
+        )
+    return "\n".join(items)
+
+
+def render(md_path: Path, html_path: Path) -> None:
+    source = md_path.read_text(encoding="utf-8")
+
+    # Split off the frontmatter-style metadata block at top (not YAML ---),
+    # then strip the H1 title line.
+    lines = source.splitlines()
+
+    # First non-blank line should be the H1 title
+    title_raw = ""
+    body_start = 0
+    for idx, line in enumerate(lines):
+        m = re.match(r'^#\s+(.*)', line)
+        if m:
+            title_raw = m.group(1)
+            body_start = idx + 1
+            break
+
+    body_md = "\n".join(lines[body_start:])
+
+    if HAS_MARKDOWN:
+        md = markdown.Markdown(
+            extensions=[
+                TocExtension(permalink=False, toc_depth="2-3"),
+                "tables",
+                "fenced_code",
+            ]
+        )
+        body_html = md.convert(body_md)
+    else:
+        print("WARNING: `markdown` library not found — using hand-rolled fallback",
+              file=sys.stderr)
+        body_html = _render_fallback(body_md)
+
+    toc = _extract_toc(body_html)
+    toc_html = _build_toc_html(toc)
+
+    page = f"""<!doctype html>
+<html lang="en">
+
+<head>
+  <meta charset="utf-8">
+  <meta name="viewport" content="width=device-width,initial-scale=1">
+  <title>ROBOT.md Spec v1 — Format Specification</title>
+  <meta name="description"
+    content="The ROBOT.md format specification — v1. YAML frontmatter schema, required fields, body sections, validation rules, and RCAN 3.0+ conformance requirements.">
+  <meta name="theme-color" content="#F4EFE6">
+
+  <meta property="og:title" content="ROBOT.md Spec v1">
+  <meta property="og:description"
+    content="ROBOT.md format specification — one file per robot, YAML + markdown, RCAN 3.0+ conformant.">
+  <meta property="og:url" content="https://robotmd.dev/spec/">
+  <meta property="og:type" content="website">
+  <meta name="twitter:card" content="summary_large_image">
+
+  <link rel="canonical" href="https://robotmd.dev/spec/">
+
+  <link rel="preconnect" href="https://fonts.googleapis.com">
+  <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>
+  <link
+    href="https://fonts.googleapis.com/css2?family=Inter+Tight:wght@300;400;500;600;700&family=JetBrains+Mono:wght@400;500;600&family=Fraunces:ital,wght@1,400;1,600&display=swap"
+    rel="stylesheet">
+
+  <link rel="stylesheet" href="/css/design.css">
+
+{PAGE_STYLES}
+</head>
+
+<body>
+
+  <!-- ===== SITE NAV ===== -->
+{NAV_HTML}
+
+  <!-- ===== PAGE HEADER ===== -->
+  <header class="page-header">
+    <div class="wrap">
+      <div class="page-eyebrow">
+        <span>Specification · v1</span>
+        <span class="rule-line" aria-hidden="true"></span>
+        <span>Draft · 2026-04-17</span>
+      </div>
+      <h1 class="page-heading">
+        ROBOT<span style="color:var(--accent)">.</span><span style="font-family:var(--serif);font-weight:400;font-style:italic;color:var(--ink-3)">md</span>
+        <b>Format</b> Specification
+      </h1>
+      <p class="page-lede">
+        One file — YAML frontmatter + markdown prose — so a planning LLM can
+        safely operate a single robot. Validated against a JSON Schema.
+        Conformant with RCAN 3.0+.
+      </p>
+    </div>
+  </header>
+
+  <!-- ===== TWO-COLUMN LAYOUT ===== -->
+  <div class="wrap">
+    <div class="spec-layout">
+
+      <!-- ---- SIDEBAR ---- -->
+      <aside class="spec-sidebar" aria-label="Spec navigation">
+
+        <div class="sidebar-label">Spec versions</div>
+        <div class="ver-block">
+          <div class="ver-current">
+            <span>v1</span>
+            <span class="ver-badge">Current</span>
+          </div>
+          <ul>
+            <li><a href="/spec/v0.2-design.md">v0.2-design (historical)</a></li>
+            <li><a href="/spec/v0.1-mcp-design.md">v0.1-mcp-design (historical)</a></li>
+          </ul>
+        </div>
+
+        <div class="sidebar-label">On this page</div>
+        <nav class="toc" aria-label="Table of contents">
+          <ul>
+{toc_html}
+          </ul>
+        </nav>
+
+        <a class="schema-link" href="/schema/v1/robot.schema.json">
+          JSON Schema v1 →
+        </a>
+
+        <div class="validate-hint">
+          Validate a local file:<br>
+          <code>robot-md validate ROBOT.md</code>
+        </div>
+
+      </aside>
+
+      <!-- ---- SPEC BODY ---- -->
+      <article class="spec-body" aria-label="ROBOT.md Format Specification v1">
+{body_html}
+      </article>
+
+    </div>
+  </div>
+
+  <!-- ===== FOOTER ===== -->
+{FOOTER_HTML}
+
+</body>
+
+</html>
+"""
+
+    html_path.write_text(page, encoding="utf-8")
+    print(f"Rendered {md_path} → {html_path} ({html_path.stat().st_size} bytes)")
+
+
+if __name__ == "__main__":
+    render(MD_SRC, HTML_OUT)

--- a/site/spec/index.html
+++ b/site/spec/index.html
@@ -337,25 +337,25 @@
         <div class="sidebar-label">On this page</div>
         <nav class="toc" aria-label="Table of contents">
           <ul>
-            <li><a href="#1-overview">1. Overview</a></li>
-            <li><a href="#2-file-structure">2. File structure</a></li>
-            <li><a href="#3-frontmatter-required-fields">3. Frontmatter — required fields</a></li>
-            <li class="toc-sub"><a href="#31-rcan_version-string-required">3.1 rcan_version (string, required)</a></li>
-            <li class="toc-sub"><a href="#32-metadata-map-required">3.2 metadata (map, required)</a></li>
-            <li class="toc-sub"><a href="#33-physics-map-required">3.3 physics (map, required)</a></li>
-            <li class="toc-sub"><a href="#34-drivers-array-required">3.4 drivers (array, required)</a></li>
-            <li class="toc-sub"><a href="#35-safety-map-required">3.5 safety (map, required)</a></li>
-            <li><a href="#4-frontmatter-conditionally-required">4. Frontmatter — conditionally required</a></li>
-            <li class="toc-sub"><a href="#41-capabilities-array-of-strings-required-if-physicsdof-0">4.1 capabilities (array of strings, required if physics.dof &gt; 0)</a></li>
-            <li class="toc-sub"><a href="#42-network-map-required-for-network-addressable-robots">4.2 network (map, required for network-addressable robots)</a></li>
-            <li class="toc-sub"><a href="#43-brain-map-required-if-the-robot-uses-an-llm-planner">4.3 brain (map, required if the robot uses an LLM planner)</a></li>
-            <li class="toc-sub"><a href="#44-compliance-map-required-for-eu-deployed-robots">4.4 compliance (map, required for EU-deployed robots)</a></li>
-            <li><a href="#5-body-required-sections">5. Body — required sections</a></li>
-            <li><a href="#6-body-planner-usage">6. Body — planner usage</a></li>
-            <li><a href="#7-extensions">7. Extensions</a></li>
-            <li><a href="#8-validation">8. Validation</a></li>
-            <li><a href="#9-versioning">9. Versioning</a></li>
-            <li><a href="#10-references">10. References</a></li>
+            <li><a href="#overview">1. Overview</a></li>
+            <li><a href="#file-structure">2. File structure</a></li>
+            <li><a href="#required-fields">3. Frontmatter — required fields</a></li>
+            <li class="toc-sub"><a href="#rcan-version">3.1 rcan_version (string, required)</a></li>
+            <li class="toc-sub"><a href="#metadata">3.2 metadata (map, required)</a></li>
+            <li class="toc-sub"><a href="#physics">3.3 physics (map, required)</a></li>
+            <li class="toc-sub"><a href="#drivers">3.4 drivers (array, required)</a></li>
+            <li class="toc-sub"><a href="#safety">3.5 safety (map, required)</a></li>
+            <li><a href="#conditional-fields">4. Frontmatter — conditionally required</a></li>
+            <li class="toc-sub"><a href="#capabilities">4.1 capabilities (array of strings, required if physics.dof &gt; 0)</a></li>
+            <li class="toc-sub"><a href="#network">4.2 network (map, required for network-addressable robots)</a></li>
+            <li class="toc-sub"><a href="#brain">4.3 brain (map, required if the robot uses an LLM planner)</a></li>
+            <li class="toc-sub"><a href="#compliance">4.4 compliance (map, required for EU-deployed robots)</a></li>
+            <li><a href="#body-required">5. Body — required sections</a></li>
+            <li><a href="#body-planner">6. Body — planner usage</a></li>
+            <li><a href="#extensions">7. Extensions</a></li>
+            <li><a href="#validation">8. Validation</a></li>
+            <li><a href="#versioning">9. Versioning</a></li>
+            <li><a href="#references">10. References</a></li>
           </ul>
         </nav>
 
@@ -376,7 +376,7 @@
 <strong>Date:</strong> 2026-04-17
 <strong>Authors:</strong> craigm26 et al.
 <strong>License:</strong> Apache-2.0 (same as repo)</p>
-<h2 id="1-overview">1. Overview</h2>
+<h2 id="overview">1. Overview</h2>
 <p><code>ROBOT.md</code> is a single file that declares what a robot <strong>is</strong> and what it <strong>can do</strong>, in a form that both machines (JSON Schema + RCAN validators) and LLM planners (Claude Opus 4.7, Sonnet, etc.) can consume directly.</p>
 <p>The file is markdown with a leading YAML frontmatter block:</p>
 <ul>
@@ -384,7 +384,7 @@
 <li>The <strong>body</strong> is human/LLM prose: identity narrative, capabilities explained, safety gates described, task-routing guidance. Read by the planner at session start.</li>
 </ul>
 <p>This parallels <code>CLAUDE.md</code>'s role for codebases: a single file, read at session start, that orients the planner.</p>
-<h2 id="2-file-structure">2. File structure</h2>
+<h2 id="file-structure">2. File structure</h2>
 <pre><code>---
 &lt;YAML frontmatter&gt;
 ---
@@ -392,8 +392,8 @@
 &lt;Markdown body&gt;
 </code></pre>
 <p>The frontmatter delimiters MUST be exactly three hyphens (<code>---</code>) on their own lines. The frontmatter MUST be valid YAML 1.1 (compatible with PyYAML <code>safe_load</code>). The body MAY be empty but MUST be present (at minimum a single <code># &lt;robot_name&gt;</code> H1).</p>
-<h2 id="3-frontmatter-required-fields">3. Frontmatter — required fields</h2>
-<h3 id="31-rcan_version-string-required">3.1 <code>rcan_version</code> (string, required)</h3>
+<h2 id="required-fields">3. Frontmatter — required fields</h2>
+<h3 id="rcan-version">3.1 <code>rcan_version</code> (string, required)</h3>
 <p>The RCAN protocol version this ROBOT.md conforms to. MUST be one of:</p>
 <ul>
 <li><code>"3.0"</code> — current (recommended)</li>
@@ -401,7 +401,7 @@
 <li>Future <code>3.x</code> versions (forward-compatible per <code>castor.compliance.is_accepted_version</code>)</li>
 </ul>
 <p>Rejected: <code>"1.x"</code> (EU AI Act compliance gap; ROBOT.md requires v2.1+).</p>
-<h3 id="32-metadata-map-required">3.2 <code>metadata</code> (map, required)</h3>
+<h3 id="metadata">3.2 <code>metadata</code> (map, required)</h3>
 <table>
 <thead>
 <tr>
@@ -462,7 +462,7 @@
 </tr>
 </tbody>
 </table>
-<h3 id="33-physics-map-required">3.3 <code>physics</code> (map, required)</h3>
+<h3 id="physics">3.3 <code>physics</code> (map, required)</h3>
 <table>
 <thead>
 <tr>
@@ -499,7 +499,7 @@
   limits_deg: [min, max]   # or limits_mm for prismatic joints
   length_mm: 60            # link length downstream of this joint
 </code></pre>
-<h3 id="34-drivers-array-required">3.4 <code>drivers</code> (array, required)</h3>
+<h3 id="drivers">3.4 <code>drivers</code> (array, required)</h3>
 <p>A list of hardware drivers the robot uses. At least one entry is required. Each driver declares <code>id</code> and <code>protocol</code>; additional fields are protocol-specific.</p>
 <pre><code class="language-yaml">drivers:
   - id: arm_servos
@@ -513,7 +513,7 @@
     model: OAK-D
 </code></pre>
 <p>Recognized protocols match <code>castor.drivers.&lt;name&gt;</code> in OpenCastor (full list: <code>spec/rationale.md</code>).</p>
-<h3 id="35-safety-map-required">3.5 <code>safety</code> (map, required)</h3>
+<h3 id="safety">3.5 <code>safety</code> (map, required)</h3>
 <table>
 <thead>
 <tr>
@@ -575,8 +575,8 @@
   response_ms: 100          # time from trigger to motion-halt
 </code></pre>
 <p>At minimum, <code>software: true</code> with <code>response_ms</code> is required.</p>
-<h2 id="4-frontmatter-conditionally-required">4. Frontmatter — conditionally required</h2>
-<h3 id="41-capabilities-array-of-strings-required-if-physicsdof-0">4.1 <code>capabilities</code> (array of strings, required if <code>physics.dof &gt; 0</code>)</h3>
+<h2 id="conditional-fields">4. Frontmatter — conditionally required</h2>
+<h3 id="capabilities">4.1 <code>capabilities</code> (array of strings, required if <code>physics.dof &gt; 0</code>)</h3>
 <p>Named skills the robot exposes. Each name SHOULD map to a skill registered in the deploying runtime's <code>SkillRegistry</code>. Standard namespaces:</p>
 <ul>
 <li><code>nav.*</code> — navigation (move, stop, go_to)</li>
@@ -586,7 +586,7 @@
 <li><code>system.*</code> — lifecycle (shutdown, reboot, calibrate)</li>
 </ul>
 <p>Vendor-specific skills MAY use their own namespace (e.g., <code>bosdyn.crouch</code>).</p>
-<h3 id="42-network-map-required-for-network-addressable-robots">4.2 <code>network</code> (map, required for network-addressable robots)</h3>
+<h3 id="network">4.2 <code>network</code> (map, required for network-addressable robots)</h3>
 <table>
 <thead>
 <tr>
@@ -618,7 +618,7 @@
 </tr>
 </tbody>
 </table>
-<h3 id="43-brain-map-required-if-the-robot-uses-an-llm-planner">4.3 <code>brain</code> (map, required if the robot uses an LLM planner)</h3>
+<h3 id="brain">4.3 <code>brain</code> (map, required if the robot uses an LLM planner)</h3>
 <table>
 <thead>
 <tr>
@@ -660,7 +660,7 @@
     navigation: periodic
     reasoning: planner
 </code></pre>
-<h3 id="44-compliance-map-required-for-eu-deployed-robots">4.4 <code>compliance</code> (map, required for EU-deployed robots)</h3>
+<h3 id="compliance">4.4 <code>compliance</code> (map, required for EU-deployed robots)</h3>
 <table>
 <thead>
 <tr>
@@ -687,7 +687,7 @@
 </tr>
 </tbody>
 </table>
-<h2 id="5-body-required-sections">5. Body — required sections</h2>
+<h2 id="body-required">5. Body — required sections</h2>
 <p>The markdown body MUST contain:</p>
 <ol>
 <li><code># &lt;metadata.robot_name&gt;</code> — H1 matching <code>metadata.robot_name</code> (case-insensitive)</li>
@@ -701,7 +701,7 @@
 <li><code>## Extension Points</code> — how to add skills/drivers</li>
 <li><code>## References</code> — links to spec, runtime, RRF entry</li>
 </ul>
-<h2 id="6-body-planner-usage">6. Body — planner usage</h2>
+<h2 id="body-planner">6. Body — planner usage</h2>
 <p>A Claude session with this ROBOT.md in context at startup is expected to:</p>
 <ol>
 <li>Cite the robot by name in its first response</li>
@@ -710,7 +710,7 @@
 <li>Refuse capabilities NOT listed in <code>capabilities[]</code></li>
 <li>Honor <code>compliance</code> flags (e.g., extra caution for <code>eu_ai_act.audit_retention_days &gt; 0</code>)</li>
 </ol>
-<h2 id="7-extensions">7. Extensions</h2>
+<h2 id="extensions">7. Extensions</h2>
 <p>Vendor-specific extensions MUST use the <code>extensions:</code> block with namespaced keys:</p>
 <pre><code class="language-yaml">extensions:
   x-opencastor:
@@ -719,7 +719,7 @@
     spot_config_version: &quot;3.2&quot;
 </code></pre>
 <p>Unknown <code>extensions.x-*</code> keys MUST NOT cause validation failure.</p>
-<h2 id="8-validation">8. Validation</h2>
+<h2 id="validation">8. Validation</h2>
 <p>A ROBOT.md is <strong>valid</strong> if and only if:</p>
 <ol>
 <li>Frontmatter parses as YAML without error</li>
@@ -736,14 +736,14 @@
 <li><code>3</code> — RCAN conformance violation</li>
 <li><code>4</code> — missing required body section</li>
 </ul>
-<h2 id="9-versioning">9. Versioning</h2>
+<h2 id="versioning">9. Versioning</h2>
 <p>The spec version is <code>v1</code>. Future versions:</p>
 <ul>
 <li><code>v1.x</code> — backward-compatible additions (new optional fields, new optional sections)</li>
 <li><code>v2</code> — breaking changes (field renames, required→optional changes that affect validation)</li>
 </ul>
 <p>Breaking changes live at a new schema URL (<code>schema/v2/robot.schema.json</code>) and the spec file is renamed accordingly. Both served indefinitely.</p>
-<h2 id="10-references">10. References</h2>
+<h2 id="references">10. References</h2>
 <ul>
 <li>RCAN protocol: <a href="https://rcan.dev/spec/">https://rcan.dev/spec/</a></li>
 <li>Robot Registry Foundation: <a href="https://robotregistryfoundation.org/">https://robotregistryfoundation.org/</a></li>

--- a/site/spec/index.html
+++ b/site/spec/index.html
@@ -271,48 +271,6 @@
       border-radius: 2px;
     }
     .spec-body tr:last-child td { border-bottom: none }
-
-    .spec-body .req-icon { color: var(--ok); font-size: 13px }
-
-    .exit-codes {
-      display: grid;
-      grid-template-columns: 60px 1fr;
-      gap: 0;
-      border: 1px solid var(--rule);
-      overflow: hidden;
-      margin: 12px 0 20px;
-    }
-    .exit-codes .ec-row {
-      display: contents;
-    }
-    .exit-codes .ec-code {
-      font-family: var(--mono);
-      font-size: 14px;
-      font-weight: 600;
-      padding: 10px 14px;
-      border-bottom: 1px solid var(--rule);
-      border-right: 1px solid var(--rule);
-      background: var(--paper-2);
-      color: var(--accent-ink);
-    }
-    .exit-codes .ec-desc {
-      font-size: 13.5px;
-      padding: 10px 14px;
-      border-bottom: 1px solid var(--rule);
-      color: var(--ink-2);
-    }
-    .exit-codes .ec-code:last-of-type,
-    .exit-codes .ec-desc:last-of-type { border-bottom: none }
-
-    .spec-note {
-      background: var(--accent-wash);
-      border-left: 3px solid var(--accent);
-      padding: 12px 16px;
-      font-size: 13.5px;
-      color: var(--ink-2);
-      margin: 12px 0 20px;
-      line-height: 1.55;
-    }
   </style>
 </head>
 
@@ -326,7 +284,7 @@
       </a>
       <nav aria-label="Site navigation">
         <a href="/spec/" class="current" aria-current="page">Spec</a>
-        <a href="/agents/claude-code/">Agents</a>
+        <a href="/agents/">Agents</a>
         <a href="/mcp/">MCP</a>
         <a href="/registry/">Registry</a>
         <a href="/compliance/">Compliance</a>
@@ -379,25 +337,25 @@
         <div class="sidebar-label">On this page</div>
         <nav class="toc" aria-label="Table of contents">
           <ul>
-            <li><a href="#overview">1. Overview</a></li>
-            <li><a href="#file-structure">2. File structure</a></li>
-            <li><a href="#required-fields">3. Required fields</a></li>
-            <li class="toc-sub"><a href="#rcan-version">3.1 rcan_version</a></li>
-            <li class="toc-sub"><a href="#metadata">3.2 metadata</a></li>
-            <li class="toc-sub"><a href="#physics">3.3 physics</a></li>
-            <li class="toc-sub"><a href="#drivers">3.4 drivers</a></li>
-            <li class="toc-sub"><a href="#safety">3.5 safety</a></li>
-            <li><a href="#conditional-fields">4. Conditional fields</a></li>
-            <li class="toc-sub"><a href="#capabilities">4.1 capabilities</a></li>
-            <li class="toc-sub"><a href="#network">4.2 network</a></li>
-            <li class="toc-sub"><a href="#brain">4.3 brain</a></li>
-            <li class="toc-sub"><a href="#compliance">4.4 compliance</a></li>
-            <li><a href="#body-required">5. Body — required sections</a></li>
-            <li><a href="#body-planner">6. Body — planner usage</a></li>
-            <li><a href="#extensions">7. Extensions</a></li>
-            <li><a href="#validation">8. Validation</a></li>
-            <li><a href="#versioning">9. Versioning</a></li>
-            <li><a href="#references">10. References</a></li>
+            <li><a href="#1-overview">1. Overview</a></li>
+            <li><a href="#2-file-structure">2. File structure</a></li>
+            <li><a href="#3-frontmatter-required-fields">3. Frontmatter — required fields</a></li>
+            <li class="toc-sub"><a href="#31-rcan_version-string-required">3.1 rcan_version (string, required)</a></li>
+            <li class="toc-sub"><a href="#32-metadata-map-required">3.2 metadata (map, required)</a></li>
+            <li class="toc-sub"><a href="#33-physics-map-required">3.3 physics (map, required)</a></li>
+            <li class="toc-sub"><a href="#34-drivers-array-required">3.4 drivers (array, required)</a></li>
+            <li class="toc-sub"><a href="#35-safety-map-required">3.5 safety (map, required)</a></li>
+            <li><a href="#4-frontmatter-conditionally-required">4. Frontmatter — conditionally required</a></li>
+            <li class="toc-sub"><a href="#41-capabilities-array-of-strings-required-if-physicsdof-0">4.1 capabilities (array of strings, required if physics.dof &gt; 0)</a></li>
+            <li class="toc-sub"><a href="#42-network-map-required-for-network-addressable-robots">4.2 network (map, required for network-addressable robots)</a></li>
+            <li class="toc-sub"><a href="#43-brain-map-required-if-the-robot-uses-an-llm-planner">4.3 brain (map, required if the robot uses an LLM planner)</a></li>
+            <li class="toc-sub"><a href="#44-compliance-map-required-for-eu-deployed-robots">4.4 compliance (map, required for EU-deployed robots)</a></li>
+            <li><a href="#5-body-required-sections">5. Body — required sections</a></li>
+            <li><a href="#6-body-planner-usage">6. Body — planner usage</a></li>
+            <li><a href="#7-extensions">7. Extensions</a></li>
+            <li><a href="#8-validation">8. Validation</a></li>
+            <li><a href="#9-versioning">9. Versioning</a></li>
+            <li><a href="#10-references">10. References</a></li>
           </ul>
         </nav>
 
@@ -414,91 +372,136 @@
 
       <!-- ---- SPEC BODY ---- -->
       <article class="spec-body" aria-label="ROBOT.md Format Specification v1">
-
-        <h2 id="overview">1. Overview</h2>
-        <p>
-          <code>ROBOT.md</code> is a single file that declares what a robot <strong>is</strong>
-          and what it <strong>can do</strong>, in a form that both machines
-          (JSON Schema + RCAN validators) and LLM planners
-          (Claude Opus 4.7, Sonnet, etc.) can consume directly.
-        </p>
-        <p>The file is markdown with a leading YAML frontmatter block:</p>
-        <ul>
-          <li>The <strong>frontmatter</strong> is the machine-readable declaration: identity, physics,
-              drivers, safety, capabilities, compliance. Validated against
-              <a href="/schema/v1/robot.schema.json"><code>schema/v1/robot.schema.json</code></a>.</li>
-          <li>The <strong>body</strong> is human/LLM prose: identity narrative, capabilities explained,
-              safety gates described, task-routing guidance. Read by the planner at session start.</li>
-        </ul>
-        <p>
-          This parallels <code>CLAUDE.md</code>'s role for codebases: a single file, read at session
-          start, that orients the planner.
-        </p>
-
-        <h2 id="file-structure">2. File structure</h2>
-        <pre><code>---
+<p><strong>Status:</strong> Draft (v0.1)
+<strong>Date:</strong> 2026-04-17
+<strong>Authors:</strong> craigm26 et al.
+<strong>License:</strong> Apache-2.0 (same as repo)</p>
+<h2 id="1-overview">1. Overview</h2>
+<p><code>ROBOT.md</code> is a single file that declares what a robot <strong>is</strong> and what it <strong>can do</strong>, in a form that both machines (JSON Schema + RCAN validators) and LLM planners (Claude Opus 4.7, Sonnet, etc.) can consume directly.</p>
+<p>The file is markdown with a leading YAML frontmatter block:</p>
+<ul>
+<li>The <strong>frontmatter</strong> is the machine-readable declaration: identity, physics, drivers, safety, capabilities, compliance. Validated against <code>schema/v1/robot.schema.json</code>.</li>
+<li>The <strong>body</strong> is human/LLM prose: identity narrative, capabilities explained, safety gates described, task-routing guidance. Read by the planner at session start.</li>
+</ul>
+<p>This parallels <code>CLAUDE.md</code>'s role for codebases: a single file, read at session start, that orients the planner.</p>
+<h2 id="2-file-structure">2. File structure</h2>
+<pre><code>---
 &lt;YAML frontmatter&gt;
 ---
 
-&lt;Markdown body&gt;</code></pre>
-        <p>
-          The frontmatter delimiters MUST be exactly three hyphens (<code>---</code>) on their own lines.
-          The frontmatter MUST be valid YAML 1.1 (compatible with PyYAML <code>safe_load</code>).
-          The body MAY be empty but MUST be present (at minimum a single <code># &lt;robot_name&gt;</code> H1).
-        </p>
-
-        <h2 id="required-fields">3. Frontmatter — required fields</h2>
-
-        <h3 id="rcan-version">3.1 <code>rcan_version</code> <small style="font-size:11px;color:var(--ink-4);font-family:var(--mono)">(string, required)</small></h3>
-        <p>The RCAN protocol version this ROBOT.md conforms to. MUST be one of:</p>
-        <ul>
-          <li><code>"3.0"</code> — current (recommended)</li>
-          <li><code>"2.2"</code>, <code>"2.1"</code> — accepted via OpenCastor compatibility mode but operators should migrate</li>
-          <li>Future <code>3.x</code> versions (forward-compatible per <code>castor.compliance.is_accepted_version</code>)</li>
-        </ul>
-        <p>Rejected: <code>"1.x"</code> (EU AI Act compliance gap; ROBOT.md requires v2.1+).</p>
-
-        <h3 id="metadata">3.2 <code>metadata</code> <small style="font-size:11px;color:var(--ink-4);font-family:var(--mono)">(map, required)</small></h3>
-        <table>
-          <thead>
-            <tr><th>Field</th><th>Type</th><th>Required</th><th>Description</th></tr>
-          </thead>
-          <tbody>
-            <tr><td><code>robot_name</code></td><td>string</td><td><span class="req-icon">✅</span></td><td>Short display name (e.g., <code>bob</code>)</td></tr>
-            <tr><td><code>rrn</code></td><td>string</td><td>recommended</td><td>RRF-assigned RRN, or empty string until registered</td></tr>
-            <tr><td><code>rrn_uri</code></td><td>string</td><td>recommended</td><td>Canonical URI form of the RRN</td></tr>
-            <tr><td><code>ruri</code></td><td>string</td><td>recommended</td><td>Gateway URL (e.g., <code>rcan://robot.local:8001/bob</code>)</td></tr>
-            <tr><td><code>manufacturer</code></td><td>string</td><td>optional</td><td>Vendor or operator</td></tr>
-            <tr><td><code>model</code></td><td>string</td><td>optional</td><td>Model identifier</td></tr>
-            <tr><td><code>version</code></td><td>string</td><td>optional</td><td>Firmware/deployment version</td></tr>
-            <tr><td><code>license</code></td><td>string</td><td>optional</td><td>SPDX license identifier</td></tr>
-          </tbody>
-        </table>
-
-        <h3 id="physics">3.3 <code>physics</code> <small style="font-size:11px;color:var(--ink-4);font-family:var(--mono)">(map, required)</small></h3>
-        <table>
-          <thead>
-            <tr><th>Field</th><th>Type</th><th>Required</th><th>Description</th></tr>
-          </thead>
-          <tbody>
-            <tr><td><code>type</code></td><td>string</td><td><span class="req-icon">✅</span></td><td><code>arm</code> | <code>wheeled</code> | <code>tracked</code> | <code>legged</code> | <code>arm+camera</code> | <code>humanoid</code> | <code>other</code></td></tr>
-            <tr><td><code>dof</code></td><td>int</td><td><span class="req-icon">✅</span></td><td>Degrees of freedom (0 for purely sensory robots)</td></tr>
-            <tr><td><code>kinematics</code></td><td>array</td><td>optional</td><td>Per-joint entries (required if <code>type</code> is arm-based and <code>dof &gt; 0</code>)</td></tr>
-          </tbody>
-        </table>
-        <p>Each kinematics entry:</p>
-        <pre><code>- id: shoulder_pan
+&lt;Markdown body&gt;
+</code></pre>
+<p>The frontmatter delimiters MUST be exactly three hyphens (<code>---</code>) on their own lines. The frontmatter MUST be valid YAML 1.1 (compatible with PyYAML <code>safe_load</code>). The body MAY be empty but MUST be present (at minimum a single <code># &lt;robot_name&gt;</code> H1).</p>
+<h2 id="3-frontmatter-required-fields">3. Frontmatter — required fields</h2>
+<h3 id="31-rcan_version-string-required">3.1 <code>rcan_version</code> (string, required)</h3>
+<p>The RCAN protocol version this ROBOT.md conforms to. MUST be one of:</p>
+<ul>
+<li><code>"3.0"</code> — current (recommended)</li>
+<li><code>"2.2"</code>, <code>"2.1"</code> — accepted via OpenCastor compatibility mode but operators should migrate</li>
+<li>Future <code>3.x</code> versions (forward-compatible per <code>castor.compliance.is_accepted_version</code>)</li>
+</ul>
+<p>Rejected: <code>"1.x"</code> (EU AI Act compliance gap; ROBOT.md requires v2.1+).</p>
+<h3 id="32-metadata-map-required">3.2 <code>metadata</code> (map, required)</h3>
+<table>
+<thead>
+<tr>
+<th>Field</th>
+<th>Type</th>
+<th>Required</th>
+<th>Description</th>
+</tr>
+</thead>
+<tbody>
+<tr>
+<td><code>robot_name</code></td>
+<td>string</td>
+<td>✅</td>
+<td>Short display name (e.g., <code>bob</code>)</td>
+</tr>
+<tr>
+<td><code>rrn</code></td>
+<td>string</td>
+<td>recommended</td>
+<td>RRF-assigned RRN, or empty string until registered</td>
+</tr>
+<tr>
+<td><code>rrn_uri</code></td>
+<td>string</td>
+<td>recommended</td>
+<td>Canonical URI form of the RRN</td>
+</tr>
+<tr>
+<td><code>ruri</code></td>
+<td>string</td>
+<td>recommended</td>
+<td>Gateway URL (e.g., <code>rcan://robot.local:8001/bob</code>)</td>
+</tr>
+<tr>
+<td><code>manufacturer</code></td>
+<td>string</td>
+<td>optional</td>
+<td>Vendor or operator</td>
+</tr>
+<tr>
+<td><code>model</code></td>
+<td>string</td>
+<td>optional</td>
+<td>Model identifier</td>
+</tr>
+<tr>
+<td><code>version</code></td>
+<td>string</td>
+<td>optional</td>
+<td>Firmware/deployment version</td>
+</tr>
+<tr>
+<td><code>license</code></td>
+<td>string</td>
+<td>optional</td>
+<td>SPDX license identifier</td>
+</tr>
+</tbody>
+</table>
+<h3 id="33-physics-map-required">3.3 <code>physics</code> (map, required)</h3>
+<table>
+<thead>
+<tr>
+<th>Field</th>
+<th>Type</th>
+<th>Required</th>
+<th>Description</th>
+</tr>
+</thead>
+<tbody>
+<tr>
+<td><code>type</code></td>
+<td>string</td>
+<td>✅</td>
+<td><code>arm</code> | <code>wheeled</code> | <code>tracked</code> | <code>legged</code> | <code>arm+camera</code> | <code>humanoid</code> | <code>other</code></td>
+</tr>
+<tr>
+<td><code>dof</code></td>
+<td>int</td>
+<td>✅</td>
+<td>Degrees of freedom (0 for purely sensory robots)</td>
+</tr>
+<tr>
+<td><code>kinematics</code></td>
+<td>array</td>
+<td>optional</td>
+<td>Per-joint entries (required if <code>type</code> is arm-based and <code>dof &gt; 0</code>)</td>
+</tr>
+</tbody>
+</table>
+<p>Each kinematics entry:</p>
+<pre><code class="language-yaml">- id: shoulder_pan
   axis: x | y | z
   limits_deg: [min, max]   # or limits_mm for prismatic joints
-  length_mm: 60            # link length downstream of this joint</code></pre>
-
-        <h3 id="drivers">3.4 <code>drivers</code> <small style="font-size:11px;color:var(--ink-4);font-family:var(--mono)">(array, required)</small></h3>
-        <p>
-          A list of hardware drivers the robot uses. At least one entry is required.
-          Each driver declares <code>id</code> and <code>protocol</code>;
-          additional fields are protocol-specific.
-        </p>
-        <pre><code>drivers:
+  length_mm: 60            # link length downstream of this joint
+</code></pre>
+<h3 id="34-drivers-array-required">3.4 <code>drivers</code> (array, required)</h3>
+<p>A list of hardware drivers the robot uses. At least one entry is required. Each driver declares <code>id</code> and <code>protocol</code>; additional fields are protocol-specific.</p>
+<pre><code class="language-yaml">drivers:
   - id: arm_servos
     protocol: feetech       # feetech | dynamixel | pca9685 | gpio | ros2 | ...
     port: /dev/ttyUSB0
@@ -507,72 +510,143 @@
     count: 6
   - id: camera
     protocol: depthai
-    model: OAK-D</code></pre>
-        <p>Recognized protocols match <code>castor.drivers.&lt;name&gt;</code> in OpenCastor.</p>
-
-        <h3 id="safety">3.5 <code>safety</code> <small style="font-size:11px;color:var(--ink-4);font-family:var(--mono)">(map, required)</small></h3>
-        <table>
-          <thead>
-            <tr><th>Field</th><th>Type</th><th>Required</th><th>Description</th></tr>
-          </thead>
-          <tbody>
-            <tr><td><code>p66_enabled</code></td><td>bool</td><td>recommended</td><td>P66 safety manifest active</td></tr>
-            <tr><td><code>loa_enforcement</code></td><td>bool</td><td>recommended</td><td>RCAN Level-of-Assurance enforcement</td></tr>
-            <tr><td><code>max_joint_velocity_dps</code></td><td>number</td><td>if applicable</td><td>Max degrees/sec across all joints</td></tr>
-            <tr><td><code>max_linear_velocity_ms</code></td><td>number</td><td>if applicable</td><td>Max m/s (wheeled/tracked)</td></tr>
-            <tr><td><code>payload_kg</code></td><td>number</td><td>if applicable</td><td>Max payload</td></tr>
-            <tr><td><code>estop</code></td><td>map</td><td><span class="req-icon">✅</span></td><td>E-stop configuration</td></tr>
-            <tr><td><code>hitl_gates</code></td><td>array</td><td>recommended</td><td>Human-in-the-loop gate scopes</td></tr>
-          </tbody>
-        </table>
-        <p>The <code>estop</code> map:</p>
-        <pre><code>estop:
+    model: OAK-D
+</code></pre>
+<p>Recognized protocols match <code>castor.drivers.&lt;name&gt;</code> in OpenCastor (full list: <code>spec/rationale.md</code>).</p>
+<h3 id="35-safety-map-required">3.5 <code>safety</code> (map, required)</h3>
+<table>
+<thead>
+<tr>
+<th>Field</th>
+<th>Type</th>
+<th>Required</th>
+<th>Description</th>
+</tr>
+</thead>
+<tbody>
+<tr>
+<td><code>p66_enabled</code></td>
+<td>bool</td>
+<td>recommended</td>
+<td>P66 safety manifest active</td>
+</tr>
+<tr>
+<td><code>loa_enforcement</code></td>
+<td>bool</td>
+<td>recommended</td>
+<td>RCAN Level-of-Assurance enforcement</td>
+</tr>
+<tr>
+<td><code>max_joint_velocity_dps</code></td>
+<td>number</td>
+<td>if applicable</td>
+<td>Max degrees/sec across all joints</td>
+</tr>
+<tr>
+<td><code>max_linear_velocity_ms</code></td>
+<td>number</td>
+<td>if applicable</td>
+<td>Max m/s (wheeled/tracked)</td>
+</tr>
+<tr>
+<td><code>payload_kg</code></td>
+<td>number</td>
+<td>if applicable</td>
+<td>Max payload</td>
+</tr>
+<tr>
+<td><code>estop</code></td>
+<td>map</td>
+<td>✅</td>
+<td>E-stop configuration — see below</td>
+</tr>
+<tr>
+<td><code>hitl_gates</code></td>
+<td>array</td>
+<td>recommended</td>
+<td>Human-in-the-loop gate scopes</td>
+</tr>
+</tbody>
+</table>
+<p>The <code>estop</code> map:</p>
+<pre><code class="language-yaml">estop:
   hardware: false           # dedicated physical button?
   software: true            # software interrupt supported
-  response_ms: 100          # time from trigger to motion-halt</code></pre>
-        <p>At minimum, <code>software: true</code> with <code>response_ms</code> is required.</p>
-
-        <h2 id="conditional-fields">4. Frontmatter — conditionally required</h2>
-
-        <h3 id="capabilities">4.1 <code>capabilities</code> <small style="font-size:11px;color:var(--ink-4);font-family:var(--mono)">(array of strings, required if physics.dof &gt; 0)</small></h3>
-        <p>
-          Named skills the robot exposes. Each name SHOULD map to a skill registered in the
-          deploying runtime's <code>SkillRegistry</code>. Standard namespaces:
-        </p>
-        <ul>
-          <li><code>nav.*</code> — navigation (move, stop, go_to)</li>
-          <li><code>arm.*</code> — manipulation (pick, place, reach, grip)</li>
-          <li><code>vision.*</code> — perception (describe, detect, track)</li>
-          <li><code>status.*</code> — introspection (report, health)</li>
-          <li><code>system.*</code> — lifecycle (shutdown, reboot, calibrate)</li>
-        </ul>
-        <p>Vendor-specific skills MAY use their own namespace (e.g., <code>bosdyn.crouch</code>).</p>
-
-        <h3 id="network">4.2 <code>network</code> <small style="font-size:11px;color:var(--ink-4);font-family:var(--mono)">(map, required for network-addressable robots)</small></h3>
-        <table>
-          <thead>
-            <tr><th>Field</th><th>Type</th><th>Description</th></tr>
-          </thead>
-          <tbody>
-            <tr><td><code>rrf_endpoint</code></td><td>URL</td><td><code>https://robotregistryfoundation.org</code> or self-hosted RRF</td></tr>
-            <tr><td><code>port</code></td><td>int</td><td>Gateway port</td></tr>
-            <tr><td><code>signing_alg</code></td><td>string</td><td><code>pqc-hybrid-v1</code> (required at RCAN 3.0 L2+); <code>ml-dsa-65</code>; or <code>ed25519</code> (L1 only, sunset in 3.x)</td></tr>
-            <tr><td><code>transports</code></td><td>array</td><td><code>[http, mqtt, ws]</code> etc.</td></tr>
-          </tbody>
-        </table>
-
-        <h3 id="brain">4.3 <code>brain</code> <small style="font-size:11px;color:var(--ink-4);font-family:var(--mono)">(map, required if robot uses LLM planner)</small></h3>
-        <table>
-          <thead>
-            <tr><th>Field</th><th>Type</th><th>Description</th></tr>
-          </thead>
-          <tbody>
-            <tr><td><code>planning</code></td><td>map</td><td>LLM provider + model + confidence gate</td></tr>
-            <tr><td><code>reactive</code></td><td>map</td><td>Optional low-latency layer (e.g., VLA model)</td></tr>
-            <tr><td><code>task_routing</code></td><td>map</td><td>RCAN task-category routing overrides</td></tr>
-          </tbody>
-        </table>
-        <pre><code>brain:
+  response_ms: 100          # time from trigger to motion-halt
+</code></pre>
+<p>At minimum, <code>software: true</code> with <code>response_ms</code> is required.</p>
+<h2 id="4-frontmatter-conditionally-required">4. Frontmatter — conditionally required</h2>
+<h3 id="41-capabilities-array-of-strings-required-if-physicsdof-0">4.1 <code>capabilities</code> (array of strings, required if <code>physics.dof &gt; 0</code>)</h3>
+<p>Named skills the robot exposes. Each name SHOULD map to a skill registered in the deploying runtime's <code>SkillRegistry</code>. Standard namespaces:</p>
+<ul>
+<li><code>nav.*</code> — navigation (move, stop, go_to)</li>
+<li><code>arm.*</code> — manipulation (pick, place, reach, grip)</li>
+<li><code>vision.*</code> — perception (describe, detect, track)</li>
+<li><code>status.*</code> — introspection (report, health)</li>
+<li><code>system.*</code> — lifecycle (shutdown, reboot, calibrate)</li>
+</ul>
+<p>Vendor-specific skills MAY use their own namespace (e.g., <code>bosdyn.crouch</code>).</p>
+<h3 id="42-network-map-required-for-network-addressable-robots">4.2 <code>network</code> (map, required for network-addressable robots)</h3>
+<table>
+<thead>
+<tr>
+<th>Field</th>
+<th>Type</th>
+<th>Description</th>
+</tr>
+</thead>
+<tbody>
+<tr>
+<td><code>rrf_endpoint</code></td>
+<td>URL</td>
+<td><code>https://robotregistryfoundation.org</code> or self-hosted RRF</td>
+</tr>
+<tr>
+<td><code>port</code></td>
+<td>int</td>
+<td>Gateway port</td>
+</tr>
+<tr>
+<td><code>signing_alg</code></td>
+<td>string</td>
+<td><code>pqc-hybrid-v1</code> (required at RCAN 3.0 L2+); <code>ml-dsa-65</code>; or <code>ed25519</code> (L1 only, sunset in 3.x)</td>
+</tr>
+<tr>
+<td><code>transports</code></td>
+<td>array</td>
+<td><code>[http, mqtt, ws]</code> etc.</td>
+</tr>
+</tbody>
+</table>
+<h3 id="43-brain-map-required-if-the-robot-uses-an-llm-planner">4.3 <code>brain</code> (map, required if the robot uses an LLM planner)</h3>
+<table>
+<thead>
+<tr>
+<th>Field</th>
+<th>Type</th>
+<th>Description</th>
+</tr>
+</thead>
+<tbody>
+<tr>
+<td><code>planning</code></td>
+<td>map</td>
+<td>LLM provider + model + confidence gate</td>
+</tr>
+<tr>
+<td><code>reactive</code></td>
+<td>map</td>
+<td>Optional low-latency layer (e.g., VLA model)</td>
+</tr>
+<tr>
+<td><code>task_routing</code></td>
+<td>map</td>
+<td>RCAN task-category routing overrides</td>
+</tr>
+</tbody>
+</table>
+<p>Example:</p>
+<pre><code class="language-yaml">brain:
   planning:
     provider: anthropic
     model: claude-opus-4-7
@@ -584,94 +658,98 @@
     sensor_poll: fast_only
     safety: planner_always
     navigation: periodic
-    reasoning: planner</code></pre>
-
-        <h3 id="compliance">4.4 <code>compliance</code> <small style="font-size:11px;color:var(--ink-4);font-family:var(--mono)">(map, required for EU-deployed robots)</small></h3>
-        <table>
-          <thead>
-            <tr><th>Field</th><th>Type</th><th>Description</th></tr>
-          </thead>
-          <tbody>
-            <tr><td><code>fria_ref</code></td><td>URL or null</td><td>Signed FRIA document URI (RCAN §27). <code>null</code> = pending <code>castor fria generate</code>.</td></tr>
-            <tr><td><code>iso_42001</code></td><td>map</td><td><code>{ self_assessed: bool, level: 1-5 }</code></td></tr>
-            <tr><td><code>eu_ai_act</code></td><td>map</td><td><code>{ audit_retention_days: int }</code> (≥ 365 for Annex III systems)</td></tr>
-          </tbody>
-        </table>
-
-        <h2 id="body-required">5. Body — required sections</h2>
-        <p>The markdown body MUST contain:</p>
-        <ol>
-          <li><code># &lt;metadata.robot_name&gt;</code> — H1 matching <code>metadata.robot_name</code> (case-insensitive)</li>
-          <li><code>## Identity</code> — 1-2 paragraphs describing the robot</li>
-          <li><code>## What &lt;robot_name&gt; Can Do</code> — prose capability narrative</li>
-          <li><code>## Safety Gates</code> — which actions gated, how E-stop works</li>
-        </ol>
-        <p>Optional sections:</p>
-        <ul>
-          <li><code>## Task Routing</code> — expands on <code>brain.task_routing</code></li>
-          <li><code>## Extension Points</code> — how to add skills/drivers</li>
-          <li><code>## References</code> — links to spec, runtime, RRF entry</li>
-        </ul>
-
-        <h2 id="body-planner">6. Body — planner usage</h2>
-        <p>A Claude session with this ROBOT.md in context at startup is expected to:</p>
-        <ol>
-          <li>Cite the robot by name in its first response</li>
-          <li>Respect <code>safety.hitl_gates</code> without prompting</li>
-          <li>Route tasks according to <code>brain.task_routing</code></li>
-          <li>Refuse capabilities NOT listed in <code>capabilities[]</code></li>
-          <li>Honor <code>compliance</code> flags (e.g., extra caution for <code>eu_ai_act.audit_retention_days &gt; 0</code>)</li>
-        </ol>
-
-        <h2 id="extensions">7. Extensions</h2>
-        <p>
-          Vendor-specific extensions MUST use the <code>extensions:</code> block with namespaced keys:
-        </p>
-        <pre><code>extensions:
+    reasoning: planner
+</code></pre>
+<h3 id="44-compliance-map-required-for-eu-deployed-robots">4.4 <code>compliance</code> (map, required for EU-deployed robots)</h3>
+<table>
+<thead>
+<tr>
+<th>Field</th>
+<th>Type</th>
+<th>Description</th>
+</tr>
+</thead>
+<tbody>
+<tr>
+<td><code>fria_ref</code></td>
+<td>URL or null</td>
+<td>Signed Fundamental Rights Impact Assessment document URI (RCAN §27). <code>null</code> = placeholder pending <code>castor fria generate</code>.</td>
+</tr>
+<tr>
+<td><code>iso_42001</code></td>
+<td>map</td>
+<td><code>{ self_assessed: bool, level: 1-5 }</code></td>
+</tr>
+<tr>
+<td><code>eu_ai_act</code></td>
+<td>map</td>
+<td><code>{ audit_retention_days: int }</code> (≥ 365 for Annex III systems)</td>
+</tr>
+</tbody>
+</table>
+<h2 id="5-body-required-sections">5. Body — required sections</h2>
+<p>The markdown body MUST contain:</p>
+<ol>
+<li><code># &lt;metadata.robot_name&gt;</code> — H1 matching <code>metadata.robot_name</code> (case-insensitive)</li>
+<li><code>## Identity</code> — 1-2 paragraphs describing the robot</li>
+<li><code>## What &lt;robot_name&gt; Can Do</code> — prose capability narrative</li>
+<li><code>## Safety Gates</code> — which actions gated, how E-stop works</li>
+</ol>
+<p>Optional sections:</p>
+<ul>
+<li><code>## Task Routing</code> — expands on <code>brain.task_routing</code></li>
+<li><code>## Extension Points</code> — how to add skills/drivers</li>
+<li><code>## References</code> — links to spec, runtime, RRF entry</li>
+</ul>
+<h2 id="6-body-planner-usage">6. Body — planner usage</h2>
+<p>A Claude session with this ROBOT.md in context at startup is expected to:</p>
+<ol>
+<li>Cite the robot by name in its first response</li>
+<li>Respect <code>safety.hitl_gates</code> without prompting</li>
+<li>Route tasks according to <code>brain.task_routing</code></li>
+<li>Refuse capabilities NOT listed in <code>capabilities[]</code></li>
+<li>Honor <code>compliance</code> flags (e.g., extra caution for <code>eu_ai_act.audit_retention_days &gt; 0</code>)</li>
+</ol>
+<h2 id="7-extensions">7. Extensions</h2>
+<p>Vendor-specific extensions MUST use the <code>extensions:</code> block with namespaced keys:</p>
+<pre><code class="language-yaml">extensions:
   x-opencastor:
     harness_ref: /etc/opencastor/harness.yaml
   x-boston-dynamics:
-    spot_config_version: "3.2"</code></pre>
-        <p>Unknown <code>extensions.x-*</code> keys MUST NOT cause validation failure.</p>
-
-        <h2 id="validation">8. Validation</h2>
-        <p>A ROBOT.md is <strong>valid</strong> if and only if:</p>
-        <ol>
-          <li>Frontmatter parses as YAML without error</li>
-          <li>Frontmatter validates against <a href="/schema/v1/robot.schema.json"><code>schema/v1/robot.schema.json</code></a></li>
-          <li><code>rcan_version</code> passes <code>castor.compliance.is_accepted_version</code></li>
-          <li>Required body sections are present</li>
-          <li><code>capabilities</code> values match <code>nav.*</code>, <code>arm.*</code>, <code>vision.*</code>, <code>status.*</code>, <code>system.*</code>, or vendor <code>&lt;prefix&gt;.*</code> patterns</li>
-        </ol>
-        <p>The <code>robot-md validate</code> CLI returns exit codes:</p>
-        <div class="exit-codes" role="table" aria-label="robot-md validate exit codes">
-          <div class="ec-code" role="cell">0</div><div class="ec-desc" role="cell">Valid</div>
-          <div class="ec-code" role="cell">1</div><div class="ec-desc" role="cell">File not found or parse error</div>
-          <div class="ec-code" role="cell">2</div><div class="ec-desc" role="cell">Schema violation</div>
-          <div class="ec-code" role="cell">3</div><div class="ec-desc" role="cell">RCAN conformance violation</div>
-          <div class="ec-code" role="cell">4</div><div class="ec-desc" role="cell">Missing required body section</div>
-        </div>
-
-        <h2 id="versioning">9. Versioning</h2>
-        <p>The spec version is <strong>v1</strong>. Future versions:</p>
-        <ul>
-          <li><code>v1.x</code> — backward-compatible additions (new optional fields, new optional sections)</li>
-          <li><code>v2</code> — breaking changes (field renames, required→optional changes that affect validation)</li>
-        </ul>
-        <p>
-          Breaking changes live at a new schema URL (<code>schema/v2/robot.schema.json</code>)
-          and the spec file is renamed. Both served indefinitely.
-        </p>
-
-        <h2 id="references">10. References</h2>
-        <ul>
-          <li>RCAN protocol: <a href="https://rcan.dev/spec/">rcan.dev/spec/</a></li>
-          <li>Robot Registry Foundation: <a href="https://robotregistryfoundation.org/">robotregistryfoundation.org</a></li>
-          <li>OpenCastor runtime: <a href="https://github.com/craigm26/OpenCastor">github.com/craigm26/OpenCastor</a></li>
-          <li>JSON Schema spec: <a href="https://json-schema.org/draft/2020-12/">json-schema.org/draft/2020-12/</a></li>
-          <li>JSON Schema (this spec): <a href="/schema/v1/robot.schema.json">/schema/v1/robot.schema.json</a></li>
-        </ul>
-
+    spot_config_version: &quot;3.2&quot;
+</code></pre>
+<p>Unknown <code>extensions.x-*</code> keys MUST NOT cause validation failure.</p>
+<h2 id="8-validation">8. Validation</h2>
+<p>A ROBOT.md is <strong>valid</strong> if and only if:</p>
+<ol>
+<li>Frontmatter parses as YAML without error</li>
+<li>Frontmatter validates against <code>schema/v1/robot.schema.json</code></li>
+<li><code>rcan_version</code> passes <code>castor.compliance.is_accepted_version</code> (or equivalent — see rationale)</li>
+<li>Required body sections are present</li>
+<li><code>capabilities</code> values match <code>nav.*</code>, <code>arm.*</code>, <code>vision.*</code>, <code>status.*</code>, <code>system.*</code>, or vendor <code>&lt;prefix&gt;.*</code> patterns</li>
+</ol>
+<p>The <code>robot-md validate</code> CLI returns exit codes:</p>
+<ul>
+<li><code>0</code> — valid</li>
+<li><code>1</code> — file not found or parse error</li>
+<li><code>2</code> — schema violation</li>
+<li><code>3</code> — RCAN conformance violation</li>
+<li><code>4</code> — missing required body section</li>
+</ul>
+<h2 id="9-versioning">9. Versioning</h2>
+<p>The spec version is <code>v1</code>. Future versions:</p>
+<ul>
+<li><code>v1.x</code> — backward-compatible additions (new optional fields, new optional sections)</li>
+<li><code>v2</code> — breaking changes (field renames, required→optional changes that affect validation)</li>
+</ul>
+<p>Breaking changes live at a new schema URL (<code>schema/v2/robot.schema.json</code>) and the spec file is renamed accordingly. Both served indefinitely.</p>
+<h2 id="10-references">10. References</h2>
+<ul>
+<li>RCAN protocol: <a href="https://rcan.dev/spec/">https://rcan.dev/spec/</a></li>
+<li>Robot Registry Foundation: <a href="https://robotregistryfoundation.org/">https://robotregistryfoundation.org/</a></li>
+<li>OpenCastor runtime: <a href="https://github.com/craigm26/OpenCastor">https://github.com/craigm26/OpenCastor</a></li>
+<li>JSON Schema spec: <a href="https://json-schema.org/draft/2020-12/">https://json-schema.org/draft/2020-12/</a></li>
+</ul>
       </article>
 
     </div>

--- a/site/spec/v1.md
+++ b/site/spec/v1.md
@@ -5,7 +5,7 @@
 **Authors:** craigm26 et al.
 **License:** Apache-2.0 (same as repo)
 
-## 1. Overview
+## 1. Overview { #overview }
 
 `ROBOT.md` is a single file that declares what a robot **is** and what it **can do**, in a form that both machines (JSON Schema + RCAN validators) and LLM planners (Claude Opus 4.7, Sonnet, etc.) can consume directly.
 
@@ -16,7 +16,7 @@ The file is markdown with a leading YAML frontmatter block:
 
 This parallels `CLAUDE.md`'s role for codebases: a single file, read at session start, that orients the planner.
 
-## 2. File structure
+## 2. File structure { #file-structure }
 
 ```
 ---
@@ -28,9 +28,9 @@ This parallels `CLAUDE.md`'s role for codebases: a single file, read at session 
 
 The frontmatter delimiters MUST be exactly three hyphens (`---`) on their own lines. The frontmatter MUST be valid YAML 1.1 (compatible with PyYAML `safe_load`). The body MAY be empty but MUST be present (at minimum a single `# <robot_name>` H1).
 
-## 3. Frontmatter — required fields
+## 3. Frontmatter — required fields { #required-fields }
 
-### 3.1 `rcan_version` (string, required)
+### 3.1 `rcan_version` (string, required) { #rcan-version }
 
 The RCAN protocol version this ROBOT.md conforms to. MUST be one of:
 
@@ -40,7 +40,7 @@ The RCAN protocol version this ROBOT.md conforms to. MUST be one of:
 
 Rejected: `"1.x"` (EU AI Act compliance gap; ROBOT.md requires v2.1+).
 
-### 3.2 `metadata` (map, required)
+### 3.2 `metadata` (map, required) { #metadata }
 
 | Field | Type | Required | Description |
 |---|---|---|---|
@@ -53,7 +53,7 @@ Rejected: `"1.x"` (EU AI Act compliance gap; ROBOT.md requires v2.1+).
 | `version` | string | optional | Firmware/deployment version |
 | `license` | string | optional | SPDX license identifier |
 
-### 3.3 `physics` (map, required)
+### 3.3 `physics` (map, required) { #physics }
 
 | Field | Type | Required | Description |
 |---|---|---|---|
@@ -70,7 +70,7 @@ Each kinematics entry:
   length_mm: 60            # link length downstream of this joint
 ```
 
-### 3.4 `drivers` (array, required)
+### 3.4 `drivers` (array, required) { #drivers }
 
 A list of hardware drivers the robot uses. At least one entry is required. Each driver declares `id` and `protocol`; additional fields are protocol-specific.
 
@@ -89,7 +89,7 @@ drivers:
 
 Recognized protocols match `castor.drivers.<name>` in OpenCastor (full list: `spec/rationale.md`).
 
-### 3.5 `safety` (map, required)
+### 3.5 `safety` (map, required) { #safety }
 
 | Field | Type | Required | Description |
 |---|---|---|---|
@@ -112,9 +112,9 @@ estop:
 
 At minimum, `software: true` with `response_ms` is required.
 
-## 4. Frontmatter — conditionally required
+## 4. Frontmatter — conditionally required { #conditional-fields }
 
-### 4.1 `capabilities` (array of strings, required if `physics.dof > 0`)
+### 4.1 `capabilities` (array of strings, required if `physics.dof > 0`) { #capabilities }
 
 Named skills the robot exposes. Each name SHOULD map to a skill registered in the deploying runtime's `SkillRegistry`. Standard namespaces:
 
@@ -126,7 +126,7 @@ Named skills the robot exposes. Each name SHOULD map to a skill registered in th
 
 Vendor-specific skills MAY use their own namespace (e.g., `bosdyn.crouch`).
 
-### 4.2 `network` (map, required for network-addressable robots)
+### 4.2 `network` (map, required for network-addressable robots) { #network }
 
 | Field | Type | Description |
 |---|---|---|
@@ -135,7 +135,7 @@ Vendor-specific skills MAY use their own namespace (e.g., `bosdyn.crouch`).
 | `signing_alg` | string | `pqc-hybrid-v1` (required at RCAN 3.0 L2+); `ml-dsa-65`; or `ed25519` (L1 only, sunset in 3.x) |
 | `transports` | array | `[http, mqtt, ws]` etc. |
 
-### 4.3 `brain` (map, required if the robot uses an LLM planner)
+### 4.3 `brain` (map, required if the robot uses an LLM planner) { #brain }
 
 | Field | Type | Description |
 |---|---|---|
@@ -161,7 +161,7 @@ brain:
     reasoning: planner
 ```
 
-### 4.4 `compliance` (map, required for EU-deployed robots)
+### 4.4 `compliance` (map, required for EU-deployed robots) { #compliance }
 
 | Field | Type | Description |
 |---|---|---|
@@ -169,7 +169,7 @@ brain:
 | `iso_42001` | map | `{ self_assessed: bool, level: 1-5 }` |
 | `eu_ai_act` | map | `{ audit_retention_days: int }` (≥ 365 for Annex III systems) |
 
-## 5. Body — required sections
+## 5. Body — required sections { #body-required }
 
 The markdown body MUST contain:
 
@@ -184,7 +184,7 @@ Optional sections:
 - `## Extension Points` — how to add skills/drivers
 - `## References` — links to spec, runtime, RRF entry
 
-## 6. Body — planner usage
+## 6. Body — planner usage { #body-planner }
 
 A Claude session with this ROBOT.md in context at startup is expected to:
 
@@ -194,7 +194,7 @@ A Claude session with this ROBOT.md in context at startup is expected to:
 4. Refuse capabilities NOT listed in `capabilities[]`
 5. Honor `compliance` flags (e.g., extra caution for `eu_ai_act.audit_retention_days > 0`)
 
-## 7. Extensions
+## 7. Extensions { #extensions }
 
 Vendor-specific extensions MUST use the `extensions:` block with namespaced keys:
 
@@ -208,7 +208,7 @@ extensions:
 
 Unknown `extensions.x-*` keys MUST NOT cause validation failure.
 
-## 8. Validation
+## 8. Validation { #validation }
 
 A ROBOT.md is **valid** if and only if:
 
@@ -226,7 +226,7 @@ The `robot-md validate` CLI returns exit codes:
 - `3` — RCAN conformance violation
 - `4` — missing required body section
 
-## 9. Versioning
+## 9. Versioning { #versioning }
 
 The spec version is `v1`. Future versions:
 
@@ -235,7 +235,7 @@ The spec version is `v1`. Future versions:
 
 Breaking changes live at a new schema URL (`schema/v2/robot.schema.json`) and the spec file is renamed accordingly. Both served indefinitely.
 
-## 10. References
+## 10. References { #references }
 
 - RCAN protocol: <https://rcan.dev/spec/>
 - Robot Registry Foundation: <https://robotregistryfoundation.org/>


### PR DESCRIPTION
## Summary

Three follow-ups from the PR #34 review:

1. **Spec generator** (`site/scripts/render-spec.py`): Python script that renders `site/spec/v1.md` → `site/spec/index.html`. Wired into CI (`.github/workflows/deploy-site.yml`) before the "Inject build-time stats" step. Uses `markdown` library with `TocExtension`, `tables`, `fenced_code`, and `attr_list` extensions. All 19 original anchor IDs preserved via `{#slug}` annotations in `v1.md`.

2. **Agents hub page** (`site/agents/index.html`): Landing page at `/agents/` so the directory no longer 404s. Five surface cards (Claude Code, Gemini, Codex, ChatGPT, Amazon Q) with status badges, one-liner descriptions, and "Full guide →" links. "Don't see your surface?" section. Nav link on all pages updated from `/agents/claude-code/` → `/agents/`.

3. **Amazon Q surface page** (`site/agents/q/index.html`): Status badge `Pre-release · aarch64 blocked`. Explains the MCP blocker, documents the HTTP bridge fallback (`robot-md-http`), shows the future install snippet (no copy button, dashed border, reduced opacity). Capabilities table with Q CLI (MCP) + Q via HTTP bridge columns. Homepage Q card updated from "Planned" → "Pre-release" with link to `/agents/q/`.

Fixes anchor-ID regression (commit `fe48712`) before pushing.

## Related

- Closes follow-up items from PR #34

## Test plan

- [ ] `python3 site/scripts/render-spec.py` runs cleanly and produces idempotent output
- [ ] `site/spec/index.html` TOC links resolve (`#overview`, `#file-structure`, etc. — all 19 IDs intact)
- [ ] `/agents/` loads without 404
- [ ] `/agents/q/` loads; no copy button on the future install block
- [ ] Homepage Amazon Q card links to `/agents/q/` with "Pre-release" status
- [ ] All agent sub-pages include Amazon Q in the agent-nav bar
- [ ] CI step "Render spec from markdown" passes on GitHub Actions runner

🤖 Generated with [Claude Code](https://claude.com/claude-code)