### PR TITLE
docs(site): retire "reference implementation" framing + dispatcher→gateway rename + RCAN version pin (Plan 9 Phase 3)

### DIFF
--- a/site/index.html
+++ b/site/index.html
@@ -1252,15 +1252,15 @@ claude</pre>
       <div class="wrap">
         <div class="eyebrow">§ 04 — Founder-authored protocol</div>
         <h2 class="headline">
-          robot-md is the <b>reference implementation</b><br>
-          of the RCAN protocol.
+          robot-md is the <b>reference declaration layer</b><br>
+          for the RCAN protocol.
         </h2>
         <p class="body-text">
           RCAN (Robot Communication &amp; Addressing Network) is the open wire protocol
           for signed, authority-aware robot messages. robot-md's team authored the spec.
           That means every breaking decision — from ML-DSA-65 crypto to the §22-26 EU
           compliance hooks — was made in-house, not adapted from a third-party interface.
-          When the spec evolves, robot-md ships the reference implementation first.
+          When the spec evolves, robot-md ships the declaration-format updates first; the reference SDKs (rcan-py, rcan-ts) ship the protocol-implementation updates.
         </p>
         <a class="rcan-link" href="https://rcan.dev">rcan.dev — read the protocol spec →</a>
       </div>

--- a/site/managed-agents/index.html
+++ b/site/managed-agents/index.html
@@ -485,11 +485,11 @@
         <!-- OSS tier -->
         <div class="split-card">
           <div class="tier-label tier-oss">Open source · Apache-2.0</div>
-          <div class="product-name">robot-md-dispatcher</div>
+          <div class="product-name">robot-md-gateway</div>
           <p class="product-lede">
-            The Agent SDK reference implementation. BYOK Claude Agent SDK
-            wrapper around robot-md-mcp. Self-host on your robot or your
-            own cloud.
+            The reference enforcement gateway: receives signed action
+            requests, verifies, and dispatches to drivers. Self-host on
+            your robot or your own cloud.
           </p>
           <ul>
             <li>Full <code>robot-md-mcp</code> surface — all 6 resources + 3 tools</li>
@@ -499,8 +499,8 @@
             <li>Provision with <code>/enable-dispatch</code> from Claude Code</li>
           </ul>
           <a class="pkg-link"
-             href="https://github.com/RobotRegistryFoundation/robot-md-dispatcher">
-            github.com/RobotRegistryFoundation/robot-md-dispatcher →
+             href="https://github.com/RobotRegistryFoundation/robot-md-gateway">
+            github.com/RobotRegistryFoundation/robot-md-gateway →
           </a>
         </div>
 
@@ -562,8 +562,8 @@
         </p>
         <p class="body-text" style="margin-bottom: 16px;">
           The open-source
-          <code style="font-family:var(--mono);font-size:13px;color:#E8E3D3;background:#2a2825;padding:1px 5px;border-radius:2px;">robot-md-dispatcher</code>
-          is the reference Agent SDK integration — self-hosted for developers
+          <code style="font-family:var(--mono);font-size:13px;color:#E8E3D3;background:#2a2825;padding:1px 5px;border-radius:2px;">robot-md-gateway</code>
+          is the reference enforcement gateway — self-hosted for developers
           who want full control. Compliance-bot is the managed convenience
           layer for operators who want the outcome without the infrastructure.
         </p>

--- a/site/registry/index.html
+++ b/site/registry/index.html
@@ -262,7 +262,7 @@
       <h2 class="sec-title">robot-md register — mint an RRN.</h2>
       <p class="sec-lede">
         One command mints an RRN and writes it back into your ROBOT.md.
-        Requires a valid ROBOT.md with <code style="font-size:0.85em">rcan_version: "3.0"</code>.
+        Requires a valid ROBOT.md declaring an <code style="font-size:0.85em">rcan_version</code> from the <a href="https://rcan.dev/compatibility">live compatibility matrix</a>.
       </p>
 
       <div class="install-block" style="margin-top:24px;">
@@ -412,7 +412,7 @@
         When a key is revoked (via <code style="font-family:var(--mono);font-size:12.5px;background:var(--paper-2);padding:1px 5px;border-radius:2px;">robot-md revoke-key</code>
         or directly at RRF), the RRF broadcasts a revocation event to all registered
         <code style="font-family:var(--mono);font-size:12.5px;background:var(--paper-2);padding:1px 5px;border-radius:2px;">M2M_TRUSTED</code>
