### PR TITLE
fix(ci): pin wrangler commit-message to ASCII (Cloudflare API reject)

### DIFF
--- a/.github/workflows/deploy-site.yml
+++ b/.github/workflows/deploy-site.yml
@@ -41,7 +41,7 @@ jobs:
         with:
           apiToken: ${{ secrets.CLOUDFLARE_API_TOKEN }}
           accountId: ${{ secrets.CLOUDFLARE_ACCOUNT_ID }}
-          command: pages deploy site --project-name=robotmd-dev --branch=main
+          command: pages deploy site --project-name=robotmd-dev --branch=main --commit-hash=${{ github.sha }} --commit-message="${{ github.sha }} (deploy via Actions)"
 
       - name: Smoke test
         run: |


### PR DESCRIPTION
## Summary

Hotfix for the failed v1.7.0 site deploy. Cloudflare Pages API rejected the merge commit with \`code: 8000111 - Invalid commit message, it must be a valid UTF-8 string\`. The em-dashes in the squash-merge title are valid UTF-8 but Cloudflare's validator is strict.

Forces \`--commit-message\` to be the SHA (ASCII-only). Deploy will remain robust to any PR-title character choice going forward.

## Test plan

- [ ] After merge: \`Deploy site\` workflow succeeds on the merge commit
- [ ] After merge: \`https://robotmd.dev/actuators/index.json\` returns JSON (not the SPA fallback)
- [ ] After merge: \`robot-md actuator search "anything"\` returns the empty-catalog message

🤖 Generated with [Claude Code](https://claude.com/claude-code)