### PR TITLE
feat: robot-md 1.7.0 — actuator search + publish + catalog at /actuators/

### DIFF
--- a/cli/pyproject.toml
+++ b/cli/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "hatchling.build"
 
 [project]
 name = "robot-md"
-version = "1.6.0"
+version = "1.7.0"
 description = "ROBOT.md — a single self-describing file so Claude can safely operate your robot."
 readme = "../README.md"
 requires-python = ">=3.10"
@@ -38,6 +38,7 @@ dependencies = [
     "robot-md-gateway>=0.5.0a1",
     "websockets>=12",
     "watchdog>=3.0",
+    "tomli>=2.0;python_version<'3.11'",
 ]
 
 [project.optional-dependencies]

--- a/cli/src/robot_md/__main__.py
+++ b/cli/src/robot_md/__main__.py
@@ -1994,6 +1994,66 @@ def actuator_init_cmd(
     out_console.print("    robot-md-gateway list-actuators")
 
 
+@actuator_app.command("search")
+def actuator_search_cmd(
+    query: str = typer.Argument("", help="Free-text query (hardware tags, fuzzy description)."),
+    manifest: Path | None = typer.Option(
+        None,
+        "--manifest",
+        help="Path to a ROBOT.md to extract manifest_signals from.",
+    ),
+    type_filter: str = typer.Option(
+        "actuator",
+        "--type",
+        help="Entry type to search (actuator | skill | plugin | mcp).",
+    ),
+    threshold: float = typer.Option(
+        0.3,
+        "--threshold",
+        help="Soft match minimum. Below-threshold matches are tagged but still listed.",
+    ),
+    offline: bool = typer.Option(
+        False,
+        "--offline",
+        help="Use cached index only — do not hit the network.",
+    ),
+) -> None:
+    """Search the actuator catalog at https://robotmd.dev/actuators/."""
+    from robot_md.actuator import actuator_search
+    from robot_md.registry import fetch_index
+
+    try:
+        index = fetch_index(offline=offline)
+    except FileNotFoundError:
+        typer.secho(
+            "No catalog cache available. Run without --offline first to populate it.",
+            fg=typer.colors.RED,
+            err=True,
+        )
+        raise typer.Exit(FILE_ERROR) from None
+
+    parsed_manifest: dict | None = None
+    if manifest is not None:
+        try:
+            import frontmatter
+
+            with manifest.open("r") as fh:
+                post = frontmatter.load(fh)
+            parsed_manifest = post.metadata
+        except Exception as e:
+            typer.secho(f"Could not parse manifest: {e}", fg=typer.colors.RED, err=True)
+            raise typer.Exit(FILE_ERROR) from e
+
+    out = actuator_search(
+        index,
+        query=query,
+        manifest=parsed_manifest,
+        type_filter=type_filter,
+        threshold=threshold,
+    )
+    typer.echo(out)
+
+
 @app.command("publish-discovery")
 def publish_discovery(
     path: Path = typer.Argument(..., help="Path to a ROBOT.md file."),

--- a/cli/src/robot_md/__main__.py
+++ b/cli/src/robot_md/__main__.py
@@ -2054,6 +2054,87 @@ def actuator_search_cmd(
     typer.echo(out)
 
 
+@actuator_app.command("publish")
+def actuator_publish_cmd(
+    package_dir: Path = typer.Option(
+        Path("."),
+        "--package-dir",
+        "-C",
+        help="Path to the actuator package root (default: cwd).",
+    ),
+    dry_run: bool = typer.Option(
+        False,
+        "--dry-run",
+        help="Print would-be PR payloads instead of opening PRs.",
+    ),
+    publisher: str = typer.Option(
+        "",
+        "--publisher",
+        help="Publisher identifier (default: derived from `gh api user`).",
+    ),
+) -> None:
+    """Publish a scaffolded actuator to the catalog.
+
+    Detects whether the package has a Claude-plugin layout. If yes, opens TWO
+    PRs (against RobotRegistryFoundation/claude-code-plugins for the marketplace
+    entry, and against RobotRegistryFoundation/robot-md for the catalog). If
+    no, opens ONE PR (catalog only).
+
+    With --dry-run, no PRs are opened — just prints the payloads it would push.
+    """
+    from datetime import datetime, timezone
+
+    from robot_md.actuator import build_registry_entry, detect_package_metadata
+
+    try:
+        meta = detect_package_metadata(package_dir.resolve())
+    except FileNotFoundError as e:
+        typer.secho(f"Could not read package: {e}", fg=typer.colors.RED, err=True)
+        raise typer.Exit(FILE_ERROR)
+
+    if not publisher:
+        publisher = "github:unknown"
+    published_at = datetime.now(timezone.utc).strftime("%Y-%m-%dT%H:%M:%SZ")
+
+    entry = build_registry_entry(meta, publisher=publisher, published_at=published_at)
+
+    if dry_run:
+        typer.echo("=== Catalog PR (RobotRegistryFoundation/robot-md) ===")
+        typer.echo(f"  Branch: publish/{meta['name']}-{meta['version']}")
+        typer.echo("  Title: registry(actuator): publish " + meta["name"] + " v" + meta["version"])
+        typer.echo("  Modifies: site/actuators/index.json")
+        typer.echo("  Entry payload:")
+        import json as _json
+
+        typer.echo(_json.dumps(entry, indent=2))
+        if meta["has_plugin_layout"]:
+            typer.echo("\n=== Marketplace PR (RobotRegistryFoundation/claude-code-plugins) ===")
+            typer.echo(f"  Branch: publish/{meta['name']}-{meta['version']}")
+            typer.echo("  Title: marketplace: add " + meta["name"] + " plugin")
+            typer.echo("  Modifies: marketplace.json")
+            typer.echo("  Plugin block:")
+            typer.echo(
+                _json.dumps(
+                    {
+                        "name": meta["name"],
+                        "version": meta["version"],
+                        "description": meta.get("description", ""),
+                        "repository": meta.get("repository_url", ""),
+                    },
+                    indent=2,
+                )
+            )
+        return
+
+    from robot_md.actuator import open_marketplace_pr, open_registry_pr
+
+    catalog_url = open_registry_pr(entry)
+    typer.echo(f"Catalog PR: {catalog_url}")
+    if meta["has_plugin_layout"]:
+        marketplace_url = open_marketplace_pr(meta)
+        typer.echo(f"Marketplace PR: {marketplace_url}")
+
+
 @app.command("publish-discovery")
 def publish_discovery(
     path: Path = typer.Argument(..., help="Path to a ROBOT.md file."),

--- a/cli/src/robot_md/__main__.py
+++ b/cli/src/robot_md/__main__.py
@@ -1918,9 +1918,7 @@ def invoke(
 
 
 # ---------------------------------------------------------------- actuator
-actuator_app = typer.Typer(
-    help="Manage robot-md-gateway actuators (init / search / publish)."
-)
+actuator_app = typer.Typer(help="Manage robot-md-gateway actuators (init / search / publish).")
 app.add_typer(actuator_app, name="actuator")
 
 

--- a/cli/src/robot_md/__main__.py
+++ b/cli/src/robot_md/__main__.py
@@ -1919,7 +1919,7 @@ def invoke(
 
 # ---------------------------------------------------------------- actuator
 actuator_app = typer.Typer(
-    help="Manage robot-md-gateway actuators (init in v1.6.0; search + publish coming in v1.7.0)."
+    help="Manage robot-md-gateway actuators (init / search / publish)."
 )
 app.add_typer(actuator_app, name="actuator")
 

--- a/cli/src/robot_md/__main__.py
+++ b/cli/src/robot_md/__main__.py
@@ -2090,7 +2090,7 @@ def actuator_publish_cmd(
         meta = detect_package_metadata(package_dir.resolve())
     except FileNotFoundError as e:
         typer.secho(f"Could not read package: {e}", fg=typer.colors.RED, err=True)
-        raise typer.Exit(FILE_ERROR)
+        raise typer.Exit(FILE_ERROR) from e
 
     if not publisher:
         publisher = "github:unknown"

--- a/cli/src/robot_md/actuator.py
+++ b/cli/src/robot_md/actuator.py
@@ -14,7 +14,7 @@ from pathlib import Path
 if sys.version_info >= (3, 11):
     import tomllib as _toml
 else:
-    import tomli as _toml  # noqa: F401  (declared in pyproject deps for 3.10)
+    import tomli as _toml  # type: ignore[import-not-found]  # 3.10 only
 
 from robot_md.registry import (
     extract_manifest_signals,
@@ -188,8 +188,10 @@ def detect_package_metadata(pkg_dir: Path) -> dict:
                 post = frontmatter.load(sf)
             except Exception:
                 continue
-            for k_src, k_dst in (("hardware_tags", hardware_tags),
-                                  ("manifest_signals", manifest_signals)):
+            for k_src, k_dst in (
+                ("hardware_tags", hardware_tags),
+                ("manifest_signals", manifest_signals),
+            ):
                 v = post.metadata.get(k_src)
                 if isinstance(v, list):
                     k_dst.extend(str(x) for x in v)

--- a/cli/src/robot_md/actuator.py
+++ b/cli/src/robot_md/actuator.py
@@ -7,8 +7,14 @@ Plan 2 ships `actuator init`. Plans 3+ will add `actuator search` and
 from __future__ import annotations
 
 import re
+import sys
 from importlib import resources
 from pathlib import Path
+
+if sys.version_info >= (3, 11):
+    import tomllib as _toml
+else:
+    import tomli as _toml  # noqa: F401  (declared in pyproject deps for 3.10)
 
 from robot_md.registry import (
     extract_manifest_signals,
@@ -147,3 +153,90 @@ def actuator_search(
     if not nonzero:
         return format_search_results([], threshold=threshold, limit=limit)
     return format_search_results(nonzero, threshold=threshold, limit=limit)
+
+
+def detect_package_metadata(pkg_dir: Path) -> dict:
+    """Scan a scaffolded actuator package and return metadata for publish.
+
+    Reads:
+      - pyproject.toml for name, version, description, Repository URL
+      - src/<snake>/skills/*.SKILL.md frontmatter for hardware_tags + manifest_signals
+      - claude-plugin/.claude-plugin/plugin.json existence flag
+
+    Raises FileNotFoundError if pyproject.toml is missing.
+    """
+    pyproject = pkg_dir / "pyproject.toml"
+    if not pyproject.is_file():
+        raise FileNotFoundError(f"missing {pyproject}")
+    with pyproject.open("rb") as fh:
+        data = _toml.load(fh)
+    project = data.get("project", {})
+    urls = project.get("urls", {}) or {}
+    repo_url = urls.get("Repository") or urls.get("repository") or ""
+
+    snake = (project.get("name") or pkg_dir.name).replace("-", "_")
+    skills_dir = pkg_dir / "src" / snake / "skills"
+    skill_files: list[str] = []
+    hardware_tags: list[str] = []
+    manifest_signals: list[str] = []
+    if skills_dir.is_dir():
+        import frontmatter
+
+        for sf in sorted(skills_dir.glob("*.SKILL.md")):
+            skill_files.append(sf.name)
+            try:
+                post = frontmatter.load(sf)
+            except Exception:
+                continue
+            for k_src, k_dst in (("hardware_tags", hardware_tags),
+                                  ("manifest_signals", manifest_signals)):
+                v = post.metadata.get(k_src)
+                if isinstance(v, list):
+                    k_dst.extend(str(x) for x in v)
+
+    plugin_marker = pkg_dir / "claude-plugin" / ".claude-plugin" / "plugin.json"
+    return {
+        "name": project.get("name", pkg_dir.name),
+        "version": project.get("version", "0.0.0"),
+        "description": project.get("description", ""),
+        "repository_url": repo_url,
+        "hardware_tags": hardware_tags,
+        "manifest_signals": manifest_signals,
+        "has_plugin_layout": plugin_marker.is_file(),
+        "skill_files": skill_files,
+    }
+
+
+def build_registry_entry(
+    meta: dict,
+    *,
+    publisher: str,
+    published_at: str,
+) -> dict:
+    """Build the JSON entry shape that goes into site/actuators/index.json."""
+    name = meta["name"]
+    entry: dict = {
+        "type": "actuator",
+        "name": name,
+        "version": meta["version"],
+        "description": meta.get("description", ""),
+        "install": {
+            "package_manager": "pip",
+            "package": name,
+            "post_install": f"robot-md install-skill {name}",
+        },
+        "hardware_tags": meta.get("hardware_tags", []),
+        "manifest_signals": meta.get("manifest_signals", []),
+        "repository": meta.get("repository_url", ""),
+        "skill_files": meta.get("skill_files", []),
+        "publisher": publisher,
+        "published_at": published_at,
+        "verified": False,
+    }
+    if meta.get("has_plugin_layout"):
+        entry["plugin_marketplace_entry"] = {
+            "marketplace": "robotregistryfoundation",
+            "plugin_name": name,
+            "install_command": f"/plugin install {name}@robotregistryfoundation",
+        }
+    return entry

--- a/cli/src/robot_md/actuator.py
+++ b/cli/src/robot_md/actuator.py
@@ -6,8 +6,11 @@ Plan 2 ships `actuator init`. Plans 3+ will add `actuator search` and
 
 from __future__ import annotations
 
+import os
 import re
+import subprocess
 import sys
+import tempfile
 from importlib import resources
 from pathlib import Path
 
@@ -242,3 +245,171 @@ def build_registry_entry(
             "install_command": f"/plugin install {name}@robotregistryfoundation",
         }
     return entry
+
+
+REGISTRY_REPO = "RobotRegistryFoundation/robot-md"
+MARKETPLACE_REPO = "RobotRegistryFoundation/claude-code-plugins"
+
+
+def _publish_worktree(label: str) -> Path:
+    """Pick the per-publish worktree path. Allows tests to override via env."""
+    base = os.environ.get("ROBOT_MD_PUBLISH_WORKTREE")
+    if base:
+        p = Path(base) / label
+        p.mkdir(parents=True, exist_ok=True)
+        return p
+    return Path(tempfile.mkdtemp(prefix=f"robot-md-publish-{label}-"))
+
+
+def _gh(*args: str, capture: bool = False, check: bool = True) -> str:
+    """Run a gh CLI command. Returns stdout if capture=True."""
+    res = subprocess.run(
+        list(args),
+        capture_output=capture,
+        text=True,
+        check=check,
+    )
+    return res.stdout if capture else ""
+
+
+def _git(cwd: Path, *args: str, check: bool = True) -> None:
+    subprocess.run(["git", *args], cwd=str(cwd), check=check)
+
+
+def open_registry_pr(entry: dict) -> str:
+    """Fork robot-md, append entry to site/actuators/index.json, push, open PR.
+
+    Returns the PR URL.
+    """
+    import json as _json
+
+    name = entry["name"]
+    version = entry["version"]
+    branch = f"publish/{name}-{version}"
+    wt = _publish_worktree(f"registry-{name}")
+
+    subprocess.run(
+        ["gh", "repo", "fork", REGISTRY_REPO, "--clone=false", "--remote=false"],
+        check=False,
+    )
+    user = (
+        subprocess.run(
+            ["gh", "api", "user", "--jq", ".login"],
+            capture_output=True,
+            text=True,
+            check=True,
+        ).stdout.strip()
+        or "unknown"
+    )
+
+    fork_url = f"https://github.com/{user}/robot-md.git"
+    subprocess.run(["git", "clone", fork_url, str(wt)], check=True)
+    _git(wt, "checkout", "-b", branch)
+
+    index_path = wt / "site" / "actuators" / "index.json"
+    data = _json.loads(index_path.read_text()) if index_path.is_file() else {"entries": []}
+    data.setdefault("entries", []).append(entry)
+    data["generated_at"] = entry.get("published_at", data.get("generated_at"))
+    index_path.parent.mkdir(parents=True, exist_ok=True)
+    index_path.write_text(_json.dumps(data, indent=2) + "\n")
+
+    _git(wt, "add", str(index_path))
+    _git(wt, "commit", "-m", f"registry(actuator): publish {name} v{version}")
+    _git(wt, "push", "origin", branch)
+
+    pr_body = (
+        f"Adds `{name}` v{version} to the actuator catalog.\n\n"
+        "**Conformance checklist**:\n"
+        "- [ ] Implements `robot_md_gateway.actuators` Protocol\n"
+        "- [ ] Tests pass\n"
+        "- [ ] SKILL.md present at `<pkg>/skills/`\n"
+        "- [ ] Repository accessible at the URL in the entry\n"
+        "- [ ] `pip install <package>` works\n"
+    )
+    out = subprocess.run(
+        [
+            "gh",
+            "pr",
+            "create",
+            "--repo",
+            REGISTRY_REPO,
+            "--title",
+            f"registry(actuator): publish {name} v{version}",
+            "--body",
+            pr_body,
+            "--head",
+            f"{user}:{branch}",
+        ],
+        capture_output=True,
+        text=True,
+        check=True,
+    )
+    return out.stdout.strip()
+
+
+def open_marketplace_pr(meta: dict) -> str:
+    """Fork claude-code-plugins, append plugin block to marketplace.json, push, open PR.
+
+    Returns the PR URL.
+    """
+    import json as _json
+
+    name = meta["name"]
+    version = meta["version"]
+    branch = f"publish/{name}-{version}"
+    wt = _publish_worktree(f"marketplace-{name}")
+
+    subprocess.run(
+        ["gh", "repo", "fork", MARKETPLACE_REPO, "--clone=false", "--remote=false"],
+        check=False,
+    )
+    user = (
+        subprocess.run(
+            ["gh", "api", "user", "--jq", ".login"],
+            capture_output=True,
+            text=True,
+            check=True,
+        ).stdout.strip()
+        or "unknown"
+    )
+
+    fork_url = f"https://github.com/{user}/claude-code-plugins.git"
+    subprocess.run(["git", "clone", fork_url, str(wt)], check=True)
+    _git(wt, "checkout", "-b", branch)
+
+    mp_path = wt / "marketplace.json"
+    data = _json.loads(mp_path.read_text()) if mp_path.is_file() else {"plugins": []}
+    data.setdefault("plugins", []).append(
+        {
+            "name": name,
+            "version": version,
+            "description": meta.get("description", ""),
+            "repository": meta.get("repository_url", ""),
+        }
+    )
+    mp_path.parent.mkdir(parents=True, exist_ok=True)
+    mp_path.write_text(_json.dumps(data, indent=2) + "\n")
+
+    _git(wt, "add", str(mp_path))
+    _git(wt, "commit", "-m", f"marketplace: add {name} plugin")
+    _git(wt, "push", "origin", branch)
+
+    out = subprocess.run(
+        [
+            "gh",
+            "pr",
+            "create",
+            "--repo",
+            MARKETPLACE_REPO,
+            "--title",
+            f"marketplace: add {name} plugin",
+            "--body",
+            f"Adds `{name}` v{version} to the Claude Code plugin marketplace.",
+            "--head",
+            f"{user}:{branch}",
+        ],
+        capture_output=True,
+        text=True,
+        check=True,
+    )
+    return out.stdout.strip()

--- a/cli/src/robot_md/actuator.py
+++ b/cli/src/robot_md/actuator.py
@@ -10,6 +10,12 @@ import re
 from importlib import resources
 from pathlib import Path
 
+from robot_md.registry import (
+    extract_manifest_signals,
+    format_search_results,
+    score_entry,
+)
+
 _KEBAB_RE = re.compile(r"^[a-z0-9]+(-[a-z0-9]+)*$")
 
 
@@ -120,3 +126,24 @@ def scaffold_actuator_package(
     )
 
     return pkg_root
+
+
+def actuator_search(
+    index: dict,
+    *,
+    query: str,
+    manifest: dict | None,
+    type_filter: str = "actuator",
+    threshold: float = 0.3,
+    limit: int = 5,
+) -> str:
+    """Filter index entries by type, score them against query+manifest,
+    and return the formatted output string."""
+    entries = [e for e in index.get("entries", []) if e.get("type") == type_filter]
+    signals = extract_manifest_signals(manifest) if manifest else None
+    scored = [(e, score_entry(e, query=query, manifest_signals=signals)) for e in entries]
+    scored.sort(key=lambda pair: pair[1], reverse=True)
+    nonzero = [pair for pair in scored if pair[1] > 0.0]
+    if not nonzero:
+        return format_search_results([], threshold=threshold, limit=limit)
+    return format_search_results(nonzero, threshold=threshold, limit=limit)

--- a/cli/src/robot_md/registry.py
+++ b/cli/src/robot_md/registry.py
@@ -1,0 +1,40 @@
+"""Robot-md actuator catalog — fetch, score, format.
+
+Catalog data is a single static JSON served at robotmd.dev. We keep a local
+cache so `--offline` works and so HTTP hiccups degrade gracefully.
+"""
+from __future__ import annotations
+
+import json
+from pathlib import Path
+from urllib.error import URLError
+from urllib.request import urlopen
+
+DEFAULT_CATALOG_URL = "https://robotmd.dev/actuators/index.json"
+DEFAULT_CACHE_PATH = Path.home() / ".cache" / "robot-md" / "registry-index.json"
+
+
+def fetch_index(
+    *,
+    url: str = DEFAULT_CATALOG_URL,
+    cache_path: Path = DEFAULT_CACHE_PATH,
+    offline: bool = False,
+    timeout: float = 10.0,
+) -> dict:
+    """Fetch the catalog JSON, with offline cache fallback.
+
+    - offline=True: read cache only. Raises FileNotFoundError if cache absent.
+    - offline=False: fetch fresh, write to cache, return parsed JSON. On HTTP
+      failure, fall back to cache (raises FileNotFoundError if no cache).
+    """
+    if offline:
+        return json.loads(cache_path.read_text())
+    try:
+        with urlopen(url, timeout=timeout) as resp:
+            body = resp.read()
+        payload = json.loads(body.decode())
+        cache_path.parent.mkdir(parents=True, exist_ok=True)
+        cache_path.write_text(json.dumps(payload, indent=2))
+        return payload
+    except (URLError, OSError, json.JSONDecodeError):
+        return json.loads(cache_path.read_text())

--- a/cli/src/robot_md/registry.py
+++ b/cli/src/robot_md/registry.py
@@ -3,6 +3,7 @@
 Catalog data is a single static JSON served at robotmd.dev. We keep a local
 cache so `--offline` works and so HTTP hiccups degrade gracefully.
 """
+
 from __future__ import annotations
 
 import json
@@ -92,3 +93,41 @@ def score_entry(
     if sig_score is None:
         return tag_score * 0.75 + desc_score * 0.25
     return sig_score * 0.6 + tag_score * 0.3 + desc_score * 0.1
+
+
+def format_search_results(
+    scored: list[tuple[dict, float]],
+    *,
+    threshold: float = 0.3,
+    limit: int = 5,
+) -> str:
+    """Render top-N entries with their scores. Below-threshold entries are
+    still printed but tagged as weak. Empty list prints the no-match guidance.
+    """
+    if not scored:
+        return (
+            "No matches found. Ask Claude Code to write one, then "
+            "'robot-md actuator publish' so the next person finds it.\n"
+        )
+    lines: list[str] = []
+    for entry, score in scored[:limit]:
+        name = entry.get("name", "?")
+        version = entry.get("version", "")
+        desc = entry.get("description", "")
+        weak = "  (weak match — consider writing a new actuator)" if score < threshold else ""
+        lines.append(f"{score:0.2f}  {name} {version}{weak}")
+        lines.append(f"        {desc}")
+        plugin = entry.get("plugin_marketplace_entry")
+        if plugin and plugin.get("install_command"):
+            lines.append(f"        $ {plugin['install_command']}")
+        else:
+            install = entry.get("install") or {}
+            pm = install.get("package_manager", "pip")
+            pkg = install.get("package", name)
+            post = install.get("post_install")
+            cmd = f"{pm} install {pkg}"
+            if post:
+                cmd += f" && {post}"
+            lines.append(f"        $ {cmd}")
+        lines.append("")
+    return "\n".join(lines)

--- a/cli/src/robot_md/registry.py
+++ b/cli/src/robot_md/registry.py
@@ -38,3 +38,57 @@ def fetch_index(
         return payload
     except (URLError, OSError, json.JSONDecodeError):
         return json.loads(cache_path.read_text())
+
+
+def extract_manifest_signals(manifest: dict) -> list[str]:
+    """Pull all driver IDs, driver models, and camera driver_ids from a
+    parsed ROBOT.md manifest. Used as the LHS for catalog scoring."""
+    sigs: list[str] = []
+    for d in manifest.get("drivers", []) or []:
+        if isinstance(d, dict):
+            for k in ("id", "model"):
+                v = d.get(k)
+                if v:
+                    sigs.append(str(v))
+    physics = manifest.get("physics") or {}
+    solver = physics.get("solver") or {}
+    for cam in solver.get("cameras", []) or []:
+        if isinstance(cam, dict):
+            v = cam.get("driver_id")
+            if v:
+                sigs.append(str(v))
+    return sigs
+
+
+def _tokens(text: str) -> set[str]:
+    """Tokenize text by lowercasing and splitting on whitespace, dash, underscore."""
+    return {t.lower() for t in text.replace("-", " ").replace("_", " ").split() if t}
+
+
+def score_entry(
+    entry: dict,
+    *,
+    query: str,
+    manifest_signals: list[str] | None,
+) -> float:
+    """Score an entry's relevance to a query + manifest. Range [0.0, 1.0]."""
+    entry_signals = {s.lower() for s in entry.get("manifest_signals", []) or []}
+    entry_tag_tokens: set[str] = set()
+    for t in entry.get("hardware_tags", []) or []:
+        entry_tag_tokens |= _tokens(str(t))
+    desc = (entry.get("description") or "").lower()
+    q_tokens = _tokens(query)
+
+    if manifest_signals is None:
+        sig_score = None
+    else:
+        ms_lower = {s.lower() for s in manifest_signals}
+        sig_score = 1.0 if entry_signals & ms_lower else 0.0
+
+    tag_score = 1.0 if entry_tag_tokens & q_tokens else 0.0
+
+    desc_score = 1.0 if (q_tokens and any(t in desc for t in q_tokens)) else 0.0
+
+    if sig_score is None:
+        return tag_score * 0.75 + desc_score * 0.25
+    return sig_score * 0.6 + tag_score * 0.3 + desc_score * 0.1

--- a/cli/src/robot_md/registry.py
+++ b/cli/src/robot_md/registry.py
@@ -18,7 +18,7 @@ DEFAULT_CACHE_PATH = Path.home() / ".cache" / "robot-md" / "registry-index.json"
 def fetch_index(
     *,
     url: str = DEFAULT_CATALOG_URL,
-    cache_path: Path = DEFAULT_CACHE_PATH,
+    cache_path: Path | None = None,
     offline: bool = False,
     timeout: float = 10.0,
 ) -> dict:
@@ -28,6 +28,8 @@ def fetch_index(
     - offline=False: fetch fresh, write to cache, return parsed JSON. On HTTP
       failure, fall back to cache (raises FileNotFoundError if no cache).
     """
+    if cache_path is None:
+        cache_path = DEFAULT_CACHE_PATH
     if offline:
         return json.loads(cache_path.read_text())
     try:

--- a/cli/src/robot_md/skills/using-robot-md.SKILL.md
+++ b/cli/src/robot_md/skills/using-robot-md.SKILL.md
@@ -207,6 +207,33 @@ from a terminal, or — in the future — a pendant). Tell them you saw it
 - Prefer MCP resources over shell-out when the MCP server is registered
 - Surface gate-gaps rather than silently proceeding
 
+## Before writing an actuator from scratch
+
+When the user has a ROBOT.md and asks Claude Code to write a new actuator (or any add-on),
+ALWAYS run the catalog search FIRST:
+
+    robot-md actuator search --manifest ./ROBOT.md
+
+Read the matches. If a match scores well against the user's hardware:
+
+1. If `plugin_marketplace_entry` is present, prefer:
+   /plugin install <name>@<marketplace>
+2. Otherwise:
+   pip install <package> && robot-md install-skill <package>
+
+Only proceed to writing a new actuator if the user explicitly declines the match,
+or no match exceeds a meaningful relevance threshold.
+
+This is the share-broadly principle: every duplicated actuator is a missed
+multiplier for the next reader. If you DO write a new one, complete the loop:
+
+    robot-md actuator publish
+
+so the next person finds it.
+
+(Today this discipline is actuator-scoped. The principle generalizes to skills,
+plugins, and MCPs — those entries land in the catalog as schema-tagged additions.)
+
 ## Installation
 
 This skill ships as part of the [`robot-md` Claude Code plugin](https://github.com/RobotRegistryFoundation/claude-code-plugins). Install with:

--- a/cli/tests/integration/test_actuator_catalog_html.py
+++ b/cli/tests/integration/test_actuator_catalog_html.py
@@ -1,6 +1,7 @@
 """Smoke test for the actuator catalog page. Parses the static HTML and
 verifies it embeds the JSON-loading JS, an empty-state, and a results
 container. Marked slow because it does real file I/O outside cli/."""
+
 from __future__ import annotations
 
 from pathlib import Path

--- a/cli/tests/integration/test_actuator_catalog_html.py
+++ b/cli/tests/integration/test_actuator_catalog_html.py
@@ -1,0 +1,31 @@
+"""Smoke test for the actuator catalog page. Parses the static HTML and
+verifies it embeds the JSON-loading JS, an empty-state, and a results
+container. Marked slow because it does real file I/O outside cli/."""
+from __future__ import annotations
+
+from pathlib import Path
+
+import pytest
+
+REPO_ROOT = Path(__file__).resolve().parents[3]
+HTML = REPO_ROOT / "site" / "actuators" / "index.html"
+
+
+@pytest.mark.slow
+def test_actuator_catalog_html_exists():
+    assert HTML.is_file(), f"missing: {HTML}"
+
+
+@pytest.mark.slow
+def test_actuator_catalog_html_embeds_loader():
+    src = HTML.read_text()
+    # Must fetch the sibling JSON.
+    assert "index.json" in src, "expected fetch of sibling index.json"
+    # Must render an entry list container the JS targets.
+    assert 'id="entries"' in src or "id='entries'" in src
+    # Must render an empty state.
+    assert "No actuators published yet" in src
+    # Must render a fuzzy filter input.
+    assert 'id="filter"' in src or "id='filter'" in src
+    # Must mention plugin badge for plugin_marketplace_entry case.
+    assert "plugin install" in src.lower()

--- a/cli/tests/test_actuator_publish.py
+++ b/cli/tests/test_actuator_publish.py
@@ -1,0 +1,106 @@
+"""Tests for robot_md.actuator.detect_package_metadata + publish helpers."""
+from __future__ import annotations
+
+import json
+from pathlib import Path
+
+import pytest
+
+from robot_md.actuator import (
+    build_registry_entry,
+    detect_package_metadata,
+)
+
+
+def _scaffold_minimal_actuator(parent: Path, *, with_plugin: bool) -> Path:
+    pkg = parent / "my-actuator"
+    pkg.mkdir()
+    (pkg / "pyproject.toml").write_text("""\
+[project]
+name = "my-actuator"
+version = "0.2.0"
+description = "Example actuator"
+
+[project.urls]
+Repository = "https://github.com/example/my-actuator"
+""")
+    skills_dir = pkg / "src" / "my_actuator" / "skills"
+    skills_dir.mkdir(parents=True)
+    (skills_dir / "using-my-actuator.SKILL.md").write_text("""\
+---
+name: using-my-actuator
+hardware_tags: [arm, feetech]
+manifest_signals: [SO-ARM101]
+---
+
+# my-actuator
+""")
+    if with_plugin:
+        plugin_dir = pkg / "claude-plugin" / ".claude-plugin"
+        plugin_dir.mkdir(parents=True)
+        (plugin_dir / "plugin.json").write_text(json.dumps({
+            "name": "my-actuator",
+            "version": "0.2.0",
+        }))
+    return pkg
+
+
+def test_detect_metadata_reads_pyproject_and_skill(tmp_path):
+    pkg = _scaffold_minimal_actuator(tmp_path, with_plugin=False)
+    meta = detect_package_metadata(pkg)
+    assert meta["name"] == "my-actuator"
+    assert meta["version"] == "0.2.0"
+    assert meta["description"] == "Example actuator"
+    assert meta["repository_url"] == "https://github.com/example/my-actuator"
+    assert meta["hardware_tags"] == ["arm", "feetech"]
+    assert meta["manifest_signals"] == ["SO-ARM101"]
+    assert meta["has_plugin_layout"] is False
+    assert meta["skill_files"] == ["using-my-actuator.SKILL.md"]
+
+
+def test_detect_metadata_finds_plugin_layout(tmp_path):
+    pkg = _scaffold_minimal_actuator(tmp_path, with_plugin=True)
+    meta = detect_package_metadata(pkg)
+    assert meta["has_plugin_layout"] is True
+
+
+def test_detect_metadata_raises_on_missing_pyproject(tmp_path):
+    with pytest.raises(FileNotFoundError):
+        detect_package_metadata(tmp_path)
+
+
+def test_build_registry_entry_without_plugin():
+    meta = {
+        "name": "rpi-cam", "version": "1.0",
+        "description": "Pi camera driver",
+        "repository_url": "https://github.com/me/rpi-cam",
+        "hardware_tags": ["raspberry-pi", "camera"],
+        "manifest_signals": [],
+        "has_plugin_layout": False,
+        "skill_files": ["using-rpi-cam.SKILL.md"],
+    }
+    e = build_registry_entry(meta, publisher="github:me", published_at="2026-05-09T00:00:00Z")
+    assert e["type"] == "actuator"
+    assert e["name"] == "rpi-cam"
+    assert e["version"] == "1.0"
+    assert e["install"]["package"] == "rpi-cam"
+    assert e["install"]["post_install"] == "robot-md install-skill rpi-cam"
+    assert "plugin_marketplace_entry" not in e
+    assert e["verified"] is False
+
+
+def test_build_registry_entry_with_plugin_includes_marketplace_block():
+    meta = {
+        "name": "feetech-arm", "version": "0.5",
+        "description": "Feetech arm",
+        "repository_url": "https://github.com/me/feetech-arm",
+        "hardware_tags": ["arm"], "manifest_signals": ["SO-ARM101"],
+        "has_plugin_layout": True,
+        "skill_files": ["using-feetech-arm.SKILL.md"],
+    }
+    e = build_registry_entry(
+        meta, publisher="github:me", published_at="2026-05-09T00:00:00Z",
+    )
+    assert e["plugin_marketplace_entry"]["marketplace"] == "robotregistryfoundation"
+    assert e["plugin_marketplace_entry"]["plugin_name"] == "feetech-arm"
+    assert e["plugin_marketplace_entry"]["install_command"] == "/plugin install feetech-arm@robotregistryfoundation"

--- a/cli/tests/test_actuator_publish.py
+++ b/cli/tests/test_actuator_publish.py
@@ -1,4 +1,5 @@
 """Tests for robot_md.actuator.detect_package_metadata + publish helpers."""
+
 from __future__ import annotations
 
 import json
@@ -38,10 +39,14 @@ manifest_signals: [SO-ARM101]
     if with_plugin:
         plugin_dir = pkg / "claude-plugin" / ".claude-plugin"
         plugin_dir.mkdir(parents=True)
-        (plugin_dir / "plugin.json").write_text(json.dumps({
-            "name": "my-actuator",
-            "version": "0.2.0",
-        }))
+        (plugin_dir / "plugin.json").write_text(
+            json.dumps(
+                {
+                    "name": "my-actuator",
+                    "version": "0.2.0",
+                }
+            )
+        )
     return pkg
 
 
@@ -71,7 +76,8 @@ def test_detect_metadata_raises_on_missing_pyproject(tmp_path):
 
 def test_build_registry_entry_without_plugin():
     meta = {
-        "name": "rpi-cam", "version": "1.0",
+        "name": "rpi-cam",
+        "version": "1.0",
         "description": "Pi camera driver",
         "repository_url": "https://github.com/me/rpi-cam",
         "hardware_tags": ["raspberry-pi", "camera"],
@@ -91,16 +97,23 @@ def test_build_registry_entry_without_plugin():
 
 def test_build_registry_entry_with_plugin_includes_marketplace_block():
     meta = {
-        "name": "feetech-arm", "version": "0.5",
+        "name": "feetech-arm",
+        "version": "0.5",
         "description": "Feetech arm",
         "repository_url": "https://github.com/me/feetech-arm",
-        "hardware_tags": ["arm"], "manifest_signals": ["SO-ARM101"],
+        "hardware_tags": ["arm"],
+        "manifest_signals": ["SO-ARM101"],
         "has_plugin_layout": True,
         "skill_files": ["using-feetech-arm.SKILL.md"],
     }
     e = build_registry_entry(
-        meta, publisher="github:me", published_at="2026-05-09T00:00:00Z",
+        meta,
+        publisher="github:me",
+        published_at="2026-05-09T00:00:00Z",
     )
     assert e["plugin_marketplace_entry"]["marketplace"] == "robotregistryfoundation"
     assert e["plugin_marketplace_entry"]["plugin_name"] == "feetech-arm"
-    assert e["plugin_marketplace_entry"]["install_command"] == "/plugin install feetech-arm@robotregistryfoundation"
+    assert (
+        e["plugin_marketplace_entry"]["install_command"]
+        == "/plugin install feetech-arm@robotregistryfoundation"
+    )

--- a/cli/tests/test_actuator_publish.py
+++ b/cli/tests/test_actuator_publish.py
@@ -6,11 +6,15 @@ import json
 from pathlib import Path
 
 import pytest
+from typer.testing import CliRunner
 
+from robot_md.__main__ import app
 from robot_md.actuator import (
     build_registry_entry,
     detect_package_metadata,
 )
+
+_runner = CliRunner()
 
 
 def _scaffold_minimal_actuator(parent: Path, *, with_plugin: bool) -> Path:
@@ -119,13 +123,6 @@ def test_build_registry_entry_with_plugin_includes_marketplace_block():
     )
 
 
-from typer.testing import CliRunner
-
-from robot_md.__main__ import app
-
-_runner = CliRunner()
-
-
 def test_publish_dry_run_no_plugin_emits_one_pr_payload(tmp_path):
     pkg = _scaffold_minimal_actuator(tmp_path, with_plugin=False)
     res = _runner.invoke(
@@ -160,3 +157,52 @@ def test_publish_dry_run_missing_pyproject_errors(tmp_path):
     )
     assert res.exit_code != 0
     assert "pyproject.toml" in res.output.lower()
+
+
+def test_open_registry_pr_writes_entry_and_calls_gh(tmp_path, monkeypatch):
+    from robot_md.actuator import open_registry_pr
+
+    calls: list[list[str]] = []
+    pr_url = "https://github.com/RobotRegistryFoundation/robot-md/pull/999"
+
+    def _fake_run(cmd, *args, **kwargs):
+        calls.append(cmd)
+
+        class _R:
+            stdout = pr_url if cmd[:2] == ["gh", "pr"] else ""
+            returncode = 0
+
+        return _R()
+
+    monkeypatch.setattr("robot_md.actuator.subprocess.run", _fake_run)
+    monkeypatch.setenv("ROBOT_MD_PUBLISH_WORKTREE", str(tmp_path / "wt"))
+    entry = {"type": "actuator", "name": "x", "version": "1"}
+    out = open_registry_pr(entry)
+    assert out == pr_url
+    invoked = [c[0] for c in calls if c]
+    assert "gh" in invoked
+    assert "git" in invoked
+
+
+def test_open_marketplace_pr_emits_correct_title(tmp_path, monkeypatch):
+    from robot_md.actuator import open_marketplace_pr
+
+    pr_url = "https://github.com/RobotRegistryFoundation/claude-code-plugins/pull/42"
+    titles_seen: list[str] = []
+
+    def _fake_run(cmd, *args, **kwargs):
+        if cmd[:3] == ["gh", "pr", "create"]:
+            i = cmd.index("--title")
+            titles_seen.append(cmd[i + 1])
+
+        class _R:
+            stdout = pr_url if cmd[:2] == ["gh", "pr"] else ""
+            returncode = 0
+
+        return _R()
+
+    monkeypatch.setattr("robot_md.actuator.subprocess.run", _fake_run)
+    monkeypatch.setenv("ROBOT_MD_PUBLISH_WORKTREE", str(tmp_path / "wt"))
+    out = open_marketplace_pr({"name": "feetech-arm", "version": "0.5"})
+    assert out == pr_url
+    assert any("feetech-arm" in t for t in titles_seen)

--- a/cli/tests/test_actuator_publish.py
+++ b/cli/tests/test_actuator_publish.py
@@ -117,3 +117,46 @@ def test_build_registry_entry_with_plugin_includes_marketplace_block():
         e["plugin_marketplace_entry"]["install_command"]
         == "/plugin install feetech-arm@robotregistryfoundation"
     )
+
+
+from typer.testing import CliRunner
+
+from robot_md.__main__ import app
+
+_runner = CliRunner()
+
+
+def test_publish_dry_run_no_plugin_emits_one_pr_payload(tmp_path):
+    pkg = _scaffold_minimal_actuator(tmp_path, with_plugin=False)
+    res = _runner.invoke(
+        app,
+        ["actuator", "publish", "--dry-run", "--package-dir", str(pkg)],
+        env={"NO_COLOR": "1", "TERM": "dumb", "COLUMNS": "200"},
+    )
+    assert res.exit_code == 0, res.output
+    assert "robot-md" in res.stdout
+    assert "site/actuators/index.json" in res.stdout
+    assert "claude-code-plugins" not in res.stdout
+
+
+def test_publish_dry_run_with_plugin_emits_two_pr_payloads(tmp_path):
+    pkg = _scaffold_minimal_actuator(tmp_path, with_plugin=True)
+    res = _runner.invoke(
+        app,
+        ["actuator", "publish", "--dry-run", "--package-dir", str(pkg)],
+        env={"NO_COLOR": "1", "TERM": "dumb", "COLUMNS": "200"},
+    )
+    assert res.exit_code == 0, res.output
+    assert "claude-code-plugins" in res.stdout
+    assert "marketplace.json" in res.stdout
+    assert "site/actuators/index.json" in res.stdout
+
+
+def test_publish_dry_run_missing_pyproject_errors(tmp_path):
+    res = _runner.invoke(
+        app,
+        ["actuator", "publish", "--dry-run", "--package-dir", str(tmp_path)],
+        env={"NO_COLOR": "1", "TERM": "dumb", "COLUMNS": "200"},
+    )
+    assert res.exit_code != 0
+    assert "pyproject.toml" in res.output.lower()

--- a/cli/tests/test_actuator_search.py
+++ b/cli/tests/test_actuator_search.py
@@ -1,12 +1,15 @@
 """Tests for robot_md.actuator.actuator_search business logic."""
+
 from __future__ import annotations
 
 import json
-from pathlib import Path
 
-import pytest
+from typer.testing import CliRunner
 
+from robot_md.__main__ import app
 from robot_md.actuator import actuator_search
+
+runner = CliRunner()
 
 
 def _fake_index() -> dict:
@@ -14,21 +17,26 @@ def _fake_index() -> dict:
         "schema_version": "1.0",
         "entries": [
             {
-                "type": "actuator", "name": "feetech-arm",
-                "version": "1.0", "description": "Feetech bus arm driver",
+                "type": "actuator",
+                "name": "feetech-arm",
+                "version": "1.0",
+                "description": "Feetech bus arm driver",
                 "hardware_tags": ["arm", "feetech"],
                 "manifest_signals": ["SO-ARM101"],
                 "install": {"package_manager": "pip", "package": "feetech-arm"},
             },
             {
-                "type": "actuator", "name": "rpi-camera",
-                "version": "0.3", "description": "Raspberry Pi camera driver",
+                "type": "actuator",
+                "name": "rpi-camera",
+                "version": "0.3",
+                "description": "Raspberry Pi camera driver",
                 "hardware_tags": ["raspberry-pi", "camera"],
                 "manifest_signals": [],
                 "install": {"package_manager": "pip", "package": "rpi-camera"},
             },
             {
-                "type": "skill", "name": "skill-x",
+                "type": "skill",
+                "name": "skill-x",
                 "description": "a skill, not an actuator",
                 "hardware_tags": [],
                 "install": {"package_manager": "pip", "package": "skill-x"},
@@ -67,3 +75,41 @@ def test_actuator_search_threshold_marks_weak():
     # only prints up to limit anyway). Check the no-match path triggers when
     # nothing scores above 0.
     assert "No matches" in out or "weak match" in out
+
+
+def test_search_subcommand_help_is_listed():
+    res = runner.invoke(
+        app, ["actuator", "--help"], env={"NO_COLOR": "1", "TERM": "dumb", "COLUMNS": "200"}
+    )
+    assert res.exit_code == 0
+    assert "search" in res.stdout
+
+
+def test_search_offline_uses_cache(tmp_path, monkeypatch):
+    cache = tmp_path / "registry-index.json"
+    cache.write_text(
+        json.dumps(
+            {
+                "schema_version": "1.0",
+                "entries": [
+                    {
+                        "type": "actuator",
+                        "name": "cached-act",
+                        "version": "1",
+                        "description": "cached entry",
+                        "hardware_tags": ["test"],
+                        "manifest_signals": [],
+                        "install": {"package_manager": "pip", "package": "cached-act"},
+                    }
+                ],
+            }
+        )
+    )
+    monkeypatch.setattr("robot_md.registry.DEFAULT_CACHE_PATH", cache)
+    res = runner.invoke(
+        app,
+        ["actuator", "search", "test", "--offline"],
+        env={"NO_COLOR": "1", "TERM": "dumb", "COLUMNS": "200"},
+    )
+    assert res.exit_code == 0, res.output
+    assert "cached-act" in res.stdout

--- a/cli/tests/test_actuator_search.py
+++ b/cli/tests/test_actuator_search.py
@@ -1,0 +1,69 @@
+"""Tests for robot_md.actuator.actuator_search business logic."""
+from __future__ import annotations
+
+import json
+from pathlib import Path
+
+import pytest
+
+from robot_md.actuator import actuator_search
+
+
+def _fake_index() -> dict:
+    return {
+        "schema_version": "1.0",
+        "entries": [
+            {
+                "type": "actuator", "name": "feetech-arm",
+                "version": "1.0", "description": "Feetech bus arm driver",
+                "hardware_tags": ["arm", "feetech"],
+                "manifest_signals": ["SO-ARM101"],
+                "install": {"package_manager": "pip", "package": "feetech-arm"},
+            },
+            {
+                "type": "actuator", "name": "rpi-camera",
+                "version": "0.3", "description": "Raspberry Pi camera driver",
+                "hardware_tags": ["raspberry-pi", "camera"],
+                "manifest_signals": [],
+                "install": {"package_manager": "pip", "package": "rpi-camera"},
+            },
+            {
+                "type": "skill", "name": "skill-x",
+                "description": "a skill, not an actuator",
+                "hardware_tags": [],
+                "install": {"package_manager": "pip", "package": "skill-x"},
+            },
+        ],
+    }
+
+
+def test_actuator_search_filters_to_actuator_type_by_default():
+    out = actuator_search(_fake_index(), query="raspberry pi", manifest=None)
+    assert "rpi-camera" in out
+    assert "skill-x" not in out  # type=skill filtered out
+
+
+def test_actuator_search_with_manifest_uses_signals():
+    manifest = {"drivers": [{"id": "feetech_bus_0", "model": "SO-ARM101"}]}
+    out = actuator_search(_fake_index(), query="", manifest=manifest)
+    assert "feetech-arm" in out
+
+
+def test_actuator_search_no_results_prints_no_matches():
+    out = actuator_search(_fake_index(), query="aquarium", manifest=None)
+    assert "No matches found" in out
+
+
+def test_actuator_search_type_override_searches_all():
+    out = actuator_search(_fake_index(), query="skill", manifest=None, type_filter="skill")
+    assert "skill-x" in out
+
+
+def test_actuator_search_threshold_marks_weak():
+    # Query has no token overlap and no manifest, so all scores are 0 → weak.
+    idx = _fake_index()
+    out = actuator_search(idx, query="z" * 30, manifest=None, threshold=0.3)
+    # All filtered out (score 0.0 < 0.3 means weak — but format_search_results
+    # only prints up to limit anyway). Check the no-match path triggers when
+    # nothing scores above 0.
+    assert "No matches" in out or "weak match" in out

--- a/cli/tests/test_registry.py
+++ b/cli/tests/test_registry.py
@@ -1,17 +1,17 @@
 """Tests for robot_md.registry — fetch + scoring + formatting."""
+
 from __future__ import annotations
 
 import json
-from pathlib import Path
-from unittest.mock import patch
 
 import pytest
 
 from robot_md.registry import (
     DEFAULT_CATALOG_URL,
-    fetch_index,
-    score_entry,
     extract_manifest_signals,
+    fetch_index,
+    format_search_results,
+    score_entry,
 )
 
 
@@ -26,10 +26,13 @@ def test_fetch_index_writes_cache_on_success(tmp_path, monkeypatch):
     class _FakeResp:
         def __init__(self, body):
             self._body = body
+
         def read(self):
             return self._body
+
         def __enter__(self):
             return self
+
         def __exit__(self, *a):
             return False
 
@@ -93,8 +96,10 @@ def test_extract_manifest_signals_handles_missing_keys():
 
 def test_score_entry_high_when_manifest_signal_overlaps():
     entry = {
-        "name": "x", "description": "irrelevant",
-        "hardware_tags": [], "manifest_signals": ["SO-ARM101"],
+        "name": "x",
+        "description": "irrelevant",
+        "hardware_tags": [],
+        "manifest_signals": ["SO-ARM101"],
     }
     score = score_entry(entry, query="", manifest_signals=["SO-ARM101", "OAK-D-Lite"])
     assert score >= 0.55  # at least the 0.6 weight from signal overlap
@@ -102,8 +107,10 @@ def test_score_entry_high_when_manifest_signal_overlaps():
 
 def test_score_entry_zero_when_no_overlap():
     entry = {
-        "name": "x", "description": "robot arm driver",
-        "hardware_tags": ["arm"], "manifest_signals": ["unobtanium"],
+        "name": "x",
+        "description": "robot arm driver",
+        "hardware_tags": ["arm"],
+        "manifest_signals": ["unobtanium"],
     }
     score = score_entry(entry, query="aquarium pump", manifest_signals=[])
     assert score == 0.0
@@ -111,9 +118,64 @@ def test_score_entry_zero_when_no_overlap():
 
 def test_score_entry_renormalizes_when_no_manifest():
     entry = {
-        "name": "x", "description": "raspberry pi camera driver",
-        "hardware_tags": ["raspberry-pi", "camera"], "manifest_signals": [],
+        "name": "x",
+        "description": "raspberry pi camera driver",
+        "hardware_tags": ["raspberry-pi", "camera"],
+        "manifest_signals": [],
     }
     score = score_entry(entry, query="raspberry pi", manifest_signals=None)
     # 0.3 (tag) + 0.1 (desc fuzzy) = 0.4 in raw weights; renormalized = 1.0.
     assert score == pytest.approx(1.0, abs=0.01)
+
+
+def test_format_search_results_empty_says_no_match():
+    out = format_search_results([], threshold=0.3)
+    assert "No matches found" in out
+    assert "robot-md actuator publish" in out
+
+
+def test_format_search_results_lists_top_entries_with_score():
+    scored = [
+        (
+            {
+                "name": "match-a",
+                "version": "1.0",
+                "description": "desc-a",
+                "install": {"package_manager": "pip", "package": "match-a"},
+            },
+            0.95,
+        ),
+        (
+            {
+                "name": "match-b",
+                "version": "0.2",
+                "description": "desc-b",
+                "install": {"package_manager": "pip", "package": "match-b"},
+                "plugin_marketplace_entry": {"install_command": "/plugin install match-b@rrf"},
+            },
+            0.5,
+        ),
+    ]
+    out = format_search_results(scored, threshold=0.3)
+    assert "match-a" in out and "0.95" in out
+    assert "match-b" in out and "0.50" in out
+    # Plugin entry preferred over pip when both present.
+    assert "/plugin install match-b@rrf" in out
+    assert "pip install match-a" in out
+
+
+def test_format_search_results_marks_below_threshold_as_weak():
+    scored = [
+        (
+            {
+                "name": "weak",
+                "version": "0.1",
+                "description": "barely",
+                "install": {"package_manager": "pip", "package": "weak"},
+            },
+            0.15,
+        ),
+    ]
+    out = format_search_results(scored, threshold=0.3)
+    assert "weak match" in out
+    assert "weak" in out  # entry still printed, not filtered out

--- a/cli/tests/test_registry.py
+++ b/cli/tests/test_registry.py
@@ -1,0 +1,68 @@
+"""Tests for robot_md.registry — fetch + scoring + formatting."""
+from __future__ import annotations
+
+import json
+from pathlib import Path
+from unittest.mock import patch
+
+import pytest
+
+from robot_md.registry import (
+    DEFAULT_CATALOG_URL,
+    fetch_index,
+)
+
+
+def test_default_catalog_url_points_to_robotmd_dev():
+    assert DEFAULT_CATALOG_URL == "https://robotmd.dev/actuators/index.json"
+
+
+def test_fetch_index_writes_cache_on_success(tmp_path, monkeypatch):
+    cache = tmp_path / "registry-index.json"
+    payload = {"schema_version": "1.0", "entries": [{"type": "actuator", "name": "x"}]}
+
+    class _FakeResp:
+        def __init__(self, body):
+            self._body = body
+        def read(self):
+            return self._body
+        def __enter__(self):
+            return self
+        def __exit__(self, *a):
+            return False
+
+    def _fake_urlopen(url, timeout=10):
+        assert url == DEFAULT_CATALOG_URL
+        return _FakeResp(json.dumps(payload).encode())
+
+    monkeypatch.setattr("robot_md.registry.urlopen", _fake_urlopen)
+    out = fetch_index(cache_path=cache, offline=False)
+    assert out == payload
+    assert json.loads(cache.read_text()) == payload
+
+
+def test_fetch_index_offline_reads_cache(tmp_path):
+    cache = tmp_path / "registry-index.json"
+    payload = {"schema_version": "1.0", "entries": []}
+    cache.write_text(json.dumps(payload))
+    out = fetch_index(cache_path=cache, offline=True)
+    assert out == payload
+
+
+def test_fetch_index_offline_missing_cache_raises(tmp_path):
+    cache = tmp_path / "missing.json"
+    with pytest.raises(FileNotFoundError):
+        fetch_index(cache_path=cache, offline=True)
+
+
+def test_fetch_index_falls_back_to_cache_on_http_error(tmp_path, monkeypatch):
+    cache = tmp_path / "registry-index.json"
+    payload = {"schema_version": "1.0", "entries": [{"name": "stale"}]}
+    cache.write_text(json.dumps(payload))
+
+    def _fake_urlopen(url, timeout=10):
+        raise OSError("network down")
+
+    monkeypatch.setattr("robot_md.registry.urlopen", _fake_urlopen)
+    out = fetch_index(cache_path=cache, offline=False)
+    assert out == payload

--- a/cli/tests/test_registry.py
+++ b/cli/tests/test_registry.py
@@ -10,6 +10,8 @@ import pytest
 from robot_md.registry import (
     DEFAULT_CATALOG_URL,
     fetch_index,
+    score_entry,
+    extract_manifest_signals,
 )
 
 
@@ -66,3 +68,52 @@ def test_fetch_index_falls_back_to_cache_on_http_error(tmp_path, monkeypatch):
     monkeypatch.setattr("robot_md.registry.urlopen", _fake_urlopen)
     out = fetch_index(cache_path=cache, offline=False)
     assert out == payload
+
+
+def test_extract_manifest_signals_pulls_driver_ids_and_camera_ids():
+    manifest = {
+        "drivers": [
+            {"id": "feetech_bus_0", "model": "SO-ARM101"},
+            {"id": "oak_d_0", "model": "OAK-D-Lite"},
+        ],
+        "physics": {"solver": {"cameras": [{"driver_id": "oak_d_0"}]}},
+    }
+    sig = extract_manifest_signals(manifest)
+    assert "feetech_bus_0" in sig
+    assert "SO-ARM101" in sig
+    assert "oak_d_0" in sig
+    assert "OAK-D-Lite" in sig
+
+
+def test_extract_manifest_signals_handles_missing_keys():
+    assert extract_manifest_signals({}) == []
+    assert extract_manifest_signals({"drivers": []}) == []
+    assert extract_manifest_signals({"physics": {}}) == []
+
+
+def test_score_entry_high_when_manifest_signal_overlaps():
+    entry = {
+        "name": "x", "description": "irrelevant",
+        "hardware_tags": [], "manifest_signals": ["SO-ARM101"],
+    }
+    score = score_entry(entry, query="", manifest_signals=["SO-ARM101", "OAK-D-Lite"])
+    assert score >= 0.55  # at least the 0.6 weight from signal overlap
+
+
+def test_score_entry_zero_when_no_overlap():
+    entry = {
+        "name": "x", "description": "robot arm driver",
+        "hardware_tags": ["arm"], "manifest_signals": ["unobtanium"],
+    }
+    score = score_entry(entry, query="aquarium pump", manifest_signals=[])
+    assert score == 0.0
+
+
+def test_score_entry_renormalizes_when_no_manifest():
+    entry = {
+        "name": "x", "description": "raspberry pi camera driver",
+        "hardware_tags": ["raspberry-pi", "camera"], "manifest_signals": [],
+    }
+    score = score_entry(entry, query="raspberry pi", manifest_signals=None)
+    # 0.3 (tag) + 0.1 (desc fuzzy) = 0.4 in raw weights; renormalized = 1.0.
+    assert score == pytest.approx(1.0, abs=0.01)

--- a/cli/tests/test_skill_content.py
+++ b/cli/tests/test_skill_content.py
@@ -1,0 +1,19 @@
+"""Tests that the bundled SKILL.md ships the expected guidance sections."""
+from __future__ import annotations
+
+from pathlib import Path
+
+SKILL = (
+    Path(__file__).resolve().parents[1]
+    / "src"
+    / "robot_md"
+    / "skills"
+    / "using-robot-md.SKILL.md"
+)
+
+
+def test_skill_contains_search_before_write_section():
+    src = SKILL.read_text()
+    assert "Before writing an actuator from scratch" in src
+    assert "robot-md actuator search" in src
+    assert "robot-md actuator publish" in src

--- a/cli/tests/test_skill_content.py
+++ b/cli/tests/test_skill_content.py
@@ -1,14 +1,11 @@
 """Tests that the bundled SKILL.md ships the expected guidance sections."""
+
 from __future__ import annotations
 
 from pathlib import Path
 
 SKILL = (
-    Path(__file__).resolve().parents[1]
-    / "src"
-    / "robot_md"
-    / "skills"
-    / "using-robot-md.SKILL.md"
+    Path(__file__).resolve().parents[1] / "src" / "robot_md" / "skills" / "using-robot-md.SKILL.md"
 )
 
 

--- a/site/actuators/index.html
+++ b/site/actuators/index.html
@@ -1,0 +1,161 @@
+<!doctype html>
+<html lang="en">
+<head>
+  <meta charset="utf-8">
+  <meta name="viewport" content="width=device-width,initial-scale=1">
+  <title>Actuator catalog — ROBOT.md</title>
+  <meta name="description" content="Discover production actuators for robot-md-gateway. Search by hardware tag, manifest signal, or fuzzy text. Install via pip or /plugin install.">
+  <meta name="theme-color" content="#F4EFE6">
+  <meta property="og:title" content="Actuator catalog — ROBOT.md">
+  <meta property="og:description" content="Production actuators discoverable from CLI or browser. Search-before-write.">
+  <meta property="og:url" content="https://robotmd.dev/actuators/">
+  <meta property="og:type" content="website">
+  <link rel="canonical" href="https://robotmd.dev/actuators/">
+  <link rel="preconnect" href="https://fonts.googleapis.com">
+  <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>
+  <link href="https://fonts.googleapis.com/css2?family=Inter+Tight:wght@300;400;500;600;700&family=JetBrains+Mono:wght@400;500;600&family=Fraunces:ital,wght@1,400;1,600&display=swap" rel="stylesheet">
+  <link rel="stylesheet" href="/css/design.css">
+  <style>
+    .filter-bar { display:flex; gap:12px; align-items:center; margin: 24px 0 12px; }
+    .filter-bar input { flex:1; font-family: var(--mono); font-size: 14px; padding: 10px 14px; border: 1px solid var(--rule); background: var(--paper); color: var(--ink); border-radius: 2px; }
+    .filter-bar select { font-family: var(--mono); font-size: 12px; padding: 9px 12px; border: 1px solid var(--rule); background: var(--paper-2); color: var(--ink); }
+    .entry-card { padding: 20px 24px; border: 1px solid var(--rule); margin-bottom: 12px; }
+    .entry-card.hidden { display: none; }
+    .entry-name { font-family: var(--mono); font-weight: 600; font-size: 15px; color: var(--ink); }
+    .entry-version { font-family: var(--mono); font-size: 11px; color: var(--ink-3); margin-left: 8px; }
+    .entry-type { font-family: var(--mono); font-size: 10px; letter-spacing: .14em; text-transform: uppercase; color: var(--accent); margin-left: 12px; }
+    .entry-desc { font-size: 13.5px; color: var(--ink-2); margin: 8px 0 12px; line-height: 1.5; }
+    .entry-tags { display: flex; gap: 6px; flex-wrap: wrap; margin: 8px 0 12px; }
+    .entry-tag { font-family: var(--mono); font-size: 10.5px; padding: 2px 8px; background: var(--paper-2); border: 1px solid var(--rule); color: var(--ink-3); }
+    .entry-install { font-family: var(--mono); font-size: 12px; background: var(--ink); color: #E8E3D3; padding: 10px 14px; margin: 6px 0; }
+    .entry-plugin-badge { font-family: var(--mono); font-size: 10.5px; padding: 3px 8px; background: var(--accent); color: var(--paper); margin-left: 8px; letter-spacing: .08em; text-transform: uppercase; }
+    .empty-state { padding: 40px 24px; text-align: center; color: var(--ink-3); border: 1px dashed var(--rule); }
+  </style>
+</head>
+<body>
+  <header class="site-nav" role="banner">
+    <div class="wrap site-nav-inner">
+      <a class="wordmark" href="/" aria-label="ROBOT.md home">
+        ROBOT<span class="dot">.</span><span class="md">md</span>
+      </a>
+      <nav aria-label="Site navigation">
+        <a href="https://docs.robotmd.dev/spec/">Spec</a>
+        <a href="/agents/claude-code/">Agents</a>
+        <a href="https://docs.robotmd.dev/mcp/">MCP</a>
+        <a href="/actuators/" class="current" aria-current="page">Actuators</a>
+        <a href="/registry/">Registry</a>
+        <a href="https://docs.robotmd.dev/compliance/">Compliance</a>
+        <a href="/managed-agents/">Managed Agents</a>
+        <a href="/robots">Robots</a>
+        <a href="https://github.com/RobotRegistryFoundation/robot-md" aria-label="GitHub repository">GitHub</a>
+      </nav>
+    </div>
+  </header>
+  <header class="page-header">
+    <div class="wrap">
+      <div class="page-eyebrow">
+        <span>Actuator catalog</span>
+        <span class="rule-line" aria-hidden="true"></span>
+        <span><a href="https://robotmd.dev/cookbook/">cookbook</a> · search-before-write</span>
+      </div>
+      <h1 class="page-heading">Discoverable production <em>actuators</em>.</h1>
+      <p class="page-lede">
+        Each entry maps a hardware archetype or manifest signal to a published Python package
+        and (when shipped) a Claude Code plugin. Search from the CLI:
+        <code style="font-family:var(--mono);font-size:0.85em">robot-md actuator search "raspberry pi camera"</code>.
+      </p>
+    </div>
+  </header>
+  <section class="sec">
+    <div class="wrap">
+      <div class="filter-bar">
+        <input id="filter" placeholder="Filter by name, description, hardware tag…" aria-label="Filter actuators">
+        <select id="type-filter" aria-label="Filter by type">
+          <option value="">All types</option>
+          <option value="actuator">actuator</option>
+          <option value="skill">skill</option>
+          <option value="plugin">plugin</option>
+          <option value="mcp">mcp</option>
+        </select>
+      </div>
+      <div id="entries"></div>
+      <div id="empty" class="empty-state" hidden>
+        No actuators published yet — be the first.
+        Run <code style="font-family:var(--mono)">robot-md actuator publish</code> from your package directory.
+      </div>
+    </div>
+  </section>
+  <footer class="wrap foot">
+    <div>ROBOT.md · © 2026 Craig Merry · <a href="https://www.craigmerry.com">craigmerry.com</a></div>
+    <div>
+      <a href="/">Home</a> ·
+      <a href="https://docs.robotmd.dev/spec/">Spec</a> ·
+      <a href="/registry/">Registry</a> ·
+      <a href="/actuators/">Actuators</a> ·
+      <a href="https://github.com/RobotRegistryFoundation/robot-md">GitHub</a>
+    </div>
+  </footer>
+  <script>
+    (async () => {
+      const container = document.getElementById('entries');
+      const empty = document.getElementById('empty');
+      const filter = document.getElementById('filter');
+      const typeFilter = document.getElementById('type-filter');
+      let data = { entries: [] };
+      try {
+        const res = await fetch('./index.json', { cache: 'no-cache' });
+        data = await res.json();
+      } catch (e) {
+        container.innerHTML = '<div class="empty-state">Catalog data unavailable. Try again later.</div>';
+        return;
+      }
+      function renderEntry(e) {
+        const div = document.createElement('div');
+        div.className = 'entry-card';
+        div.dataset.haystack = [e.name, e.description, (e.hardware_tags || []).join(' '), (e.manifest_signals || []).join(' ')].join(' ').toLowerCase();
+        div.dataset.type = e.type || 'actuator';
+        const pluginBadge = e.plugin_marketplace_entry
+          ? `<span class="entry-plugin-badge">Available as Claude Code plugin</span>` : '';
+        const tags = (e.hardware_tags || []).map(t => `<span class="entry-tag">${t}</span>`).join('');
+        const pluginCmd = e.plugin_marketplace_entry
+          ? `<div class="entry-install">$ ${e.plugin_marketplace_entry.install_command}</div>` : '';
+        const pipCmd = e.install
+          ? `<div class="entry-install">$ ${e.install.package_manager} install ${e.install.package}${e.install.post_install ? ' && ' + e.install.post_install : ''}</div>`
+          : '';
+        div.innerHTML = `
+          <div>
+            <span class="entry-name">${e.name}</span>
+            <span class="entry-version">${e.version || ''}</span>
+            <span class="entry-type">${e.type || 'actuator'}</span>
+            ${pluginBadge}
+          </div>
+          <div class="entry-desc">${e.description || ''}</div>
+          <div class="entry-tags">${tags}</div>
+          ${pluginCmd}
+          ${pipCmd}
+        `;
+        return div;
+      }
+      const entries = (data.entries || []).map(renderEntry);
+      entries.forEach(el => container.appendChild(el));
+      function applyFilter() {
+        const q = filter.value.trim().toLowerCase();
+        const t = typeFilter.value;
+        let visible = 0;
+        entries.forEach(el => {
+          const matchText = !q || el.dataset.haystack.includes(q);
+          const matchType = !t || el.dataset.type === t;
+          const show = matchText && matchType;
+          el.classList.toggle('hidden', !show);
+          if (show) visible++;
+        });
+        empty.hidden = visible > 0 || (data.entries || []).length === 0;
+        if ((data.entries || []).length === 0) empty.hidden = false;
+      }
+      filter.addEventListener('input', applyFilter);
+      typeFilter.addEventListener('change', applyFilter);
+      applyFilter();
+    })();
+  </script>
+</body>
+</html>

--- a/site/actuators/index.json
+++ b/site/actuators/index.json
@@ -1,0 +1,5 @@
+{
+  "schema_version": "1.0",
+  "generated_at": "2026-05-09T00:00:00Z",
+  "entries": []
+}

--- a/site/index.html
+++ b/site/index.html
@@ -899,6 +899,7 @@
         <a href="https://docs.robotmd.dev/spec/">Spec</a>
         <a href="/agents/">Agents</a>
         <a href="https://docs.robotmd.dev/mcp/">MCP</a>
+        <a href="/actuators/">Actuators</a>
         <a href="/registry/">Registry</a>
         <a href="https://docs.robotmd.dev/compliance/">Compliance</a>
         <a href="/managed-agents/">Managed Agents</a>

--- a/site/registry/index.html
+++ b/site/registry/index.html
@@ -189,6 +189,7 @@
         <a href="https://docs.robotmd.dev/spec/">Spec</a>
         <a href="/agents/claude-code/">Agents</a>
         <a href="https://docs.robotmd.dev/mcp/">MCP</a>
+        <a href="/actuators/">Actuators</a>
         <a href="/registry/" class="current" aria-current="page">Registry</a>
         <a href="https://docs.robotmd.dev/compliance/">Compliance</a>
         <a href="/managed-agents/">Managed Agents</a>


### PR DESCRIPTION
## Summary

Plan 3 of the gateway-actuator-extension umbrella — ships the share-broadly half of the actuator surface.

- **`robot-md actuator search "<query>" [--manifest ROBOT.md] [--type ...] [--threshold ...] [--offline]`** — fetches `https://robotmd.dev/actuators/index.json`, scores entries against query + manifest signals, prints top-5 with install commands.
- **`robot-md actuator publish [--dry-run] [--package-dir]`** — detects plugin layout, opens 1 or 2 GitHub PRs (catalog + optionally marketplace).
- **New static catalog** at `https://robotmd.dev/actuators/` — HTML + JSON, no framework, no build.
- **Bundled `using-robot-md.SKILL.md`** updated: Claude is now told to search-before-write.
- **robot-md 1.6.0 → 1.7.0** (minor).

## Path-collision note

Spec §3.1–3.2 placed the catalog at `site/registry/`, which would have overwritten the existing RRF identity page. Operator decision (2026-05-09) was to host the catalog at `site/actuators/` instead. All references updated accordingly.

## Test plan

- [x] All four CI test matrix versions green (Py 3.10/3.11/3.12/3.13)
- [x] +33 new tests (registry/search/publish/skill); no regressions
- [x] ruff format + check both clean
- [ ] After merge: `robot-md actuator search "raspberry pi"` returns the no-match message (catalog ships empty)
- [ ] After merge: \`https://robotmd.dev/actuators/\` loads, filter input + type select work, empty-state visible

🤖 Generated with [Claude Code](https://claude.com/claude-code)