### PR TITLE
fix(cli): filter pispbe-* Pi ISP nodes from v4l2 camera list

### DIFF
--- a/cli/src/robot_md/autodetect.py
+++ b/cli/src/robot_md/autodetect.py
@@ -211,6 +211,15 @@ USB_DB: dict[tuple[str, str], dict[str, str]] = {
     },
 }
 
+# --------------------------------------------------------------------------- #
+# V4L2 known non-camera filters                                              #
+# --------------------------------------------------------------------------- #
+# Known non-camera V4L2 device-name prefixes. Conservative: false positives
+# (hiding a real camera) are worse than false negatives (showing a probe
+# node). Each entry MUST be documented with provenance.
+V4L2_KNOWN_NON_CAMERA_PREFIXES = (
+    "pispbe-",  # Raspberry Pi ISP back-end probe nodes (provenance: Pi 5 + IMX708)
+)
 
 # --------------------------------------------------------------------------- #
 # Data types                                                                  #
@@ -687,6 +696,8 @@ def probe_v4l2_cameras() -> list[DetectedCamera]:
     for path in devices:
         caps = _v4l2_device_capabilities(path)
         model = caps.get("model", "USB Camera")
+        if any(model.startswith(p) for p in V4L2_KNOWN_NON_CAMERA_PREFIXES):
+            continue  # filtered; debug logging optional in future
         cams.append(
             DetectedCamera(
                 driver_id=_slugify(model) + "-" + Path(path).name,

--- a/cli/tests/test_autodetect_v4l2_filter.py
+++ b/cli/tests/test_autodetect_v4l2_filter.py
@@ -1,0 +1,29 @@
+from unittest.mock import patch
+from robot_md.autodetect import probe_v4l2_cameras
+
+
+def test_pispbe_video_nodes_are_filtered():
+    """Pi ISP probe nodes (pispbe-*) should not appear as cameras."""
+    fake_paths = [
+        "/dev/video0",   # real USB cam
+        "/dev/video19",  # pispbe-input
+        "/dev/video20",  # pispbe-tdn-input
+        "/dev/video21",  # pispbe-stitch-input
+    ]
+    fake_caps = {
+        "/dev/video0":  {"model": "Logitech C920",   "width": 1280, "height": 720},
+        "/dev/video19": {"model": "pispbe-input",    "width": 640,  "height": 480},
+        "/dev/video20": {"model": "pispbe-tdn-input","width": 640,  "height": 480},
+        "/dev/video21": {"model": "pispbe-stitch-input","width": 640,"height": 480},
+    }
+
+    with patch("robot_md.autodetect._v4l2_list_devices", return_value=fake_paths), \
+         patch("robot_md.autodetect._v4l2_device_capabilities",
+               side_effect=lambda p: fake_caps[p]):
+        cams = probe_v4l2_cameras()
+
+    models = [c.model for c in cams]
+    assert "Logitech C920" in models
+    assert not any(m.startswith("pispbe-") for m in models), (
+        f"pispbe-* nodes leaked into camera list: {models}"
+    )


### PR DESCRIPTION
## Summary
- Adds `V4L2_KNOWN_NON_CAMERA_PREFIXES = ("pispbe-",)` at module level in `autodetect.py` with provenance comment (Pi 5 + IMX708).
- Applies the filter inside `probe_v4l2_cameras` so the ~35 Pi ISP back-end probe nodes (pispbe-input, pispbe-tdn-input, etc.) no longer surface as false-positive cameras in `robot-md doctor`.
- Closes Spec A gap #8 from the baseline.
- Conservative design: filter is per-prefix, false positives (hiding a real camera) are worse than false negatives — new prefixes require provenance comments.

## Test plan
- [x] `pytest cli/tests/test_autodetect_v4l2_filter.py -v` — PASS (real Logitech cam preserved, all 3 pispbe variants filtered)
- [x] All 17 existing autodetect tests green
- [ ] Manual smoke on Bob (Pi 5): `robot-md doctor` no longer lists pispbe-* devices

🤖 Generated with [Claude Code](https://claude.com/claude-code)