### PR TITLE
fix: robot-md 1.7.1 — set User-Agent on catalog fetch (DOA hotfix)

### DIFF
--- a/cli/pyproject.toml
+++ b/cli/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "hatchling.build"
 
 [project]
 name = "robot-md"
-version = "1.7.0"
+version = "1.7.1"
 description = "ROBOT.md — a single self-describing file so Claude can safely operate your robot."
 readme = "../README.md"
 requires-python = ">=3.10"

--- a/cli/src/robot_md/registry.py
+++ b/cli/src/robot_md/registry.py
@@ -9,10 +9,11 @@ from __future__ import annotations
 import json
 from pathlib import Path
 from urllib.error import URLError
-from urllib.request import urlopen
+from urllib.request import Request, urlopen
 
 DEFAULT_CATALOG_URL = "https://robotmd.dev/actuators/index.json"
 DEFAULT_CACHE_PATH = Path.home() / ".cache" / "robot-md" / "registry-index.json"
+USER_AGENT = "robot-md/cli (+https://robotmd.dev)"
 
 
 def fetch_index(
@@ -33,7 +34,8 @@ def fetch_index(
     if offline:
         return json.loads(cache_path.read_text())
     try:
-        with urlopen(url, timeout=timeout) as resp:
+        req = Request(url, headers={"User-Agent": USER_AGENT})
+        with urlopen(req, timeout=timeout) as resp:
             body = resp.read()
         payload = json.loads(body.decode())
         cache_path.parent.mkdir(parents=True, exist_ok=True)

--- a/cli/tests/test_registry.py
+++ b/cli/tests/test_registry.py
@@ -36,8 +36,11 @@ def test_fetch_index_writes_cache_on_success(tmp_path, monkeypatch):
         def __exit__(self, *a):
             return False
 
-    def _fake_urlopen(url, timeout=10):
-        assert url == DEFAULT_CATALOG_URL
+    def _fake_urlopen(req, timeout=10):
+        actual_url = req.full_url if hasattr(req, "full_url") else req
+        assert actual_url == DEFAULT_CATALOG_URL
+        if hasattr(req, "headers"):
+            assert any(k.lower() == "user-agent" for k in req.headers)
         return _FakeResp(json.dumps(payload).encode())
 
     monkeypatch.setattr("robot_md.registry.urlopen", _fake_urlopen)
@@ -65,7 +68,7 @@ def test_fetch_index_falls_back_to_cache_on_http_error(tmp_path, monkeypatch):
     payload = {"schema_version": "1.0", "entries": [{"name": "stale"}]}
     cache.write_text(json.dumps(payload))
 
-    def _fake_urlopen(url, timeout=10):
+    def _fake_urlopen(req, timeout=10):
         raise OSError("network down")
 
     monkeypatch.setattr("robot_md.registry.urlopen", _fake_urlopen)


### PR DESCRIPTION
## Summary

\`robot-md actuator search\` was DOA in 1.7.0: Cloudflare's bot protection returns HTTP 403 for the default \`Python-urllib/X.Y\` User-Agent. Curl works because it sends a recognized UA.

Fix: pass an explicit User-Agent via \`urllib.request.Request\`. Bump to 1.7.1.

## Reproduction

```bash
pip install robot-md==1.7.0
robot-md actuator search "anything"
# → "No catalog cache available. Run without --offline first to populate it."
```

## Verification (post-merge + 1.7.1 PyPI)

```bash
pip install -U robot-md==1.7.1
robot-md actuator search "anything"
# Expected: "No matches found. Ask Claude Code to write one, then 'robot-md actuator publish'..."
```

## Test plan

- [x] Updated \`test_fetch_index_writes_cache_on_success\` to verify the Request carries User-Agent
- [x] Other tests unchanged; 13/13 pass
- [ ] After merge + tag v1.7.1: smoke install verifies search reaches the catalog

🤖 Generated with [Claude Code](https://claude.com/claude-code)