### PR TITLE
feat: Spec A Tasks 13-17 — install_backend init phase

### DIFF
--- a/cli/src/robot_md/__init__.py
+++ b/cli/src/robot_md/__init__.py
@@ -1,6 +1,7 @@
 """robot-md — parse, validate, and render ROBOT.md files."""
 
-from importlib.metadata import version as _pkg_version, PackageNotFoundError
+from importlib.metadata import PackageNotFoundError
+from importlib.metadata import version as _pkg_version
 
 try:
     __version__ = _pkg_version("robot-md")

--- a/cli/src/robot_md/doctor.py
+++ b/cli/src/robot_md/doctor.py
@@ -265,9 +265,14 @@ def check_drivers(fm: dict[str, Any] | None) -> list[CheckResult]:
             if not p.exists():
                 out.append(_fail(label, "drivers", f"{port} — does not exist (unplugged?)"))
             elif _is_owned_by_gateway(p):
-                out.append(_warn(label, "drivers",
-                    f"{port} — claimed by robot-md-gateway user (intentional); "
-                    f"talk to the gateway at 127.0.0.1:8080, not the device directly."))
+                out.append(
+                    _warn(
+                        label,
+                        "drivers",
+                        f"{port} — claimed by robot-md-gateway user (intentional); "
+                        f"talk to the gateway at 127.0.0.1:8080, not the device directly.",
+                    )
+                )
             elif not os.access(p, os.R_OK | os.W_OK):
                 out.append(_warn(label, "drivers", f"{port} — exists but not RW (dialout group?)"))
             else:

