### PR TITLE
chore(ci): bump emit-version-tuple to v3.2.3

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -69,7 +69,7 @@ jobs:
           MANIFEST_VERSION=$(cat cli/src/robot_md/schemas/v1/version.txt | tr -d '[:space:]')
           echo "MANIFEST_VERSION=$MANIFEST_VERSION" >> "$GITHUB_ENV"
       - name: Emit cli_version envelope
-        uses: continuonai/rcan-spec/.github/actions/emit-version-tuple@v3.2.1
+        uses: continuonai/rcan-spec/.github/actions/emit-version-tuple@v3.2.3
         with:
           project: robot-md
           ran: ${{ secrets.ROBOT_MD_RAN }}
@@ -82,7 +82,7 @@ jobs:
           ed25519_kid: ${{ secrets.ROBOT_MD_KID }}
           release_tag: ${{ github.ref_name }}
       - name: Emit manifest_spec_version envelope
-        uses: continuonai/rcan-spec/.github/actions/emit-version-tuple@v3.2.1
+        uses: continuonai/rcan-spec/.github/actions/emit-version-tuple@v3.2.3
         with:
           project: robot-md
           ran: ${{ secrets.ROBOT_MD_RAN }}


### PR DESCRIPTION
## Summary
- Bump `continuonai/rcan-spec/.github/actions/emit-version-tuple` pin from v3.2.1 to v3.2.3 (release.yml, both jobs).
- v3.2.3 (rcan-spec [PR #209](https://github.com/continuonai/rcan-spec/pull/209), `feb92cb`) adds `--repo "${{ github.repository }}"` to `gh release upload`, fixing the `fatal: not a git repository` failure in checkout-less publish jobs.
- Also rolls forward past v3.2.1 (pre-filename-namespacing) so the next robot-md release emits a matrix envelope with the v3.2.1+ namespaced shape.

## Test plan
- [ ] CI green on this PR
- [ ] Next robot-md release tag: emit-version-tuple step exits 0 and attaches the signed envelope to the release

🤖 Generated with [Claude Code](https://claude.com/claude-code)