### PR TITLE
fix(cli): source __version__ from importlib.metadata

### DIFF
--- a/cli/src/robot_md/__init__.py
+++ b/cli/src/robot_md/__init__.py
@@ -1,3 +1,9 @@
 """robot-md — parse, validate, and render ROBOT.md files."""
 
-__version__ = "1.5.1"
+from importlib.metadata import version as _pkg_version, PackageNotFoundError
+
+try:
+    __version__ = _pkg_version("robot-md")
+except PackageNotFoundError:
+    # Editable install before egg-info is registered, or running from source tree.
+    __version__ = "0.0.0+source"

--- a/cli/tests/test_version.py
+++ b/cli/tests/test_version.py
@@ -1,0 +1,25 @@
+import subprocess
+import sys
+from importlib.metadata import version as pkg_version
+
+
+def test_version_command_matches_installed_metadata():
+    """`robot-md --version` must report the same string as pip metadata."""
+    expected = pkg_version("robot-md")
+    result = subprocess.run(
+        [sys.executable, "-m", "robot_md", "--version"],
+        capture_output=True,
+        text=True,
+        check=True,
+    )
+    out = result.stdout.strip()
+    assert out.endswith(expected), (
+        f"version drift: --version reported {out!r}, "
+        f"pip metadata reports {expected!r}"
+    )
+
+
+def test_dunder_version_matches_installed_metadata():
+    """`robot_md.__version__` must come from importlib.metadata, not a literal."""
+    import robot_md
+    assert robot_md.__version__ == pkg_version("robot-md")


### PR DESCRIPTION
## Summary
- Replaces hardcoded `__version__ = "1.5.1"` in `cli/src/robot_md/__init__.py` with `importlib.metadata.version("robot-md")` lookup.
- Adds regression tests asserting the CLI output matches pip-show metadata.
- Closes Spec A gap #5 (version-string mismatch) from `operations/2026-05-10-bob-10min-baseline.md`.

## Test plan
- [x] `pytest cli/tests/test_version.py -v` — 2/2 PASS
- [x] `robot-md --version` now matches `pip3 show robot-md | grep Version`
- [ ] Manual smoke after merge: install on Pi, confirm both report same version

🤖 Generated with [Claude Code](https://claude.com/claude-code)