### PR TITLE
fix(parser): accept directory paths, resolve to <dir>/ROBOT.md (#32)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,13 @@ Format follows [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 
 ---
 
+## [Unreleased]
+
+### Fixed
+- **`parse_file` now accepts directories** — `robot-md compliance status .`, `robot-md validate ./bob`, and every other CLI command that takes a manifest path now resolve a directory argument to `<dir>/ROBOT.md`. Previously raised `ParseError: Is a directory`. ([#32](https://github.com/RobotRegistryFoundation/robot-md/issues/32))
+
+---
+
 ## [1.4.0] — 2026-04-30
 
 **SP-HP hot-plug daemon + SP-AN announce/confirm + SP6 Phase 1 self-attestation.** Three independent feature tracks land together; together they change what registering a new piece of hardware feels like — OS-level event, conversational confirm in Claude, cryptographically self-attested eval scores.

--- a/cli/src/robot_md/parser.py
+++ b/cli/src/robot_md/parser.py
@@ -22,9 +22,23 @@ class ParsedRobotMd:
 
 
 def parse_file(path: Path | str) -> ParsedRobotMd:
-    """Parse a ROBOT.md file from disk."""
+    """Parse a ROBOT.md file from disk.
+
+    If `path` is a directory, resolves to ``<path>/ROBOT.md`` — so callers
+    can pass either an explicit manifest file or its containing directory.
+    This makes `robot-md compliance status .`, `robot-md validate ./bob`,
+    and similar invocations work as users naturally expect (issue #32).
+    """
     p = Path(path)
-    if not p.exists():
+    if p.is_dir():
+        candidate = p / "ROBOT.md"
+        if not candidate.exists():
+            raise ParseError(
+                f"no ROBOT.md found in directory {p} — pass the manifest path "
+                f"explicitly or `cd` into a directory containing one."
+            )
+        p = candidate
+    elif not p.exists():
         raise ParseError(f"file not found: {p}")
     try:
         text = p.read_text()

--- a/cli/tests/test_parser.py
+++ b/cli/tests/test_parser.py
@@ -99,7 +99,7 @@ def test_parse_dot_directory_resolves(tmp_path, monkeypatch):
 
 def test_parse_directory_without_robot_md_raises(tmp_path):
     """A directory with no ROBOT.md inside surfaces a clear error message."""
-    with pytest.raises(ParseError, match="ROBOT.md"):
+    with pytest.raises(ParseError, match=r"ROBOT\.md"):
         parse_file(tmp_path)
 
 

--- a/cli/tests/test_parser.py
+++ b/cli/tests/test_parser.py
@@ -70,12 +70,7 @@ def test_parse_text_has_no_source_path(fixtures_dir):
 def test_parse_directory_resolves_to_robot_md(tmp_path):
     """A directory containing ROBOT.md is accepted; parses the manifest inside."""
     (tmp_path / "ROBOT.md").write_text(
-        "---\n"
-        "rcan_version: '3.0'\n"
-        "metadata:\n"
-        "  robot_name: dirtest\n"
-        "---\n"
-        "# dirtest\n"
+        "---\nrcan_version: '3.0'\nmetadata:\n  robot_name: dirtest\n---\n# dirtest\n"
     )
     result = parse_file(tmp_path)
     assert result.frontmatter["metadata"]["robot_name"] == "dirtest"
@@ -85,12 +80,7 @@ def test_parse_directory_resolves_to_robot_md(tmp_path):
 def test_parse_dot_directory_resolves(tmp_path, monkeypatch):
     """`robot-md compliance status .` — the original failure mode in #32."""
     (tmp_path / "ROBOT.md").write_text(
-        "---\n"
-        "rcan_version: '3.0'\n"
-        "metadata:\n"
-        "  robot_name: dottest\n"
-        "---\n"
-        "# dottest\n"
+        "---\nrcan_version: '3.0'\nmetadata:\n  robot_name: dottest\n---\n# dottest\n"
     )
     monkeypatch.chdir(tmp_path)
     result = parse_file(Path("."))
@@ -107,12 +97,7 @@ def test_parse_explicit_file_in_directory_still_works(tmp_path):
     """Passing the explicit path inside a directory keeps working unchanged."""
     manifest = tmp_path / "ROBOT.md"
     manifest.write_text(
-        "---\n"
-        "rcan_version: '3.0'\n"
-        "metadata:\n"
-        "  robot_name: explicit\n"
-        "---\n"
-        "# explicit\n"
+        "---\nrcan_version: '3.0'\nmetadata:\n  robot_name: explicit\n---\n# explicit\n"
     )
     result = parse_file(manifest)
     assert result.frontmatter["metadata"]["robot_name"] == "explicit"

--- a/cli/tests/test_parser.py
+++ b/cli/tests/test_parser.py
@@ -58,3 +58,62 @@ def test_parse_text_has_no_source_path(fixtures_dir):
     path = fixtures_dir / "valid" / "minimal.ROBOT.md"
     result = parse_text(_read(path))
     assert result.source_path is None
+
+
+# ── Issue #32: directory paths resolve to <dir>/ROBOT.md ───────────────────
+# Every CLI command that takes a manifest path (compliance status, render,
+# emit-*, validate, ...) goes through parse_file. Pushing the dir→ROBOT.md
+# resolution here makes `robot-md compliance status .` and equivalents
+# work as users naturally expect.
+
+
+def test_parse_directory_resolves_to_robot_md(tmp_path):
+    """A directory containing ROBOT.md is accepted; parses the manifest inside."""
+    (tmp_path / "ROBOT.md").write_text(
+        "---\n"
+        "rcan_version: '3.0'\n"
+        "metadata:\n"
+        "  robot_name: dirtest\n"
+        "---\n"
+        "# dirtest\n"
+    )
+    result = parse_file(tmp_path)
+    assert result.frontmatter["metadata"]["robot_name"] == "dirtest"
+    assert result.source_path == tmp_path / "ROBOT.md"
+
+
+def test_parse_dot_directory_resolves(tmp_path, monkeypatch):
+    """`robot-md compliance status .` — the original failure mode in #32."""
+    (tmp_path / "ROBOT.md").write_text(
+        "---\n"
+        "rcan_version: '3.0'\n"
+        "metadata:\n"
+        "  robot_name: dottest\n"
+        "---\n"
+        "# dottest\n"
+    )
+    monkeypatch.chdir(tmp_path)
+    result = parse_file(Path("."))
+    assert result.frontmatter["metadata"]["robot_name"] == "dottest"
+
+
+def test_parse_directory_without_robot_md_raises(tmp_path):
+    """A directory with no ROBOT.md inside surfaces a clear error message."""
+    with pytest.raises(ParseError, match="ROBOT.md"):
+        parse_file(tmp_path)
+
+
+def test_parse_explicit_file_in_directory_still_works(tmp_path):
+    """Passing the explicit path inside a directory keeps working unchanged."""
+    manifest = tmp_path / "ROBOT.md"
+    manifest.write_text(
+        "---\n"
+        "rcan_version: '3.0'\n"
+        "metadata:\n"
+        "  robot_name: explicit\n"
+        "---\n"
+        "# explicit\n"
+    )
+    result = parse_file(manifest)
+    assert result.frontmatter["metadata"]["robot_name"] == "explicit"
+    assert result.source_path == manifest


### PR DESCRIPTION
## Summary

Closes #32. Push directory→ROBOT.md resolution into \`parser.parse_file\` so every CLI command that takes a manifest path (\`compliance status\`, \`validate\`, \`render\`, \`emit-*\`, ...) accepts \`.\` and other directory arguments without crashing.

## Behavior

| Input | Before | After |
|---|---|---|
| \`.\` (current dir with ROBOT.md) | \`ParseError: Is a directory\` | parses \`./ROBOT.md\` |
| \`./bob\` (dir with ROBOT.md inside) | \`ParseError: Is a directory\` | parses \`./bob/ROBOT.md\` |
| \`./bob\` (dir without ROBOT.md) | \`ParseError: Is a directory\` | \`ParseError: no ROBOT.md found in directory ./bob — pass the manifest path explicitly...\` |
| \`./ROBOT.md\` (explicit file) | works | works (unchanged) |
| \`./does-not-exist.md\` | \`ParseError: file not found\` | \`ParseError: file not found\` (unchanged) |

## Why \`parse_file\`, not \`compliance_status\`

The bug was first surfaced via \`robot-md compliance status .\` but every other CLI command (\`validate\`, \`render\`, \`emit-fria\`, \`emit-ifu\`, ...) routes through \`parse_file\` and would have hit the same shape on directory arguments. Fixing at the parser layer means a single change covers every caller — and matches the suggestion in the original issue (\"Or push the resolution into parse_file so all callers benefit\").

## Test plan

- [x] 4 new parser tests pin the directory-resolution behavior (covers happy path, \`.\` under chdir, dir-without-ROBOT.md error message, explicit-file unchanged).
- [x] Full parser + compliance test sweep: 56 passed.
- [x] Empirically verified on bob: \`robot-md compliance status .\` from \`~/bob\` no longer crashes; reports compliance status normally.

## CHANGELOG

Added an \`[Unreleased]\` entry under \`### Fixed\`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)