### PR TITLE
fix(cli): bump rcan_version template from 3.0 to 3.2

### DIFF
--- a/cli/src/robot_md/autodetect.py
+++ b/cli/src/robot_md/autodetect.py
@@ -763,7 +763,7 @@ def emit_draft(scan: Scan) -> str:
     lines: list[str] = []
     lines.append("---")
     lines.append(_DRAFT_HEADER_YAML_COMMENT.rstrip())
-    lines.append('rcan_version: "3.0"')
+    lines.append('rcan_version: "3.2"')
     lines.append("metadata:")
     lines.append('  robot_name: "CHANGE-ME"  # TODO: short display name; must match H1 below')
     lines.append('  rrn: ""  # blank until `robot-md register` (v0.2) returns one')

--- a/cli/tests/test_autodetect_rcan_version.py
+++ b/cli/tests/test_autodetect_rcan_version.py
@@ -1,0 +1,16 @@
+import yaml
+from robot_md.autodetect import Scan, emit_draft
+
+
+def test_emit_draft_uses_current_rcan_version():
+    """The init draft must match the current canonical RCAN spec version."""
+    # Pin to the canonical version. When rcan-py bumps, this test forces a
+    # template review — drift is intentional friction.
+    expected = "3.2"
+    draft = emit_draft(Scan())
+    fm_block = draft.split("---\n", 2)[1]  # frontmatter between --- markers
+    fm = yaml.safe_load(fm_block)
+    assert fm["rcan_version"] == expected, (
+        f"rcan_version template drift: emitted {fm['rcan_version']!r}, "
+        f"expected {expected!r}. Bump the template literal in autodetect.py."
+    )


### PR DESCRIPTION
## Summary
- Bumps the literal `rcan_version: "3.0"` inside `emit_draft` to `"3.2"` so freshly-init'd ROBOT.md matches the current canonical RCAN spec version (used by cookbook + case studies).
- Adds a regression test that asserts the emitted draft pins to "3.2" — intentional friction for future version bumps.
- Closes Spec A gap #4 (template drift) from the baseline.

## Test plan
- [x] `pytest cli/tests/test_autodetect_rcan_version.py -v` — PASS
- [x] All 17 existing autodetect tests still green
- [ ] Manual smoke: after merge, `robot-md init` writes manifest with `rcan_version: "3.2"`

🤖 Generated with [Claude Code](https://claude.com/claude-code)