### PR TITLE
ci: emit version-tuple envelope on release (Plan 1 Task 6)

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -62,6 +62,21 @@ jobs:
           body: ${{ steps.tag.outputs.message }}
           generate_release_notes: true
           files: dist/*
+      - name: Set VERSION
+        run: echo "VERSION=${GITHUB_REF_NAME#v}" >> "$GITHUB_ENV"
+      - name: Emit version-tuple envelope
+        uses: continuonai/rcan-spec/.github/actions/emit-version-tuple@v3.2.0
+        with:
+          project: robot-md
+          ran: ${{ secrets.ROBOT_MD_RAN }}
+          field: cli_version
+          value: ${{ env.VERSION }}
+          depends_on: '{"protocol_version":">=3.2.0","manifest_spec_version":"==${{ env.VERSION }}"}'
+          pq_signing_key: ${{ secrets.ROBOT_MD_MLDSA65_PRIV }}
+          pq_kid: ${{ secrets.ROBOT_MD_PQ_KID }}
+          ed25519_signing_key: ${{ secrets.ROBOT_MD_ED25519_PRIV }}
+          ed25519_kid: ${{ secrets.ROBOT_MD_KID }}
+          release_tag: ${{ github.ref_name }}
 
   pypi-publish:
     # Manual-only. Trigger via "Release" workflow → Run workflow →


### PR DESCRIPTION
Adds the emit-version-tuple composite action step to robot-md's release workflow. After merge + next release, robot-md will produce a hybrid-signed `version-tuple-envelope.json` artifact attached to the release.

## What changed

Single file modified: `.github/workflows/release.yml`

Two steps appended to the `github-release` job (after "Create GitHub Release"):

1. **Set VERSION** — strips the leading `v` from `github.ref_name` (e.g. `v1.5.1` → `1.5.1`) so bare semver is used in the envelope.
2. **Emit version-tuple envelope** — calls `continuonai/rcan-spec/.github/actions/emit-version-tuple@v3.2.0`, attaches `version-tuple-envelope.json` to the GitHub release.

## Notes

- Action: `continuonai/rcan-spec/.github/actions/emit-version-tuple@v3.2.0`
- Signing identity: `RAN-000000000002` (per Plan 1 Task 5.5)
- `permissions: contents: write` was already set on the `github-release` job — no change needed
- `Set VERSION` shim required: tags follow `v*.*.*`; bare semver needed for `value` and `depends_on` constraint operators

## Validation

Validated end-to-end by no-op v1.5.1 release in Plan 1 Task 7.