--- a/cli/src/robot_md/init.py
+++ b/cli/src/robot_md/init.py
@@ -545,6 +545,7 @@ _PHASE_NAMES = (
     "PhaseResult",
     "phase_write_manifest",
     "phase_register",
+    "phase_install_backend",
     "phase_install_mcp",
     "phase_install_skill",
     "phase_calibrate_sign",
@@ -621,6 +622,7 @@ def default_flow(
     _self = sys.modules[__name__]
     phase_write_manifest = _self.phase_write_manifest  # type: ignore[attr-defined]
     phase_register = _self.phase_register  # type: ignore[attr-defined]
+    phase_install_backend = _self.phase_install_backend  # type: ignore[attr-defined]
     # install_mcp deprecated per SP1 R1 — plugin's .mcp.json handles wiring.
     phase_install_skill = _self.phase_install_skill  # type: ignore[attr-defined]
     phase_calibrate_sign = _self.phase_calibrate_sign  # type: ignore[attr-defined]
@@ -657,6 +659,16 @@ def default_flow(
     if r_write.status != "ok":
         _print_tally(results, out_path)
         return 2  # only fatal exit path
+
+    # Phase 1.25: auto-install backend packages indicated by the hardware scan.
+    # The manifest references devices the operator can't actually drive without
+    # the matching backend; failing here is fatal to the init flow.
+    ib_result = phase_install_backend(scan)
+    results.append(ib_result)
+    if ib_result.status == "failed":
+        sys.stderr.write(f"✗ {ib_result.message}\n")
+        _print_tally(results, out_path)
+        return 1
 
     # Phase 1.5: scaffold scripts/ + compliance/ alongside the manifest.
     # EU AI Act evidence has to live somewhere reproducible — emit-* artifacts

--- a/cli/src/robot_md/init_phases/__init__.py
+++ b/cli/src/robot_md/init_phases/__init__.py
@@ -26,6 +26,7 @@ from robot_md.init_phases.calibrate_extrinsic import phase_calibrate_extrinsic  
 from robot_md.init_phases.calibrate_sign import phase_calibrate_sign  # noqa: E402
 from robot_md.init_phases.calibrate_zero import phase_calibrate_zero  # noqa: E402
 from robot_md.init_phases.compliance_scaffold import phase_compliance_scaffold  # noqa: E402
+from robot_md.init_phases.install_backend import phase_install_backend  # noqa: E402
 from robot_md.init_phases.install_mcp import phase_install_mcp  # noqa: E402
 from robot_md.init_phases.install_skill import phase_install_skill  # noqa: E402
 from robot_md.init_phases.register import phase_register  # noqa: E402
@@ -41,6 +42,7 @@ __all__ = [
     "phase_calibrate_sign",
     "phase_calibrate_zero",
     "phase_compliance_scaffold",
+    "phase_install_backend",
     "phase_install_mcp",
     "phase_install_skill",
     "phase_register",

--- a/cli/src/robot_md/init_phases/install_backend.py
+++ b/cli/src/robot_md/init_phases/install_backend.py
@@ -42,7 +42,9 @@ _RULES: list = [
     ),
     (
         lambda devs: any(
-            d.vid == "03e7" and d.pid in ("2485", "f63c") for d in devs
+            getattr(d, "vid", None) == "03e7"
+            and getattr(d, "pid", None) in ("2485", "f63c")
+            for d in devs
         ),
         PackageMatch(
             package="oak-d-actuator",

--- a/cli/src/robot_md/init_phases/install_backend.py
+++ b/cli/src/robot_md/init_phases/install_backend.py
@@ -11,7 +11,7 @@ the operator can't actually use without the backend).
 from __future__ import annotations
 
 import os  # noqa: F401
-import subprocess  # noqa: F401
+import subprocess
 import sys
 from dataclasses import dataclass
 from pathlib import Path
@@ -77,3 +77,34 @@ def is_externally_managed_env() -> bool:
     stdlib = Path(sysconfig.get_path("stdlib"))
     marker = stdlib / "EXTERNALLY-MANAGED"
     return marker.exists()
+
+
+@dataclass(frozen=True)
+class InstallResult:
+    package: str
+    ok: bool
+    stdout: str = ""
+    stderr: str = ""
+
+
+def install_one(package: str, *, min_version: str = "") -> InstallResult:
+    """Run `pip install --user [--break-system-packages] <pkg>[>=ver]`.
+
+    Emits a one-line stderr explanation when --break-system-packages is added
+    so the operator can see the workaround without surprise.
+    """
+    spec = package + (f">={min_version}" if min_version else "")
+    cmd = [sys.executable, "-m", "pip", "install", "--user", spec]
+    if is_externally_managed_env():
+        cmd.insert(cmd.index("install") + 1, "--break-system-packages")
+        sys.stderr.write(
+            f"⚠ Adding --break-system-packages because this Python install is "
+            f"externally-managed (PEP 668). Consider pipx for a cleaner future install.\n"
+        )
+    result = subprocess.run(cmd, capture_output=True, text=True)
+    return InstallResult(
+        package=package,
+        ok=(result.returncode == 0),
+        stdout=result.stdout,
+        stderr=result.stderr,
+    )

--- a/cli/src/robot_md/init_phases/install_backend.py
+++ b/cli/src/robot_md/init_phases/install_backend.py
@@ -100,8 +100,8 @@ def install_one(package: str, *, min_version: str = "") -> InstallResult:
     if is_externally_managed_env():
         cmd.insert(cmd.index("install") + 1, "--break-system-packages")
         sys.stderr.write(
-            f"⚠ Adding --break-system-packages because this Python install is "
-            f"externally-managed (PEP 668). Consider pipx for a cleaner future install.\n"
+            "⚠ Adding --break-system-packages because this Python install is "
+            "externally-managed (PEP 668). Consider pipx for a cleaner future install.\n"
         )
     result = subprocess.run(cmd, capture_output=True, text=True)
     return InstallResult(
@@ -128,11 +128,16 @@ def phase_install_backend(scan) -> PhaseResult:
         sys.stdout.write(f"    Installing {m.package}…\n")
         r = install_one(m.package, min_version=m.min_version)
         if not r.ok:
+            stderr_tail = r.stderr.splitlines()[-1] if r.stderr else "unknown error"
             return PhaseResult(
                 phase="install_backend",
                 status="failed",
-                message=f"failed to install {r.package}: {r.stderr.splitlines()[-1] if r.stderr else 'unknown error'}",
-                detail={"installed": installed, "failed_package": r.package, "stderr": r.stderr},
+                message=f"failed to install {r.package}: {stderr_tail}",
+                detail={
+                    "installed": installed,
+                    "failed_package": r.package,
+                    "stderr": r.stderr,
+                },
             )
         installed.append(r.package)
         sys.stdout.write(f"    ✓ {r.package}\n")

--- a/cli/src/robot_md/init_phases/install_backend.py
+++ b/cli/src/robot_md/init_phases/install_backend.py
@@ -14,7 +14,7 @@ import os  # noqa: F401
 import subprocess  # noqa: F401
 import sys
 from dataclasses import dataclass
-from pathlib import Path  # noqa: F401
+from pathlib import Path
 
 from robot_md.autodetect import Device
 from robot_md.init_phases import PhaseResult  # noqa: F401
@@ -62,3 +62,18 @@ def match_packages_for_devices(devices: list[Device]) -> list[PackageMatch]:
             matches.append(match)
             seen.add(match.package)
     return matches
+
+
+def is_externally_managed_env() -> bool:
+    """True when the current Python install is PEP-668 externally-managed.
+
+    - In a venv (sys.prefix != sys.base_prefix) → False (never managed).
+    - Otherwise, look for an `EXTERNALLY-MANAGED` marker in the stdlib dir.
+      Pi OS Bookworm+ ships one; pure Python.org installs do not.
+    """
+    import sysconfig
+    if sys.prefix != sys.base_prefix:
+        return False
+    stdlib = Path(sysconfig.get_path("stdlib"))
+    marker = stdlib / "EXTERNALLY-MANAGED"
+    return marker.exists()

--- a/cli/src/robot_md/init_phases/install_backend.py
+++ b/cli/src/robot_md/init_phases/install_backend.py
@@ -1,0 +1,64 @@
+"""Init phase: auto-install backend packages based on detected hardware.
+
+Runs after `write_manifest` and before `register`. Reads the autodetect scan,
+determines which backend packages (so-arm101-actuator, oak-d-actuator, …)
+should be present, and pip-installs them. PEP 668 aware.
+
+Failure on install is fatal to the init flow (the manifest references devices
+the operator can't actually use without the backend).
+"""
+
+from __future__ import annotations
+
+import os  # noqa: F401
+import subprocess  # noqa: F401
+import sys
+from dataclasses import dataclass
+from pathlib import Path  # noqa: F401
+
+from robot_md.autodetect import Device
+from robot_md.init_phases import PhaseResult  # noqa: F401
+
+
+@dataclass(frozen=True)
+class PackageMatch:
+    package: str
+    reason: str
+    min_version: str = ""
+    rpn: str = ""
+
+
+_RULES: list = [
+    (
+        lambda devs: any(
+            d.protocol == "feetech" and d.role == "servo-bus"
+            for d in devs
+        ),
+        PackageMatch(
+            package="so-arm101-actuator",
+            reason="Feetech servo bus detected — the SO-ARM101 driver is the supported backend.",
+            rpn="RPN-000000000002",
+        ),
+    ),
+    (
+        lambda devs: any(
+            d.vid == "03e7" and d.pid in ("2485", "f63c") for d in devs
+        ),
+        PackageMatch(
+            package="oak-d-actuator",
+            reason="Luxonis OAK-D camera detected — installing the depth+RGB driver.",
+            rpn="RPN-000000000003",
+        ),
+    ),
+]
+
+
+def match_packages_for_devices(devices: list[Device]) -> list[PackageMatch]:
+    """Return the list of packages to install based on the device scan."""
+    matches: list[PackageMatch] = []
+    seen: set[str] = set()
+    for predicate, match in _RULES:
+        if predicate(devices) and match.package not in seen:
+            matches.append(match)
+            seen.add(match.package)
+    return matches

--- a/cli/src/robot_md/init_phases/install_backend.py
+++ b/cli/src/robot_md/init_phases/install_backend.py
@@ -17,7 +17,7 @@ from dataclasses import dataclass
 from pathlib import Path
 
 from robot_md.autodetect import Device
-from robot_md.init_phases import PhaseResult  # noqa: F401
+from robot_md.init_phases import PhaseResult
 
 
 @dataclass(frozen=True)
@@ -107,4 +107,36 @@ def install_one(package: str, *, min_version: str = "") -> InstallResult:
         ok=(result.returncode == 0),
         stdout=result.stdout,
         stderr=result.stderr,
+    )
+
+
+def phase_install_backend(scan) -> PhaseResult:
+    """Init phase entry point. Installs all backend packages indicated by the scan."""
+    matches = match_packages_for_devices(scan.devices)
+    if not matches:
+        return PhaseResult(
+            phase="install_backend",
+            status="ok",
+            message="no backend packages required (no matching hardware)",
+            detail={"installed": []},
+        )
+    installed: list[str] = []
+    for m in matches:
+        sys.stdout.write(f"  • {m.reason}\n")
+        sys.stdout.write(f"    Installing {m.package}…\n")
+        r = install_one(m.package, min_version=m.min_version)
+        if not r.ok:
+            return PhaseResult(
+                phase="install_backend",
+                status="failed",
+                message=f"failed to install {r.package}: {r.stderr.splitlines()[-1] if r.stderr else 'unknown error'}",
+                detail={"installed": installed, "failed_package": r.package, "stderr": r.stderr},
+            )
+        installed.append(r.package)
+        sys.stdout.write(f"    ✓ {r.package}\n")
+    return PhaseResult(
+        phase="install_backend",
+        status="ok",
+        message=f"installed {len(installed)} backend package(s)",
+        detail={"installed": installed},
     )

--- a/cli/src/robot_md/init_phases/install_backend.py
+++ b/cli/src/robot_md/init_phases/install_backend.py
@@ -30,10 +30,7 @@ class PackageMatch:
 
 _RULES: list = [
     (
-        lambda devs: any(
-            d.protocol == "feetech" and d.role == "servo-bus"
-            for d in devs
-        ),
+        lambda devs: any(d.protocol == "feetech" and d.role == "servo-bus" for d in devs),
         PackageMatch(
             package="so-arm101-actuator",
             reason="Feetech servo bus detected — the SO-ARM101 driver is the supported backend.",
@@ -42,8 +39,7 @@ _RULES: list = [
     ),
     (
         lambda devs: any(
-            getattr(d, "vid", None) == "03e7"
-            and getattr(d, "pid", None) in ("2485", "f63c")
+            getattr(d, "vid", None) == "03e7" and getattr(d, "pid", None) in ("2485", "f63c")
             for d in devs
         ),
         PackageMatch(
@@ -74,6 +70,7 @@ def is_externally_managed_env() -> bool:
       Pi OS Bookworm+ ships one; pure Python.org installs do not.
     """
     import sysconfig
+
     if sys.prefix != sys.base_prefix:
         return False
     stdlib = Path(sysconfig.get_path("stdlib"))

--- a/cli/tests/integration/test_init_default_flow.py
+++ b/cli/tests/integration/test_init_default_flow.py
@@ -57,6 +57,7 @@ def test_default_flow_runs_all_phases_in_order(tmp_path, fake_scan):
 
     with (
         patch("robot_md.init.scan_system", return_value=fake_scan),
+        patch("robot_md.init.phase_install_backend", side_effect=_track("install_backend")),
         patch("robot_md.init.phase_write_manifest", side_effect=_track("write_manifest")),
         patch("robot_md.init.phase_register", side_effect=_track("register")),
         patch("robot_md.init.phase_install_mcp", side_effect=_track("install_mcp")),
@@ -80,8 +81,10 @@ def test_default_flow_runs_all_phases_in_order(tmp_path, fake_scan):
 
     assert rc == 0
     # install_mcp deprecated per SP1 R1 — no longer called by default_flow.
+    # install_backend runs between write_manifest and register (Spec A Task 17).
     assert calls == [
         "write_manifest",
+        "install_backend",
         "register",
         "install_skill",
         "sign_cal",
@@ -135,6 +138,7 @@ def test_non_fatal_failures_continue_and_exit_zero(tmp_path, fake_scan):
 
     with (
         patch("robot_md.init.scan_system", return_value=fake_scan),
+        patch("robot_md.init.phase_install_backend", return_value=_ok("install_backend")),
         patch("robot_md.init.phase_write_manifest", return_value=_ok("write_manifest")),
         patch("robot_md.init.phase_install_mcp", return_value=_fail("install_mcp")),
         patch("robot_md.init.phase_install_skill", return_value=_ok("install_skill")),
@@ -172,6 +176,7 @@ def test_skip_flags_omit_phases(tmp_path, fake_scan):
 
     with (
         patch("robot_md.init.scan_system", return_value=fake_scan),
+        patch("robot_md.init.phase_install_backend", return_value=_ok("install_backend")),
         patch("robot_md.init.phase_write_manifest", side_effect=_rec("write_manifest")),
         patch("robot_md.init.phase_register", side_effect=_rec("register")),
         patch("robot_md.init.phase_install_mcp", side_effect=_rec("install_mcp")),
@@ -204,6 +209,10 @@ def test_tally_prints_one_line_per_executed_phase(tmp_path, fake_scan, capsys):
     _zero_msg = "zero_pose_steps patched"
     with (
         patch("robot_md.init.scan_system", return_value=fake_scan),
+        patch(
+            "robot_md.init.phase_install_backend",
+            return_value=_ok("install_backend"),
+        ),
         patch(
             "robot_md.init.phase_write_manifest",
             return_value=_ok("write_manifest", "wrote ROBOT.md"),
@@ -287,6 +296,7 @@ def test_claude_md_refresh_runs_after_register_so_rrn_is_not_stale(tmp_path, fak
 
     with (
         patch("robot_md.init.scan_system", return_value=fake_scan),
+        patch("robot_md.init.phase_install_backend", return_value=_ok("install_backend")),
         patch("robot_md.init.phase_register", side_effect=_fake_register),
         patch("robot_md.init.phase_install_mcp", return_value=_ok("install_mcp")),
         patch("robot_md.init.phase_install_skill", return_value=_ok("install_skill")),

--- a/cli/tests/test_autodetect_rcan_version.py
+++ b/cli/tests/test_autodetect_rcan_version.py
@@ -1,4 +1,5 @@
 import yaml
+
 from robot_md.autodetect import Scan, emit_draft
 
 

--- a/cli/tests/test_autodetect_v4l2_filter.py
+++ b/cli/tests/test_autodetect_v4l2_filter.py
@@ -6,21 +6,22 @@ from robot_md.autodetect import probe_v4l2_cameras
 def test_pispbe_video_nodes_are_filtered():
     """Pi ISP probe nodes (pispbe-*) should not appear as cameras."""
     fake_paths = [
-        "/dev/video0",   # real USB cam
+        "/dev/video0",  # real USB cam
         "/dev/video19",  # pispbe-input
         "/dev/video20",  # pispbe-tdn-input
         "/dev/video21",  # pispbe-stitch-input
     ]
     fake_caps = {
-        "/dev/video0":  {"model": "Logitech C920",   "width": 1280, "height": 720},
-        "/dev/video19": {"model": "pispbe-input",    "width": 640,  "height": 480},
-        "/dev/video20": {"model": "pispbe-tdn-input","width": 640,  "height": 480},
-        "/dev/video21": {"model": "pispbe-stitch-input","width": 640,"height": 480},
+        "/dev/video0": {"model": "Logitech C920", "width": 1280, "height": 720},
+        "/dev/video19": {"model": "pispbe-input", "width": 640, "height": 480},
+        "/dev/video20": {"model": "pispbe-tdn-input", "width": 640, "height": 480},
+        "/dev/video21": {"model": "pispbe-stitch-input", "width": 640, "height": 480},
     }
 
-    with patch("robot_md.autodetect._v4l2_list_devices", return_value=fake_paths), \
-         patch("robot_md.autodetect._v4l2_device_capabilities",
-               side_effect=lambda p: fake_caps[p]):
+    with (
+        patch("robot_md.autodetect._v4l2_list_devices", return_value=fake_paths),
+        patch("robot_md.autodetect._v4l2_device_capabilities", side_effect=lambda p: fake_caps[p]),
+    ):
         cams = probe_v4l2_cameras()
 
     models = [c.model for c in cams]

--- a/cli/tests/test_autodetect_v4l2_filter.py
+++ b/cli/tests/test_autodetect_v4l2_filter.py
@@ -1,4 +1,5 @@
 from unittest.mock import patch
+
 from robot_md.autodetect import probe_v4l2_cameras
 
 

--- a/cli/tests/test_doctor_gateway_claim.py
+++ b/cli/tests/test_doctor_gateway_claim.py
@@ -6,16 +6,16 @@ from robot_md.doctor import check_drivers
 def test_doctor_explains_ttyacm_owned_by_gateway():
     """When /dev/ttyACM0 is owned by robot-md-gateway user, surface that as
     informational warning, not a hard fail. Gateway-as-bus-owner is intended."""
-    fm = {"drivers": [{"id": "serial-ttyACM0", "protocol": "serial",
-                       "port": "/dev/ttyACM0"}]}
+    fm = {"drivers": [{"id": "serial-ttyACM0", "protocol": "serial", "port": "/dev/ttyACM0"}]}
 
-    with patch("pathlib.Path.exists", return_value=True), \
-         patch("os.access", return_value=False), \
-         patch("robot_md.doctor._is_owned_by_gateway", return_value=True):
+    with (
+        patch("pathlib.Path.exists", return_value=True),
+        patch("os.access", return_value=False),
+        patch("robot_md.doctor._is_owned_by_gateway", return_value=True),
+    ):
         results = check_drivers(fm)
 
-    matching = [r for r in results if "gateway" in r.detail.lower()
-                and r.status == "warn"]
+    matching = [r for r in results if "gateway" in r.detail.lower() and r.status == "warn"]
     assert matching, (
         f"doctor should emit warn-with-gateway-explanation; got: "
         f"{[(r.status, r.detail) for r in results]}"

--- a/cli/tests/test_doctor_gateway_claim.py
+++ b/cli/tests/test_doctor_gateway_claim.py
@@ -1,4 +1,5 @@
 from unittest.mock import patch
+
 from robot_md.doctor import check_drivers
 
 

--- a/cli/tests/test_install_backend.py
+++ b/cli/tests/test_install_backend.py
@@ -13,10 +13,23 @@ from robot_md.init_phases.install_backend import (
 def test_match_so_arm101_via_ch340_bus():
     """A Feetech servo bus hint should match so-arm101-actuator."""
     devices = [
-        Device(role="serial-bus", driver_id="serial-ch340", protocol="serial",
-               label="CH340", vid="1a86", pid="55d3", bus="usb"),
-        Device(role="servo-bus", driver_id="feetech-bus-ttyACM0", protocol="feetech",
-               label="6 servos", bus="probe", path="/dev/ttyACM0"),
+        Device(
+            role="serial-bus",
+            driver_id="serial-ch340",
+            protocol="serial",
+            label="CH340",
+            vid="1a86",
+            pid="55d3",
+            bus="usb",
+        ),
+        Device(
+            role="servo-bus",
+            driver_id="feetech-bus-ttyACM0",
+            protocol="feetech",
+            label="6 servos",
+            bus="probe",
+            path="/dev/ttyACM0",
+        ),
     ]
     matches = match_packages_for_devices(devices)
     names = [m.package for m in matches]
@@ -26,8 +39,15 @@ def test_match_so_arm101_via_ch340_bus():
 def test_match_oak_d_via_vidpid():
     """OAK-D (03e7:2485) should match oak-d-actuator."""
     devices = [
-        Device(role="camera", driver_id="cam-oak-d", protocol="depthai",
-               label="Luxonis OAK-D", vid="03e7", pid="2485", bus="usb"),
+        Device(
+            role="camera",
+            driver_id="cam-oak-d",
+            protocol="depthai",
+            label="Luxonis OAK-D",
+            vid="03e7",
+            pid="2485",
+            bus="usb",
+        ),
     ]
     matches = match_packages_for_devices(devices)
     names = [m.package for m in matches]
@@ -37,12 +57,32 @@ def test_match_oak_d_via_vidpid():
 def test_match_dedups_by_package():
     """If two devices both indicate the same backend, return one match."""
     devices = [
-        Device(role="serial-bus", driver_id="serial-ch340", protocol="serial",
-               label="CH340", vid="1a86", pid="55d3", bus="usb"),
-        Device(role="servo-bus", driver_id="feetech-bus-ttyACM0", protocol="feetech",
-               label="6 servos", bus="probe", path="/dev/ttyACM0"),
-        Device(role="serial-bus", driver_id="serial-ch340", protocol="serial",
-               label="CH340 #2", vid="1a86", pid="55d3", bus="usb"),
+        Device(
+            role="serial-bus",
+            driver_id="serial-ch340",
+            protocol="serial",
+            label="CH340",
+            vid="1a86",
+            pid="55d3",
+            bus="usb",
+        ),
+        Device(
+            role="servo-bus",
+            driver_id="feetech-bus-ttyACM0",
+            protocol="feetech",
+            label="6 servos",
+            bus="probe",
+            path="/dev/ttyACM0",
+        ),
+        Device(
+            role="serial-bus",
+            driver_id="serial-ch340",
+            protocol="serial",
+            label="CH340 #2",
+            vid="1a86",
+            pid="55d3",
+            bus="usb",
+        ),
     ]
     matches = match_packages_for_devices(devices)
     so_matches = [m for m in matches if m.package == "so-arm101-actuator"]
@@ -54,8 +94,11 @@ def test_pep668_detected_when_marker_file_exists(tmp_path):
     marker = tmp_path / "EXTERNALLY-MANAGED"
     marker.write_text("")
 
-    with patch("sysconfig.get_path", return_value=str(tmp_path)), \
-         patch("sys.prefix", "/usr"), patch("sys.base_prefix", "/usr"):
+    with (
+        patch("sysconfig.get_path", return_value=str(tmp_path)),
+        patch("sys.prefix", "/usr"),
+        patch("sys.base_prefix", "/usr"),
+    ):
         assert is_externally_managed_env() is True
 
 
@@ -72,13 +115,15 @@ def test_install_one_invokes_pip_with_break_system_packages_when_externally_mana
     def fake_run(cmd, **kwargs):
         captured_argv.append(cmd)
         from subprocess import CompletedProcess
-        return CompletedProcess(cmd, returncode=0,
-                                stdout="Successfully installed so-arm101-actuator-0.2.1\n",
-                                stderr="")
 
-    with patch("robot_md.init_phases.install_backend.is_externally_managed_env",
-               return_value=True), \
-         patch("subprocess.run", side_effect=fake_run):
+        return CompletedProcess(
+            cmd, returncode=0, stdout="Successfully installed so-arm101-actuator-0.2.1\n", stderr=""
+        )
+
+    with (
+        patch("robot_md.init_phases.install_backend.is_externally_managed_env", return_value=True),
+        patch("subprocess.run", side_effect=fake_run),
+    ):
         result = install_one("so-arm101-actuator")
 
     assert result.ok
@@ -93,11 +138,13 @@ def test_install_one_omits_break_system_packages_in_venv():
     def fake_run(cmd, **kwargs):
         captured.append(cmd)
         from subprocess import CompletedProcess
+
         return CompletedProcess(cmd, returncode=0, stdout="", stderr="")
 
-    with patch("robot_md.init_phases.install_backend.is_externally_managed_env",
-               return_value=False), \
-         patch("subprocess.run", side_effect=fake_run):
+    with (
+        patch("robot_md.init_phases.install_backend.is_externally_managed_env", return_value=False),
+        patch("subprocess.run", side_effect=fake_run),
+    ):
         install_one("oak-d-actuator")
 
     assert not any("--break-system-packages" in arg for arg in captured[0])
@@ -105,13 +152,27 @@ def test_install_one_omits_break_system_packages_in_venv():
 
 def test_phase_install_backend_returns_ok_when_all_succeed():
     """phase_install_backend runs install_one for every match and returns ok."""
-    scan = Scan(devices=[
-        Device(role="servo-bus", driver_id="feetech-bus-ttyACM0",
-               protocol="feetech", label="6 servos", bus="probe",
-               path="/dev/ttyACM0"),
-        Device(role="camera", driver_id="cam-oak-d", protocol="depthai",
-               label="OAK-D", vid="03e7", pid="2485", bus="usb"),
-    ])
+    scan = Scan(
+        devices=[
+            Device(
+                role="servo-bus",
+                driver_id="feetech-bus-ttyACM0",
+                protocol="feetech",
+                label="6 servos",
+                bus="probe",
+                path="/dev/ttyACM0",
+            ),
+            Device(
+                role="camera",
+                driver_id="cam-oak-d",
+                protocol="depthai",
+                label="OAK-D",
+                vid="03e7",
+                pid="2485",
+                bus="usb",
+            ),
+        ]
+    )
 
     calls = []
 
@@ -119,8 +180,7 @@ def test_phase_install_backend_returns_ok_when_all_succeed():
         calls.append(pkg)
         return InstallResult(package=pkg, ok=True, stdout="ok", stderr="")
 
-    with patch("robot_md.init_phases.install_backend.install_one",
-               side_effect=fake_install):
+    with patch("robot_md.init_phases.install_backend.install_one", side_effect=fake_install):
         result = phase_install_backend(scan)
 
     assert result.status == "ok"
@@ -131,16 +191,25 @@ def test_phase_install_backend_returns_ok_when_all_succeed():
 
 def test_phase_install_backend_fails_on_pip_error():
     """Any pip-install failure aborts the phase with status=failed."""
-    scan = Scan(devices=[
-        Device(role="servo-bus", driver_id="feetech-bus-ttyACM0",
-               protocol="feetech", label="6 servos", bus="probe",
-               path="/dev/ttyACM0"),
-    ])
+    scan = Scan(
+        devices=[
+            Device(
+                role="servo-bus",
+                driver_id="feetech-bus-ttyACM0",
+                protocol="feetech",
+                label="6 servos",
+                bus="probe",
+                path="/dev/ttyACM0",
+            ),
+        ]
+    )
 
-    with patch("robot_md.init_phases.install_backend.install_one",
-               return_value=InstallResult(package="so-arm101-actuator",
-                                          ok=False, stdout="",
-                                          stderr="network error")):
+    with patch(
+        "robot_md.init_phases.install_backend.install_one",
+        return_value=InstallResult(
+            package="so-arm101-actuator", ok=False, stdout="", stderr="network error"
+        ),
+    ):
         result = phase_install_backend(scan)
 
     assert result.status == "failed"

--- a/cli/tests/test_install_backend.py
+++ b/cli/tests/test_install_backend.py
@@ -3,7 +3,6 @@ from unittest.mock import patch
 from robot_md.autodetect import Device, Scan
 from robot_md.init_phases.install_backend import (
     InstallResult,
-    PackageMatch,
     install_one,
     is_externally_managed_env,
     match_packages_for_devices,

--- a/cli/tests/test_install_backend.py
+++ b/cli/tests/test_install_backend.py
@@ -1,0 +1,44 @@
+from robot_md.autodetect import Device
+from robot_md.init_phases.install_backend import (
+    PackageMatch,
+    match_packages_for_devices,
+)
+
+
+def test_match_so_arm101_via_ch340_bus():
+    """A Feetech servo bus hint should match so-arm101-actuator."""
+    devices = [
+        Device(role="serial-bus", driver_id="serial-ch340", protocol="serial",
+               label="CH340", vid="1a86", pid="55d3", bus="usb"),
+        Device(role="servo-bus", driver_id="feetech-bus-ttyACM0", protocol="feetech",
+               label="6 servos", bus="probe", path="/dev/ttyACM0"),
+    ]
+    matches = match_packages_for_devices(devices)
+    names = [m.package for m in matches]
+    assert "so-arm101-actuator" in names
+
+
+def test_match_oak_d_via_vidpid():
+    """OAK-D (03e7:2485) should match oak-d-actuator."""
+    devices = [
+        Device(role="camera", driver_id="cam-oak-d", protocol="depthai",
+               label="Luxonis OAK-D", vid="03e7", pid="2485", bus="usb"),
+    ]
+    matches = match_packages_for_devices(devices)
+    names = [m.package for m in matches]
+    assert "oak-d-actuator" in names
+
+
+def test_match_dedups_by_package():
+    """If two devices both indicate the same backend, return one match."""
+    devices = [
+        Device(role="serial-bus", driver_id="serial-ch340", protocol="serial",
+               label="CH340", vid="1a86", pid="55d3", bus="usb"),
+        Device(role="servo-bus", driver_id="feetech-bus-ttyACM0", protocol="feetech",
+               label="6 servos", bus="probe", path="/dev/ttyACM0"),
+        Device(role="serial-bus", driver_id="serial-ch340", protocol="serial",
+               label="CH340 #2", vid="1a86", pid="55d3", bus="usb"),
+    ]
+    matches = match_packages_for_devices(devices)
+    so_matches = [m for m in matches if m.package == "so-arm101-actuator"]
+    assert len(so_matches) == 1

--- a/cli/tests/test_install_backend.py
+++ b/cli/tests/test_install_backend.py
@@ -1,6 +1,9 @@
+from unittest.mock import patch
+
 from robot_md.autodetect import Device
 from robot_md.init_phases.install_backend import (
     PackageMatch,
+    is_externally_managed_env,
     match_packages_for_devices,
 )
 
@@ -42,3 +45,19 @@ def test_match_dedups_by_package():
     matches = match_packages_for_devices(devices)
     so_matches = [m for m in matches if m.package == "so-arm101-actuator"]
     assert len(so_matches) == 1
+
+
+def test_pep668_detected_when_marker_file_exists(tmp_path):
+    """A Python install with an EXTERNALLY-MANAGED marker is detected."""
+    marker = tmp_path / "EXTERNALLY-MANAGED"
+    marker.write_text("")
+
+    with patch("sysconfig.get_path", return_value=str(tmp_path)), \
+         patch("sys.prefix", "/usr"), patch("sys.base_prefix", "/usr"):
+        assert is_externally_managed_env() is True
+
+
+def test_pep668_not_detected_in_venv():
+    """A venv (sys.prefix != base_prefix) is never externally-managed."""
+    with patch("sys.prefix", "/tmp/venv"), patch("sys.base_prefix", "/usr"):
+        assert is_externally_managed_env() is False

--- a/cli/tests/test_install_backend.py
+++ b/cli/tests/test_install_backend.py
@@ -2,7 +2,9 @@ from unittest.mock import patch
 
 from robot_md.autodetect import Device
 from robot_md.init_phases.install_backend import (
+    InstallResult,
     PackageMatch,
+    install_one,
     is_externally_managed_env,
     match_packages_for_devices,
 )
@@ -61,3 +63,41 @@ def test_pep668_not_detected_in_venv():
     """A venv (sys.prefix != base_prefix) is never externally-managed."""
     with patch("sys.prefix", "/tmp/venv"), patch("sys.base_prefix", "/usr"):
         assert is_externally_managed_env() is False
+
+
+def test_install_one_invokes_pip_with_break_system_packages_when_externally_managed():
+    """When PEP 668 is in effect, pip install adds --break-system-packages."""
+    captured_argv = []
+
+    def fake_run(cmd, **kwargs):
+        captured_argv.append(cmd)
+        from subprocess import CompletedProcess
+        return CompletedProcess(cmd, returncode=0,
+                                stdout="Successfully installed so-arm101-actuator-0.2.1\n",
+                                stderr="")
+
+    with patch("robot_md.init_phases.install_backend.is_externally_managed_env",
+               return_value=True), \
+         patch("subprocess.run", side_effect=fake_run):
+        result = install_one("so-arm101-actuator")
+
+    assert result.ok
+    assert any("--break-system-packages" in arg for arg in captured_argv[0])
+    assert "so-arm101-actuator" in captured_argv[0]
+
+
+def test_install_one_omits_break_system_packages_in_venv():
+    """In a venv, pip install does NOT pass --break-system-packages."""
+    captured = []
+
+    def fake_run(cmd, **kwargs):
+        captured.append(cmd)
+        from subprocess import CompletedProcess
+        return CompletedProcess(cmd, returncode=0, stdout="", stderr="")
+
+    with patch("robot_md.init_phases.install_backend.is_externally_managed_env",
+               return_value=False), \
+         patch("subprocess.run", side_effect=fake_run):
+        install_one("oak-d-actuator")
+
+    assert not any("--break-system-packages" in arg for arg in captured[0])

--- a/cli/tests/test_install_backend.py
+++ b/cli/tests/test_install_backend.py
@@ -1,12 +1,13 @@
 from unittest.mock import patch
 
-from robot_md.autodetect import Device
+from robot_md.autodetect import Device, Scan
 from robot_md.init_phases.install_backend import (
     InstallResult,
     PackageMatch,
     install_one,
     is_externally_managed_env,
     match_packages_for_devices,
+    phase_install_backend,
 )
 
 
@@ -101,3 +102,55 @@ def test_install_one_omits_break_system_packages_in_venv():
         install_one("oak-d-actuator")
 
     assert not any("--break-system-packages" in arg for arg in captured[0])
+
+
+def test_phase_install_backend_returns_ok_when_all_succeed():
+    """phase_install_backend runs install_one for every match and returns ok."""
+    scan = Scan(devices=[
+        Device(role="servo-bus", driver_id="feetech-bus-ttyACM0",
+               protocol="feetech", label="6 servos", bus="probe",
+               path="/dev/ttyACM0"),
+        Device(role="camera", driver_id="cam-oak-d", protocol="depthai",
+               label="OAK-D", vid="03e7", pid="2485", bus="usb"),
+    ])
+
+    calls = []
+
+    def fake_install(pkg, min_version=""):
+        calls.append(pkg)
+        return InstallResult(package=pkg, ok=True, stdout="ok", stderr="")
+
+    with patch("robot_md.init_phases.install_backend.install_one",
+               side_effect=fake_install):
+        result = phase_install_backend(scan)
+
+    assert result.status == "ok"
+    assert "so-arm101-actuator" in calls
+    assert "oak-d-actuator" in calls
+    assert len(calls) == 2
+
+
+def test_phase_install_backend_fails_on_pip_error():
+    """Any pip-install failure aborts the phase with status=failed."""
+    scan = Scan(devices=[
+        Device(role="servo-bus", driver_id="feetech-bus-ttyACM0",
+               protocol="feetech", label="6 servos", bus="probe",
+               path="/dev/ttyACM0"),
+    ])
+
+    with patch("robot_md.init_phases.install_backend.install_one",
+               return_value=InstallResult(package="so-arm101-actuator",
+                                          ok=False, stdout="",
+                                          stderr="network error")):
+        result = phase_install_backend(scan)
+
+    assert result.status == "failed"
+    assert "so-arm101-actuator" in result.message
+
+
+def test_phase_install_backend_ok_when_no_matches():
+    """No matching hardware → status=ok with empty installed list."""
+    scan = Scan(devices=[])
+    result = phase_install_backend(scan)
+    assert result.status == "ok"
+    assert result.detail == {"installed": []}

--- a/cli/tests/test_version.py
+++ b/cli/tests/test_version.py
@@ -14,12 +14,12 @@ def test_version_command_matches_installed_metadata():
     )
     out = result.stdout.strip()
     assert out.endswith(expected), (
-        f"version drift: --version reported {out!r}, "
-        f"pip metadata reports {expected!r}"
+        f"version drift: --version reported {out!r}, pip metadata reports {expected!r}"
     )
 
 
 def test_dunder_version_matches_installed_metadata():
     """`robot_md.__version__` must come from importlib.metadata, not a literal."""
     import robot_md
+
     assert robot_md.__version__ == pkg_version("robot-md")


### PR DESCRIPTION
## Summary
- Adds `phase_install_backend` to the `robot-md init` flow, wired between `phase_write_manifest` and `phase_register` per Spec A
- New `cli/src/robot_md/init_phases/install_backend.py`:
  - `match_packages_for_devices()` — Feetech servo bus → `so-arm101-actuator` (RPN-000000000002), OAK-D 03e7:2485 → `oak-d-actuator` (RPN-000000000003)
  - `is_externally_managed_env()` — PEP 668 detection (Pi OS Bookworm marker file vs. venv)
  - `install_one()` — `pip install --user` with `--break-system-packages` auto-added when PEP-668-managed, with a stderr explanation
  - `phase_install_backend()` — orchestrator that fails the init flow if a required backend can't install
- 10 new unit tests + integration tests updated to mock the new phase

Plan ref: `opencastor-ops/docs/superpowers/plans/2026-05-10-spec-a-auto-discovery-and-install-wiring.md` Tasks 13-17.

## Test plan
- [x] All 10 new install_backend tests green
- [x] 6 existing default_flow integration tests still pass (now with the new phase mocked)
- [x] Broader sweep (42 init/install/phase tests) all green locally
- [ ] CI confirms on push