-        listeners. Peer runtimes (OpenCastor, robot-md-dispatcher) poll
+        listeners. Peer runtimes (OpenCastor, robot-md-gateway) poll
         <code style="font-family:var(--mono);font-size:12.5px;background:var(--paper-2);padding:1px 5px;border-radius:2px;">https://robotregistryfoundation.org/api/revocation/&lt;rrn&gt;</code>
         on a configurable interval (default: 60 seconds). Any request signed with a revoked key is
         rejected with <code style="font-family:var(--mono);font-size:12.5px;background:var(--paper-2);padding:1px 5px;border-radius:2px;">403 KEY_REVOKED</code>.


### PR DESCRIPTION
## Summary

Plan 9 Phase 3 robotmd.dev apex single-fix PR: applies the eight findings from
[`operations/2026-05-05-apex-text-accuracy/findings-robotmd-dev.md`](https://github.com/craigm26/opencastor-ops/blob/master/operations/2026-05-05-apex-text-accuracy/findings-robotmd-dev.md)
in the opencastor-ops audit repo.

The Phase 3 audit covered 12 files (site/index.html + 11 sub-pages) and
produced eight findings — three factual (Decision 2 retired-framing) and
five drift (Plan 3 dispatcher→gateway carryover plus one outdated RCAN
version pin). Forbidden-phrase lint reports `0 hits` both before and
after this PR; every finding is a regex blind-spot (semantic variant,
intervening words, underscore-vs-hyphen, retired-name reference).

## Findings landed in this PR

### Factual (Decision 2 retired-framing)

- **[F-RMD-01]** `site/index.html:1255-1257` — Apex hero §04 beat headline: "robot-md is the **reference implementation** of the RCAN protocol" → "robot-md is the **reference declaration layer** for the RCAN protocol". Per spec §3 Decision 2 verbatim, `robot-md` = reference declaration layer (Layer 1); the **reference SDKs** (rcan-py, rcan-ts at Layer 5) implement the protocol. The previous headline reversed the layer relationship.
- **[F-RMD-02]** `site/index.html:1263` — §04 beat body: "When the spec evolves, robot-md ships the reference implementation first." → "When the spec evolves, robot-md ships the declaration-format updates first; the reference SDKs (rcan-py, rcan-ts) ship the protocol-implementation updates." Preserves the founder-authored thesis (apex eyebrow `§04 — Founder-authored protocol` is intentionally retained per canonical strategy §0) while correcting the layer mismatch.
- **[F-RMD-04]** `site/managed-agents/index.html:489-493` — OSS tier card lede: "The Agent SDK reference implementation. BYOK Claude Agent SDK wrapper around robot-md-mcp." → "The reference enforcement gateway: receives signed action requests, verifies, and dispatches to drivers." Adopts the canonical Layer-3 charter (per `forbidden-phrases.json` `byok-claude-agent-sdk-launcher` replacement_hint). The existing regex requires "launcher" or "dispatcher" right after `BYOK Claude Agent SDK`; the "wrapper" variant slips the lint — same F-01-pattern blind-spot fixed in Phase 1 + Phase 2.

### Drift (Plan 3 dispatcher→gateway carryover + one outdated RCAN version)

- **[F-RMD-03]** `site/managed-agents/index.html:488` — `<div class="product-name">robot-md-dispatcher</div>` → `robot-md-gateway`. Plan 3 (closed 2026-05-03) renamed the package; PyPI is `robot-md-gateway==0.4.0a1`.
- **[F-RMD-05]** `site/managed-agents/index.html:501-503` — `<a href="https://github.com/RobotRegistryFoundation/robot-md-dispatcher">…</a>` → `…/robot-md-gateway`. Verified `curl -sI` (2026-05-08) returns HTTP/2 301 — GitHub redirects so the link still functions, but the visible URL string carries the retired name.
- **[F-RMD-06]** `site/managed-agents/index.html:563-569` — Anthropic-block body: replaces `<code>robot-md-dispatcher</code>` + "is the reference Agent SDK integration" with `<code>robot-md-gateway</code>` + "is the reference enforcement gateway".
- **[F-RMD-08]** `site/registry/index.html:411-419` — Revocation-polling body: "Peer runtimes (OpenCastor, robot-md-dispatcher) poll …" → "(OpenCastor, robot-md-gateway) poll …".
- **[F-RMD-07]** `site/registry/index.html:265` — Hardcoded `rcan_version: "3.0"` → "declaring an `rcan_version` from the [live compatibility matrix](https://rcan.dev/compatibility)". Current canonical RCAN spec is 3.2 per `config/repos.json:5`. Per `forbidden-phrases.json` replacement_hint for `rcan-version-hardcoded`: link to compatibility matrix (static HTML cannot embed live).

## Stylistic-only findings deferred

Two sub-findings deferred to a follow-up issue (filed separately):

- **[S-RMD-A]** `/enable-dispatch` slash-command name — Plan 3 carryover candidate, but the apex matches the **current canonical** name in `robot-md-mcp/commands/enable-dispatch.md`. Not a Phase 3 finding; future cleanup decision (rename to `/enable-gateway` for consistency would require coordinated robot-md-mcp + apex copy update).
- **[S-RMD-B]** Subagent missed-occurrence pattern — the `Explore` subagent flagged the first occurrence per file/section but missed repeats (`managed-agents:565`, `registry:415`). Caught by manual `grep` cross-check. Refinement queued for `feedback_subagent_audit_verify_migrations.md`.

## Verification

- [x] `python3 tools/lint_forbidden_phrases.py --dict docs/standards/forbidden-phrases.json --root ~/robot-md` exits 0 — both before AND after this PR (every finding is a regex blind-spot, so post-fix lint passing is mostly meaningless beyond confirming we didn't introduce a new literal match).
- [x] `python3 -c "from html.parser import HTMLParser; p = HTMLParser(); p.feed(open('FILE').read())"` — all 3 edited files (`site/index.html`, `site/managed-agents/index.html`, `site/registry/index.html`) parse cleanly.
- [x] `grep -rn "robot-md-dispatcher\|reference implementation\|rcan_version: \"3.0\"\|BYOK Claude Agent SDK wrapper" site/` — no remaining hits in the audited apex pages.
- [x] No tests / build steps — robot-md `site/` is pure static HTML served by Cloudflare Pages.

## Phase 1+2 sibling PRs (already shipped this work block)

- [continuonai/rcan-spec#210](https://github.com/continuonai/rcan-spec/pull/210) — Phase 1 F-01 carryover (rcan.dev about page).
- [craigm26/RobotRegistryFoundation#92](https://github.com/craigm26/RobotRegistryFoundation/pull/92) — Phase 2 F-RRF-01..06 (RRF apex).

This PR is the third in the Plan 9 work block. All three are independent (different repos, different files); none blocks the other.

## Spec / Plan references

- North star: [`docs/superpowers/specs/2026-05-04-opencastor-ecosystem-direction-design.md`](https://github.com/craigm26/opencastor-ops/blob/master/docs/superpowers/specs/2026-05-04-opencastor-ecosystem-direction-design.md) §3 Decision 2 (retire "reference implementation of RCAN" entirely; canonical Layer-1/Layer-3/Layer-4 silo charters)
- Canonical strategy: [`business/2026-05-08-strategy-canonical.md`](https://github.com/craigm26/opencastor-ops/blob/master/business/2026-05-08-strategy-canonical.md) §0 (Founder-authored standards body — preserved here) + §3 (six-layer architecture)
- Plan 3 dispatcher→gateway closure: [`project_plan_3_gateway_rename_complete_2026_05_03.md`](https://github.com/craigm26/opencastor-ops/) (PR #44 on this repo retired the dispatcher row in the README — managed-agents + registry pages were missed and are caught here)
- Forbidden-phrase dict: [`docs/standards/forbidden-phrases.json`](https://github.com/craigm26/opencastor-ops/blob/master/docs/standards/forbidden-phrases.json) — `byok-claude-agent-sdk-launcher`, `reference-implementation-of-rcan`, `rcan-version-hardcoded` (all blind-spots for the variants fixed here)
- Plan 8 redirects: `site/_redirects` — apex retains `/`, `/agents/*`, `/registry/`, `/managed-agents/`, `/robots/`, `/status/`, `/report.html`. All three edited files are apex-retained surfaces. No link-target changes in this PR.

🤖 Generated with [Claude Code](https://claude.com/claude-code)