### PR TITLE
feat: Spec A Tasks 18-22 — install-gateway subcommand

### DIFF
--- a/cli/src/robot_md/__init__.py
+++ b/cli/src/robot_md/__init__.py
@@ -1,6 +1,7 @@
 """robot-md — parse, validate, and render ROBOT.md files."""
 
-from importlib.metadata import version as _pkg_version, PackageNotFoundError
+from importlib.metadata import PackageNotFoundError
+from importlib.metadata import version as _pkg_version
 
 try:
     __version__ = _pkg_version("robot-md")

--- a/cli/src/robot_md/__main__.py
+++ b/cli/src/robot_md/__main__.py
@@ -1775,6 +1775,26 @@ def install_skill_cmd(
         out_console.print(f"[green]✓[/green] installed {p}")
 
 
+@app.command("install-gateway")
+def install_gateway_cmd(
+    manifest: Path = typer.Option(
+        Path("/etc/robot-md-gateway/ROBOT.md"),
+        "--manifest", "-m",
+        help="Path to the ROBOT.md the gateway will enforce against.",
+    ),
+    yes: bool = typer.Option(
+        False, "--yes", "-y",
+        help="Skip the sudo confirmation prompt.",
+    ),
+) -> None:
+    """Scaffold the robot-md-gateway systemd service on a fresh host (sudo)."""
+    from robot_md.install_gateway import install_gateway as _install_gateway
+
+    rc = _install_gateway(manifest_path=str(manifest), yes=yes)
+    if rc != 0:
+        raise typer.Exit(code=rc)
+
+
 @app.command()
 def invoke(
     manifest: Path = typer.Argument(..., help="Path to ROBOT.md being actuated against."),

--- a/cli/src/robot_md/__main__.py
+++ b/cli/src/robot_md/__main__.py
@@ -1779,11 +1779,14 @@ def install_skill_cmd(
 def install_gateway_cmd(
     manifest: Path = typer.Option(
         Path("/etc/robot-md-gateway/ROBOT.md"),
-        "--manifest", "-m",
+        "--manifest",
+        "-m",
         help="Path to the ROBOT.md the gateway will enforce against.",
     ),
     yes: bool = typer.Option(
-        False, "--yes", "-y",
+        False,
+        "--yes",
+        "-y",
         help="Skip the sudo confirmation prompt.",
     ),
 ) -> None:

--- a/cli/src/robot_md/doctor.py
+++ b/cli/src/robot_md/doctor.py
@@ -265,9 +265,14 @@ def check_drivers(fm: dict[str, Any] | None) -> list[CheckResult]:
             if not p.exists():
                 out.append(_fail(label, "drivers", f"{port} — does not exist (unplugged?)"))
             elif _is_owned_by_gateway(p):
-                out.append(_warn(label, "drivers",
-                    f"{port} — claimed by robot-md-gateway user (intentional); "
-                    f"talk to the gateway at 127.0.0.1:8080, not the device directly."))
+                out.append(
+                    _warn(
+                        label,
+                        "drivers",
+                        f"{port} — claimed by robot-md-gateway user (intentional); "
+                        f"talk to the gateway at 127.0.0.1:8080, not the device directly.",
+                    )
+                )
             elif not os.access(p, os.R_OK | os.W_OK):
                 out.append(_warn(label, "drivers", f"{port} — exists but not RW (dialout group?)"))
             else:

--- a/cli/src/robot_md/install_gateway.py
+++ b/cli/src/robot_md/install_gateway.py
@@ -17,8 +17,14 @@ import os
 import subprocess
 from pathlib import Path
 
+_EXEC_START = (
+    "/opt/robot-md-gateway/.venv/bin/robot-md-gateway serve "
+    "--host 127.0.0.1 --port 8080 "
+    "--bearers /etc/robot-md-gateway/bearers.yaml"
+)
 
-SYSTEMD_UNIT_TEMPLATE = """\
+
+SYSTEMD_UNIT_TEMPLATE = f"""\
 [Unit]
 Description=robot-md-gateway — enforcement gateway between agent intent and actuators
 After=network-online.target
@@ -29,7 +35,7 @@ User=robot-md-gateway
 Group=robot-md-gateway
 WorkingDirectory=/opt/robot-md-gateway
 EnvironmentFile=/etc/robot-md-gateway/gateway.env
-ExecStart=/opt/robot-md-gateway/.venv/bin/robot-md-gateway serve --host 127.0.0.1 --port 8080 --bearers /etc/robot-md-gateway/bearers.yaml
+ExecStart={_EXEC_START}
 Restart=on-failure
 RestartSec=3s
 
@@ -120,11 +126,12 @@ def install_gateway(*, manifest_path: str, yes: bool = False) -> int:
 
     sudo = ["sudo"]
     steps = [
-        sudo + ["useradd", "--system", "--no-create-home", "--shell", "/usr/sbin/nologin",
-                "robot-md-gateway"],
-        sudo + ["mkdir", "-p", "/opt/robot-md-gateway", "/etc/robot-md-gateway"],
-        sudo + ["python3", "-m", "venv", "/opt/robot-md-gateway/.venv"],
-        sudo + ["/opt/robot-md-gateway/.venv/bin/pip", "install", "robot-md-gateway"],
+        [*sudo, "useradd", "--system", "--no-create-home", "--shell",
+         "/usr/sbin/nologin", "robot-md-gateway"],
+        [*sudo, "mkdir", "-p", "/opt/robot-md-gateway", "/etc/robot-md-gateway"],
+        [*sudo, "python3", "-m", "venv", "/opt/robot-md-gateway/.venv"],
+        [*sudo, "/opt/robot-md-gateway/.venv/bin/pip", "install",
+         "robot-md-gateway"],
     ]
     for cmd in steps:
         r = subprocess.run(cmd)
@@ -134,22 +141,26 @@ def install_gateway(*, manifest_path: str, yes: bool = False) -> int:
             return 1
 
     for filename, content in [
-        ("/etc/robot-md-gateway/gateway.env", render_env_file(manifest_path=manifest_path)),
+        ("/etc/robot-md-gateway/gateway.env",
+         render_env_file(manifest_path=manifest_path)),
         ("/etc/robot-md-gateway/bearers.yaml", render_default_bearers()),
         ("/etc/systemd/system/robot-md-gateway.service", render_systemd_unit()),
     ]:
-        r = subprocess.run(sudo + ["tee", filename], input=content, text=True, capture_output=True)
+        r = subprocess.run(
+            [*sudo, "tee", filename],
+            input=content, text=True, capture_output=True,
+        )
         if r.returncode != 0:
             print(f"failed to write {filename}")
             return 1
 
     if os.path.exists(manifest_path) and manifest_path != "/etc/robot-md-gateway/ROBOT.md":
-        subprocess.run(sudo + ["cp", manifest_path, "/etc/robot-md-gateway/ROBOT.md"])
+        subprocess.run([*sudo, "cp", manifest_path, "/etc/robot-md-gateway/ROBOT.md"])
 
-    subprocess.run(sudo + ["chown", "-R", "robot-md-gateway:robot-md-gateway",
-                           "/opt/robot-md-gateway", "/etc/robot-md-gateway"])
-    subprocess.run(sudo + ["systemctl", "daemon-reload"])
-    r = subprocess.run(sudo + ["systemctl", "enable", "--now", "robot-md-gateway"])
+    subprocess.run([*sudo, "chown", "-R", "robot-md-gateway:robot-md-gateway",
+                    "/opt/robot-md-gateway", "/etc/robot-md-gateway"])
+    subprocess.run([*sudo, "systemctl", "daemon-reload"])
+    r = subprocess.run([*sudo, "systemctl", "enable", "--now", "robot-md-gateway"])
     if r.returncode != 0:
         print("systemctl enable failed")
         return 1

--- a/cli/src/robot_md/install_gateway.py
+++ b/cli/src/robot_md/install_gateway.py
@@ -45,3 +45,26 @@ def render_systemd_unit(*, manifest_path: str = "/etc/robot-md-gateway/ROBOT.md"
     """Return the rendered systemd unit text. manifest_path informs the env
     file (separate write); the unit itself is invariant of manifest location."""
     return SYSTEMD_UNIT_TEMPLATE
+
+
+def render_env_file(*, manifest_path: str) -> str:
+    """Render the contents of /etc/robot-md-gateway/gateway.env."""
+    return f"""\
+ROBOT_MD_PATH={manifest_path}
+ROBOT_MD_BEARERS_FILE=/etc/robot-md-gateway/bearers.yaml
+ROBOT_MD_LOG_LEVEL=INFO
+ROBOT_MD_TOOL_ALLOWLIST=mcp__robot__execute_capability,mcp__robot__render,mcp__robot__validate,move,home,read_state
+ROBOT_MD_REQUIRE_ENVELOPE_SIGNATURE=1
+"""
+
+
+def render_default_bearers() -> str:
+    """Render a minimal bearers.yaml. Operator must edit before first use."""
+    return """\
+# bearers.yaml — JWT bearers the gateway will accept on INVOKE envelopes.
+# Mint with: robot-md request-apikey RRN-<your-rrn>
+bearers:
+  - name: operator-default
+    token: "REPLACE-WITH-MINTED-TOKEN"
+    rrn: "RRN-XXXXXXXXXX"
+"""

--- a/cli/src/robot_md/install_gateway.py
+++ b/cli/src/robot_md/install_gateway.py
@@ -1,0 +1,47 @@
+"""robot-md install-gateway subcommand.
+
+Scaffolds the Layer 3 enforcement gateway on a fresh host:
+  - Creates `robot-md-gateway` system user
+  - pip-installs `robot-md-gateway` into /opt/robot-md-gateway/.venv/
+  - Writes /etc/robot-md-gateway/{gateway.env, bearers.yaml, ROBOT.md}
+  - Installs + enables a systemd unit
+  - Verifies the gateway is reachable on 127.0.0.1:8080
+
+Idempotent: detects an already-installed gateway and prints status without
+clobbering. Requires sudo for the actual filesystem + systemd writes.
+"""
+
+from __future__ import annotations
+
+
+SYSTEMD_UNIT_TEMPLATE = """\
+[Unit]
+Description=robot-md-gateway — enforcement gateway between agent intent and actuators
+After=network-online.target
+Wants=network-online.target
+
+[Service]
+User=robot-md-gateway
+Group=robot-md-gateway
+WorkingDirectory=/opt/robot-md-gateway
+EnvironmentFile=/etc/robot-md-gateway/gateway.env
+ExecStart=/opt/robot-md-gateway/.venv/bin/robot-md-gateway serve --host 127.0.0.1 --port 8080 --bearers /etc/robot-md-gateway/bearers.yaml
+Restart=on-failure
+RestartSec=3s
+
+NoNewPrivileges=yes
+ProtectSystem=strict
+ProtectHome=yes
+PrivateTmp=yes
+PrivateDevices=no
+DeviceAllow=/dev/ttyACM0 rw
+
+[Install]
+WantedBy=multi-user.target
+"""
+
+
+def render_systemd_unit(*, manifest_path: str = "/etc/robot-md-gateway/ROBOT.md") -> str:
+    """Return the rendered systemd unit text. manifest_path informs the env
+    file (separate write); the unit itself is invariant of manifest location."""
+    return SYSTEMD_UNIT_TEMPLATE

--- a/cli/src/robot_md/install_gateway.py
+++ b/cli/src/robot_md/install_gateway.py
@@ -90,7 +90,9 @@ def already_installed() -> bool:
     try:
         result = subprocess.run(
             ["systemctl", "is-active", "robot-md-gateway"],
-            capture_output=True, text=True, timeout=5,
+            capture_output=True,
+            text=True,
+            timeout=5,
         )
     except (subprocess.TimeoutExpired, FileNotFoundError):
         return False
@@ -117,21 +119,29 @@ def install_gateway(*, manifest_path: str, yes: bool = False) -> int:
         return 0
 
     if not yes:
-        confirm = input("This will sudo to create /opt/robot-md-gateway/, "
-                        "/etc/robot-md-gateway/, a system user, and a systemd "
-                        "unit. Continue? [y/N]: ")
+        confirm = input(
+            "This will sudo to create /opt/robot-md-gateway/, "
+            "/etc/robot-md-gateway/, a system user, and a systemd "
+            "unit. Continue? [y/N]: "
+        )
         if confirm.strip().lower() not in ("y", "yes"):
             print("aborted.")
             return 2
 
     sudo = ["sudo"]
     steps = [
-        [*sudo, "useradd", "--system", "--no-create-home", "--shell",
-         "/usr/sbin/nologin", "robot-md-gateway"],
+        [
+            *sudo,
+            "useradd",
+            "--system",
+            "--no-create-home",
+            "--shell",
+            "/usr/sbin/nologin",
+            "robot-md-gateway",
+        ],
         [*sudo, "mkdir", "-p", "/opt/robot-md-gateway", "/etc/robot-md-gateway"],
         [*sudo, "python3", "-m", "venv", "/opt/robot-md-gateway/.venv"],
-        [*sudo, "/opt/robot-md-gateway/.venv/bin/pip", "install",
-         "robot-md-gateway"],
+        [*sudo, "/opt/robot-md-gateway/.venv/bin/pip", "install", "robot-md-gateway"],
     ]
     for cmd in steps:
         r = subprocess.run(cmd)
@@ -141,14 +151,15 @@ def install_gateway(*, manifest_path: str, yes: bool = False) -> int:
             return 1
 
     for filename, content in [
-        ("/etc/robot-md-gateway/gateway.env",
-         render_env_file(manifest_path=manifest_path)),
+        ("/etc/robot-md-gateway/gateway.env", render_env_file(manifest_path=manifest_path)),
         ("/etc/robot-md-gateway/bearers.yaml", render_default_bearers()),
         ("/etc/systemd/system/robot-md-gateway.service", render_systemd_unit()),
     ]:
         r = subprocess.run(
             [*sudo, "tee", filename],
-            input=content, text=True, capture_output=True,
+            input=content,
+            text=True,
+            capture_output=True,
         )
         if r.returncode != 0:
             print(f"failed to write {filename}")
@@ -157,8 +168,16 @@ def install_gateway(*, manifest_path: str, yes: bool = False) -> int:
     if os.path.exists(manifest_path) and manifest_path != "/etc/robot-md-gateway/ROBOT.md":
         subprocess.run([*sudo, "cp", manifest_path, "/etc/robot-md-gateway/ROBOT.md"])
 
-    subprocess.run([*sudo, "chown", "-R", "robot-md-gateway:robot-md-gateway",
-                    "/opt/robot-md-gateway", "/etc/robot-md-gateway"])
+    subprocess.run(
+        [
+            *sudo,
+            "chown",
+            "-R",
+            "robot-md-gateway:robot-md-gateway",
+            "/opt/robot-md-gateway",
+            "/etc/robot-md-gateway",
+        ]
+    )
     subprocess.run([*sudo, "systemctl", "daemon-reload"])
     r = subprocess.run([*sudo, "systemctl", "enable", "--now", "robot-md-gateway"])
     if r.returncode != 0:
@@ -167,6 +186,7 @@ def install_gateway(*, manifest_path: str, yes: bool = False) -> int:
 
     try:
         import urllib.request
+
         with urllib.request.urlopen("http://127.0.0.1:8080/", timeout=5) as resp:
             print(f"gateway returned HTTP {resp.status}")
     except Exception as e:

--- a/cli/src/robot_md/install_gateway.py
+++ b/cli/src/robot_md/install_gateway.py
@@ -13,6 +13,9 @@ clobbering. Requires sudo for the actual filesystem + systemd writes.
 
 from __future__ import annotations
 
+import subprocess
+from pathlib import Path
+
 
 SYSTEMD_UNIT_TEMPLATE = """\
 [Unit]
@@ -68,3 +71,20 @@ bearers:
     token: "REPLACE-WITH-MINTED-TOKEN"
     rrn: "RRN-XXXXXXXXXX"
 """
+
+
+def already_installed() -> bool:
+    """True when /opt/robot-md-gateway/.venv has the gateway binary AND
+    systemd reports the unit active. Either alone returns False — we want
+    both for confidence."""
+    venv_binary = Path("/opt/robot-md-gateway/.venv/bin/robot-md-gateway")
+    if not venv_binary.exists():
+        return False
+    try:
+        result = subprocess.run(
+            ["systemctl", "is-active", "robot-md-gateway"],
+            capture_output=True, text=True, timeout=5,
+        )
+    except (subprocess.TimeoutExpired, FileNotFoundError):
+        return False
+    return result.returncode == 0 and result.stdout.strip() == "active"

--- a/cli/src/robot_md/install_gateway.py
+++ b/cli/src/robot_md/install_gateway.py
@@ -13,6 +13,7 @@ clobbering. Requires sudo for the actual filesystem + systemd writes.
 
 from __future__ import annotations
 
+import os
 import subprocess
 from pathlib import Path
 
@@ -88,3 +89,78 @@ def already_installed() -> bool:
     except (subprocess.TimeoutExpired, FileNotFoundError):
         return False
     return result.returncode == 0 and result.stdout.strip() == "active"
+
+
+def install_gateway(*, manifest_path: str, yes: bool = False) -> int:
+    """Full install sequence. Requires sudo. Returns 0 on success.
+
+    Steps:
+      1. Bail if already_installed (idempotent).
+      2. Confirm with operator unless yes=True.
+      3. sudo useradd robot-md-gateway (skip if exists).
+      4. sudo python3 -m venv /opt/robot-md-gateway/.venv
+      5. sudo /opt/robot-md-gateway/.venv/bin/pip install robot-md-gateway
+      6. sudo write /etc/robot-md-gateway/{gateway.env, bearers.yaml, ROBOT.md (copy)}
+      7. sudo chown -R robot-md-gateway:robot-md-gateway /opt/robot-md-gateway
+      8. sudo write /etc/systemd/system/robot-md-gateway.service
+      9. sudo systemctl daemon-reload && systemctl enable --now robot-md-gateway
+     10. Verify curl 127.0.0.1:8080 returns any HTTP response.
+    """
+    if already_installed():
+        print("robot-md-gateway already installed and active. Nothing to do.")
+        return 0
+
+    if not yes:
+        confirm = input("This will sudo to create /opt/robot-md-gateway/, "
+                        "/etc/robot-md-gateway/, a system user, and a systemd "
+                        "unit. Continue? [y/N]: ")
+        if confirm.strip().lower() not in ("y", "yes"):
+            print("aborted.")
+            return 2
+
+    sudo = ["sudo"]
+    steps = [
+        sudo + ["useradd", "--system", "--no-create-home", "--shell", "/usr/sbin/nologin",
+                "robot-md-gateway"],
+        sudo + ["mkdir", "-p", "/opt/robot-md-gateway", "/etc/robot-md-gateway"],
+        sudo + ["python3", "-m", "venv", "/opt/robot-md-gateway/.venv"],
+        sudo + ["/opt/robot-md-gateway/.venv/bin/pip", "install", "robot-md-gateway"],
+    ]
+    for cmd in steps:
+        r = subprocess.run(cmd)
+        # useradd is allowed to fail (user already exists); others must succeed.
+        if r.returncode != 0 and "useradd" not in cmd:
+            print(f"step failed: {' '.join(cmd)}")
+            return 1
+
+    for filename, content in [
+        ("/etc/robot-md-gateway/gateway.env", render_env_file(manifest_path=manifest_path)),
+        ("/etc/robot-md-gateway/bearers.yaml", render_default_bearers()),
+        ("/etc/systemd/system/robot-md-gateway.service", render_systemd_unit()),
+    ]:
+        r = subprocess.run(sudo + ["tee", filename], input=content, text=True, capture_output=True)
+        if r.returncode != 0:
+            print(f"failed to write {filename}")
+            return 1
+
+    if os.path.exists(manifest_path) and manifest_path != "/etc/robot-md-gateway/ROBOT.md":
+        subprocess.run(sudo + ["cp", manifest_path, "/etc/robot-md-gateway/ROBOT.md"])
+
+    subprocess.run(sudo + ["chown", "-R", "robot-md-gateway:robot-md-gateway",
+                           "/opt/robot-md-gateway", "/etc/robot-md-gateway"])
+    subprocess.run(sudo + ["systemctl", "daemon-reload"])
+    r = subprocess.run(sudo + ["systemctl", "enable", "--now", "robot-md-gateway"])
+    if r.returncode != 0:
+        print("systemctl enable failed")
+        return 1
+
+    try:
+        import urllib.request
+        with urllib.request.urlopen("http://127.0.0.1:8080/", timeout=5) as resp:
+            print(f"gateway returned HTTP {resp.status}")
+    except Exception as e:
+        print(f"gateway started but health probe failed: {e}")
+        return 1
+
+    print("robot-md-gateway installed and active.")
+    return 0

--- a/cli/tests/test_autodetect_rcan_version.py
+++ b/cli/tests/test_autodetect_rcan_version.py
@@ -1,4 +1,5 @@
 import yaml
+
 from robot_md.autodetect import Scan, emit_draft
 
 

--- a/cli/tests/test_autodetect_v4l2_filter.py
+++ b/cli/tests/test_autodetect_v4l2_filter.py
@@ -6,21 +6,22 @@ from robot_md.autodetect import probe_v4l2_cameras
 def test_pispbe_video_nodes_are_filtered():
     """Pi ISP probe nodes (pispbe-*) should not appear as cameras."""
     fake_paths = [
-        "/dev/video0",   # real USB cam
+        "/dev/video0",  # real USB cam
         "/dev/video19",  # pispbe-input
         "/dev/video20",  # pispbe-tdn-input
         "/dev/video21",  # pispbe-stitch-input
     ]
     fake_caps = {
-        "/dev/video0":  {"model": "Logitech C920",   "width": 1280, "height": 720},
-        "/dev/video19": {"model": "pispbe-input",    "width": 640,  "height": 480},
-        "/dev/video20": {"model": "pispbe-tdn-input","width": 640,  "height": 480},
-        "/dev/video21": {"model": "pispbe-stitch-input","width": 640,"height": 480},
+        "/dev/video0": {"model": "Logitech C920", "width": 1280, "height": 720},
+        "/dev/video19": {"model": "pispbe-input", "width": 640, "height": 480},
+        "/dev/video20": {"model": "pispbe-tdn-input", "width": 640, "height": 480},
+        "/dev/video21": {"model": "pispbe-stitch-input", "width": 640, "height": 480},
     }
 
-    with patch("robot_md.autodetect._v4l2_list_devices", return_value=fake_paths), \
-         patch("robot_md.autodetect._v4l2_device_capabilities",
-               side_effect=lambda p: fake_caps[p]):
+    with (
+        patch("robot_md.autodetect._v4l2_list_devices", return_value=fake_paths),
+        patch("robot_md.autodetect._v4l2_device_capabilities", side_effect=lambda p: fake_caps[p]),
+    ):
         cams = probe_v4l2_cameras()
 
     models = [c.model for c in cams]

--- a/cli/tests/test_autodetect_v4l2_filter.py
+++ b/cli/tests/test_autodetect_v4l2_filter.py
@@ -1,4 +1,5 @@
 from unittest.mock import patch
+
 from robot_md.autodetect import probe_v4l2_cameras
 
 

--- a/cli/tests/test_cli_install_gateway.py
+++ b/cli/tests/test_cli_install_gateway.py
@@ -1,0 +1,10 @@
+from typer.testing import CliRunner
+
+from robot_md.__main__ import app
+
+
+def test_install_gateway_command_exists():
+    runner = CliRunner()
+    result = runner.invoke(app, ["install-gateway", "--help"])
+    assert result.exit_code == 0
+    assert "install-gateway" in result.stdout.lower() or "scaffold" in result.stdout.lower()

--- a/cli/tests/test_doctor_gateway_claim.py
+++ b/cli/tests/test_doctor_gateway_claim.py
@@ -6,16 +6,16 @@ from robot_md.doctor import check_drivers
 def test_doctor_explains_ttyacm_owned_by_gateway():
     """When /dev/ttyACM0 is owned by robot-md-gateway user, surface that as
     informational warning, not a hard fail. Gateway-as-bus-owner is intended."""
-    fm = {"drivers": [{"id": "serial-ttyACM0", "protocol": "serial",
-                       "port": "/dev/ttyACM0"}]}
+    fm = {"drivers": [{"id": "serial-ttyACM0", "protocol": "serial", "port": "/dev/ttyACM0"}]}
 
-    with patch("pathlib.Path.exists", return_value=True), \
-         patch("os.access", return_value=False), \
-         patch("robot_md.doctor._is_owned_by_gateway", return_value=True):
+    with (
+        patch("pathlib.Path.exists", return_value=True),
+        patch("os.access", return_value=False),
+        patch("robot_md.doctor._is_owned_by_gateway", return_value=True),
+    ):
         results = check_drivers(fm)
 
-    matching = [r for r in results if "gateway" in r.detail.lower()
-                and r.status == "warn"]
+    matching = [r for r in results if "gateway" in r.detail.lower() and r.status == "warn"]
     assert matching, (
         f"doctor should emit warn-with-gateway-explanation; got: "
         f"{[(r.status, r.detail) for r in results]}"

--- a/cli/tests/test_doctor_gateway_claim.py
+++ b/cli/tests/test_doctor_gateway_claim.py
@@ -1,4 +1,5 @@
 from unittest.mock import patch
+
 from robot_md.doctor import check_drivers
 
 

--- a/cli/tests/test_install_gateway.py
+++ b/cli/tests/test_install_gateway.py
@@ -43,8 +43,10 @@ def test_render_default_bearers_yaml_minimal():
 
 def test_already_installed_detection():
     """venv binary present AND systemctl reports active → True."""
-    with patch("pathlib.Path.exists", return_value=True), \
-         patch("robot_md.install_gateway.subprocess.run") as run_mock:
+    with (
+        patch("pathlib.Path.exists", return_value=True),
+        patch("robot_md.install_gateway.subprocess.run") as run_mock,
+    ):
         run_mock.return_value.returncode = 0
         run_mock.return_value.stdout = "active\n"
         assert already_installed() is True

--- a/cli/tests/test_install_gateway.py
+++ b/cli/tests/test_install_gateway.py
@@ -1,0 +1,20 @@
+from robot_md.install_gateway import render_systemd_unit
+
+
+def test_systemd_unit_content():
+    """The rendered systemd unit matches Bob's known-good configuration."""
+    unit = render_systemd_unit(manifest_path="/etc/robot-md-gateway/ROBOT.md")
+
+    assert "[Unit]" in unit
+    assert "Description=robot-md-gateway" in unit
+    assert "After=network-online.target" in unit
+    assert "User=robot-md-gateway" in unit
+    assert "Group=robot-md-gateway" in unit
+    assert "WorkingDirectory=/opt/robot-md-gateway" in unit
+    assert "EnvironmentFile=/etc/robot-md-gateway/gateway.env" in unit
+    assert (
+        "ExecStart=/opt/robot-md-gateway/.venv/bin/robot-md-gateway serve "
+        "--host 127.0.0.1 --port 8080 "
+        "--bearers /etc/robot-md-gateway/bearers.yaml"
+    ) in unit
+    assert "DeviceAllow=/dev/ttyACM0 rw" in unit

--- a/cli/tests/test_install_gateway.py
+++ b/cli/tests/test_install_gateway.py
@@ -1,4 +1,8 @@
-from robot_md.install_gateway import render_systemd_unit
+from robot_md.install_gateway import (
+    render_default_bearers,
+    render_env_file,
+    render_systemd_unit,
+)
 
 
 def test_systemd_unit_content():
@@ -18,3 +22,17 @@ def test_systemd_unit_content():
         "--bearers /etc/robot-md-gateway/bearers.yaml"
     ) in unit
     assert "DeviceAllow=/dev/ttyACM0 rw" in unit
+
+
+def test_render_env_file_contains_required_keys():
+    env = render_env_file(manifest_path="/etc/robot-md-gateway/ROBOT.md")
+    assert "ROBOT_MD_PATH=/etc/robot-md-gateway/ROBOT.md" in env
+    assert "ROBOT_MD_BEARERS_FILE=/etc/robot-md-gateway/bearers.yaml" in env
+    assert "ROBOT_MD_LOG_LEVEL=INFO" in env
+    assert "ROBOT_MD_REQUIRE_ENVELOPE_SIGNATURE=1" in env
+
+
+def test_render_default_bearers_yaml_minimal():
+    text = render_default_bearers()
+    assert "bearers:" in text
+    assert "REPLACE-WITH-MINTED-TOKEN" in text

--- a/cli/tests/test_install_gateway.py
+++ b/cli/tests/test_install_gateway.py
@@ -1,4 +1,7 @@
+from unittest.mock import patch
+
 from robot_md.install_gateway import (
+    already_installed,
     render_default_bearers,
     render_env_file,
     render_systemd_unit,
@@ -36,3 +39,18 @@ def test_render_default_bearers_yaml_minimal():
     text = render_default_bearers()
     assert "bearers:" in text
     assert "REPLACE-WITH-MINTED-TOKEN" in text
+
+
+def test_already_installed_detection():
+    """venv binary present AND systemctl reports active → True."""
+    with patch("pathlib.Path.exists", return_value=True), \
+         patch("robot_md.install_gateway.subprocess.run") as run_mock:
+        run_mock.return_value.returncode = 0
+        run_mock.return_value.stdout = "active\n"
+        assert already_installed() is True
+
+
+def test_not_installed_when_venv_missing():
+    """venv binary missing → False without invoking systemctl."""
+    with patch("pathlib.Path.exists", return_value=False):
+        assert already_installed() is False

--- a/cli/tests/test_install_gateway_integration.py
+++ b/cli/tests/test_install_gateway_integration.py
@@ -1,0 +1,41 @@
+from unittest.mock import MagicMock, patch
+
+from robot_md.install_gateway import install_gateway
+
+
+def test_install_gateway_skips_when_already_installed(capsys):
+    """already_installed → print status, return 0, no side effects."""
+    with patch("robot_md.install_gateway.already_installed", return_value=True), \
+         patch("robot_md.install_gateway.subprocess.run") as run_mock:
+        rc = install_gateway(manifest_path="/etc/robot-md-gateway/ROBOT.md", yes=True)
+
+    assert rc == 0
+    out = capsys.readouterr().out
+    assert "already installed" in out.lower()
+    run_mock.assert_not_called()
+
+
+def test_install_gateway_runs_full_sequence_when_fresh():
+    """Fresh install runs: useradd → pip install → write config → systemd."""
+    calls = []
+
+    def fake_run(cmd, *args, **kwargs):
+        calls.append(cmd)
+        m = MagicMock()
+        m.returncode = 0
+        m.stdout = ""
+        return m
+
+    with patch("robot_md.install_gateway.already_installed", return_value=False), \
+         patch("robot_md.install_gateway.subprocess.run", side_effect=fake_run), \
+         patch("os.path.exists", return_value=False), \
+         patch("urllib.request.urlopen") as urlopen_mock:
+        urlopen_mock.return_value.__enter__.return_value.status = 200
+        rc = install_gateway(manifest_path="/etc/robot-md-gateway/ROBOT.md", yes=True)
+
+    assert rc == 0
+    cmd_strs = [" ".join(c) if isinstance(c, list) else c for c in calls]
+    assert any("useradd" in c for c in cmd_strs)
+    assert any("pip" in c and "install" in c for c in cmd_strs)
+    assert any("systemctl" in c and "daemon-reload" in c for c in cmd_strs)
+    assert any("systemctl" in c and "enable" in c for c in cmd_strs)

--- a/cli/tests/test_install_gateway_integration.py
+++ b/cli/tests/test_install_gateway_integration.py
@@ -5,8 +5,10 @@ from robot_md.install_gateway import install_gateway
 
 def test_install_gateway_skips_when_already_installed(capsys):
     """already_installed → print status, return 0, no side effects."""
-    with patch("robot_md.install_gateway.already_installed", return_value=True), \
-         patch("robot_md.install_gateway.subprocess.run") as run_mock:
+    with (
+        patch("robot_md.install_gateway.already_installed", return_value=True),
+        patch("robot_md.install_gateway.subprocess.run") as run_mock,
+    ):
         rc = install_gateway(manifest_path="/etc/robot-md-gateway/ROBOT.md", yes=True)
 
     assert rc == 0
@@ -26,10 +28,12 @@ def test_install_gateway_runs_full_sequence_when_fresh():
         m.stdout = ""
         return m
 
-    with patch("robot_md.install_gateway.already_installed", return_value=False), \
-         patch("robot_md.install_gateway.subprocess.run", side_effect=fake_run), \
-         patch("os.path.exists", return_value=False), \
-         patch("urllib.request.urlopen") as urlopen_mock:
+    with (
+        patch("robot_md.install_gateway.already_installed", return_value=False),
+        patch("robot_md.install_gateway.subprocess.run", side_effect=fake_run),
+        patch("os.path.exists", return_value=False),
+        patch("urllib.request.urlopen") as urlopen_mock,
+    ):
         urlopen_mock.return_value.__enter__.return_value.status = 200
         rc = install_gateway(manifest_path="/etc/robot-md-gateway/ROBOT.md", yes=True)
 

--- a/cli/tests/test_version.py
+++ b/cli/tests/test_version.py
@@ -14,12 +14,12 @@ def test_version_command_matches_installed_metadata():
     )
     out = result.stdout.strip()
     assert out.endswith(expected), (
-        f"version drift: --version reported {out!r}, "
-        f"pip metadata reports {expected!r}"
+        f"version drift: --version reported {out!r}, pip metadata reports {expected!r}"
     )
 
 
 def test_dunder_version_matches_installed_metadata():
     """`robot_md.__version__` must come from importlib.metadata, not a literal."""
     import robot_md
+
     assert robot_md.__version__ == pkg_version("robot-md")


### PR DESCRIPTION
## Summary
- Adds `robot-md install-gateway` subcommand that scaffolds the Layer 3 enforcement gateway on a fresh host (sudo)
- New `cli/src/robot_md/install_gateway.py`:
  - `render_systemd_unit()` — systemd service unit content (matches Bob's known-good shape)
  - `render_env_file()` — `/etc/robot-md-gateway/gateway.env` contents
  - `render_default_bearers()` — placeholder `bearers.yaml` with REPLACE-WITH-MINTED-TOKEN sentinel
  - `already_installed()` — venv+systemctl idempotence check
  - `install_gateway()` — full sudo-wrapped install sequence: useradd → venv → pip → write configs → daemon-reload → enable+start → health probe
- Typer `install-gateway` subcommand registered in `__main__.py` with `--manifest`/`-m` and `--yes`/`-y` flags
- 8 tests: 5 unit (render helpers, idempotence) + 2 integration (skip-when-installed, fresh-install full sequence with mocked subprocess) + 1 CLI smoke

Plan ref: `opencastor-ops/docs/superpowers/plans/2026-05-10-spec-a-auto-discovery-and-install-wiring.md` Tasks 18-22.

## Test plan
- [x] All 8 new install-gateway tests green
- [x] Ruff clean
- [ ] CI confirms on push
- [ ] Real-host integration verified later in Task 31 acceptance