### PR TITLE
feat(doctor): explain /dev/ttyACM gateway-user ownership as informational warn

### DIFF
--- a/cli/src/robot_md/doctor.py
+++ b/cli/src/robot_md/doctor.py
@@ -18,7 +18,9 @@ Output: a rich Table. Exit code 0 if all checks pass or only warn, 1 on any fail
 
 from __future__ import annotations
 
+import grp
 import os
+import pwd
 import socket
 import sys
 from dataclasses import dataclass
@@ -111,6 +113,17 @@ def _which(cmd: str) -> str | None:
         if p.is_file() and os.access(p, os.X_OK):
             return str(p)
     return None
+
+
+def _is_owned_by_gateway(path: Path) -> bool:
+    """True if the path is owned by the system robot-md-gateway user/group."""
+    try:
+        st = path.stat()
+        owner = pwd.getpwuid(st.st_uid).pw_name
+        group = grp.getgrgid(st.st_gid).gr_name
+    except (KeyError, OSError):
+        return False
+    return owner == "robot-md-gateway" or group == "robot-md-gateway"
 
 
 # ---------------------------------------------------------------- 2. manifest
@@ -251,6 +264,10 @@ def check_drivers(fm: dict[str, Any] | None) -> list[CheckResult]:
             p = Path(port)
             if not p.exists():
                 out.append(_fail(label, "drivers", f"{port} — does not exist (unplugged?)"))
+            elif _is_owned_by_gateway(p):
+                out.append(_warn(label, "drivers",
+                    f"{port} — claimed by robot-md-gateway user (intentional); "
+                    f"talk to the gateway at 127.0.0.1:8080, not the device directly."))
             elif not os.access(p, os.R_OK | os.W_OK):
                 out.append(_warn(label, "drivers", f"{port} — exists but not RW (dialout group?)"))
             else:

--- a/cli/tests/test_doctor_gateway_claim.py
+++ b/cli/tests/test_doctor_gateway_claim.py
@@ -1,0 +1,21 @@
+from unittest.mock import patch
+from robot_md.doctor import check_drivers
+
+
+def test_doctor_explains_ttyacm_owned_by_gateway():
+    """When /dev/ttyACM0 is owned by robot-md-gateway user, surface that as
+    informational warning, not a hard fail. Gateway-as-bus-owner is intended."""
+    fm = {"drivers": [{"id": "serial-ttyACM0", "protocol": "serial",
+                       "port": "/dev/ttyACM0"}]}
+
+    with patch("pathlib.Path.exists", return_value=True), \
+         patch("os.access", return_value=False), \
+         patch("robot_md.doctor._is_owned_by_gateway", return_value=True):
+        results = check_drivers(fm)
+
+    matching = [r for r in results if "gateway" in r.detail.lower()
+                and r.status == "warn"]
+    assert matching, (
+        f"doctor should emit warn-with-gateway-explanation; got: "
+        f"{[(r.status, r.detail) for r in results]}"
+    )


### PR DESCRIPTION
## Summary
- Adds `_is_owned_by_gateway(path)` helper using `pwd`/`grp` to detect when a tty device is owned by the `robot-md-gateway` system user/group (intentional architecture: gateway is the bus owner).
- Inserts a new branch in `check_drivers` BETWEEN the exists-fail and the generic permission-warn cases — order matters so the gateway message isn't masked by the existing dialout-group hint.
- The new warn message explains: "claimed by robot-md-gateway user (intentional); talk to the gateway at 127.0.0.1:8080, not the device directly."
- Closes Spec A gap #7 from the baseline.

## Test plan
- [x] `pytest cli/tests/test_doctor_gateway_claim.py -v` — PASS
- [x] All 13 doctor tests green
- [ ] Manual smoke on Bob: `robot-md doctor` now emits the gateway-claim explanation when /dev/ttyACM0 is gateway-owned

🤖 Generated with [Claude Code](https://claude.com/claude-code)