### PR TITLE
fix(ux): Spec A follow-ups — doctor + install-gateway operator UX

### DIFF
--- a/cli/src/robot_md/__main__.py
+++ b/cli/src/robot_md/__main__.py
@@ -1782,6 +1782,13 @@ def install_gateway_cmd(
         "--manifest",
         "-m",
         help="Path to the ROBOT.md the gateway will enforce against.",
+        # Don't validate readability — the default lives under
+        # /etc/robot-md-gateway/ owned by the gateway user and is unreadable
+        # by the operator. install_gateway() handles missing/unreadable
+        # paths gracefully, and its `already_installed()` early-exit must
+        # be allowed to fire before typer rejects the call.
+        exists=False,
+        readable=False,
     ),
     yes: bool = typer.Option(
         False,
@@ -1790,7 +1797,12 @@ def install_gateway_cmd(
         help="Skip the sudo confirmation prompt.",
     ),
 ) -> None:
-    """Scaffold the robot-md-gateway systemd service on a fresh host (sudo)."""
+    """Scaffold the robot-md-gateway systemd service on a fresh host (sudo).
+
+    Idempotent: when the gateway is already installed and active, prints a
+    status line and exits 0 without touching anything. Safe to re-run on
+    hosts that already have the gateway.
+    """
     from robot_md.install_gateway import install_gateway as _install_gateway
 
     rc = _install_gateway(manifest_path=str(manifest), yes=yes)

--- a/cli/src/robot_md/doctor.py
+++ b/cli/src/robot_md/doctor.py
@@ -134,12 +134,21 @@ def check_manifest(path: Path | None) -> tuple[list[CheckResult], dict[str, Any]
     out: list[CheckResult] = []
 
     if path is None:
-        candidate = Path.cwd() / "ROBOT.md"
-        if candidate.exists():
-            path = candidate
+        # Walk up from cwd looking for ROBOT.md — matches the discovery
+        # behavior of `robot-md mcp` so doctor + mcp pick the same manifest
+        # regardless of which sub-directory the operator launches from.
+        from robot_md.mcp.server import find_manifest_via_cwd_walk
+
+        found = find_manifest_via_cwd_walk(Path.cwd())
+        if found is not None:
+            path = found
         else:
             out.append(
-                _skip("manifest", "manifest", "no ROBOT.md in cwd (pass --path to target one)")
+                _skip(
+                    "manifest",
+                    "manifest",
+                    f"no ROBOT.md walking up from {Path.cwd()} (pass --path to target one)",
+                )
             )
             return out, None
 
@@ -274,7 +283,14 @@ def check_drivers(fm: dict[str, Any] | None) -> list[CheckResult]:
                     )
                 )
             elif not os.access(p, os.R_OK | os.W_OK):
-                out.append(_warn(label, "drivers", f"{port} — exists but not RW (dialout group?)"))
+                out.append(
+                    _warn(
+                        label,
+                        "drivers",
+                        f"{port} — exists but not RW. Fix: "
+                        f"`sudo usermod -aG dialout $USER` then log out + back in.",
+                    )
+                )
             else:
                 out.append(_pass(label, "drivers", f"{port} — RW"))
         elif host:

--- a/cli/src/robot_md/init_phases/voice_setup.py
+++ b/cli/src/robot_md/init_phases/voice_setup.py
@@ -135,7 +135,11 @@ def run_voice_setup(
     """Returns rc (0 on success, even when no audio devices were found)."""
     devs_mod = _try_import_pendantd()
     if devs_mod is None:
-        sys.stdout.write("pendantd not detected; skipping voice setup\n")
+        sys.stdout.write(
+            "pendantd not detected; skipping voice setup.\n"
+            "  (pendantd is the optional voice/wake-word daemon. Install with\n"
+            "  `pip install pendantd` if you want push-to-talk; safe to skip otherwise.)\n"
+        )
         return 0
 
     sys.stdout.write(_HEADER + "\n")

--- a/cli/tests/test_cli_install_gateway.py
+++ b/cli/tests/test_cli_install_gateway.py
@@ -1,3 +1,5 @@
+from unittest.mock import patch
+
 from typer.testing import CliRunner
 
 from robot_md.__main__ import app
@@ -8,3 +10,23 @@ def test_install_gateway_command_exists():
     result = runner.invoke(app, ["install-gateway", "--help"])
     assert result.exit_code == 0
     assert "install-gateway" in result.stdout.lower() or "scaffold" in result.stdout.lower()
+
+
+def test_install_gateway_default_manifest_does_not_trip_typer_readability_check():
+    """Regression: default --manifest is /etc/robot-md-gateway/ROBOT.md, which
+    is owned by the gateway system user and unreadable to the operator.
+
+    Pre-v1.9.1, typer.Option(Path, ...) defaulted to readable=True and
+    rejected the call before `install_gateway()` could run its idempotent
+    `already_installed()` early-exit. Operators on a re-install were forced
+    to skip the step manually. The option now sets readable=False so the
+    function takes over path handling.
+    """
+    runner = CliRunner()
+    # Stub install_gateway to short-circuit (don't actually try to sudo);
+    # we only care that typer accepts the default path and dispatches.
+    with patch("robot_md.install_gateway.install_gateway", return_value=0) as m:
+        result = runner.invoke(app, ["install-gateway", "--yes"])
+    assert result.exit_code == 0, f"typer rejected default path: {result.stdout}"
+    m.assert_called_once()
+    assert m.call_args.kwargs["manifest_path"] == "/etc/robot-md-gateway/ROBOT.md"

--- a/cli/tests/test_doctor.py
+++ b/cli/tests/test_doctor.py
@@ -48,10 +48,36 @@ def test_check_manifest_bob_valid():
 
 
 def test_check_manifest_no_cwd_file(tmp_path, monkeypatch):
+    # When cwd has no ROBOT.md and walking up to the filesystem root yields
+    # none either, doctor must skip cleanly. tmp_path on most CI images
+    # has no ROBOT.md anywhere on the path up to /.
     monkeypatch.chdir(tmp_path)
     results, fm = doctor.check_manifest(None)
     assert fm is None
     assert any(r.status == "skip" and "no ROBOT.md" in r.detail for r in results)
+
+
+def test_check_manifest_walks_up_from_subdir(tmp_path, monkeypatch):
+    """Doctor must find ROBOT.md when launched from a sub-directory of the
+    manifest dir, matching `robot-md mcp`'s discovery behavior.
+
+    Regression: pre-v1.9.1 doctor only checked Path.cwd() / "ROBOT.md", so
+    `cd ./scripts && robot-md doctor` from a manifest dir would report
+    "no ROBOT.md" even though one was one level up.
+    """
+    bob = Path(__file__).parent.parent.parent / "examples" / "bob.ROBOT.md"
+    if not bob.exists():
+        pytest.skip("examples/bob.ROBOT.md not in this tree")
+    manifest_dir = tmp_path / "robot"
+    manifest_dir.mkdir()
+    (manifest_dir / "ROBOT.md").write_text(bob.read_text())
+    subdir = manifest_dir / "scripts"
+    subdir.mkdir()
+    monkeypatch.chdir(subdir)
+
+    results, fm = doctor.check_manifest(None)
+    assert fm is not None, "doctor should walk up to find ROBOT.md in parent dir"
+    assert any(r.name == "manifest parse" and r.status == "pass" for r in results)
 
 
 def test_check_drivers_fail_on_missing_serial(tmp_path):


### PR DESCRIPTION
## Summary

Four operator-UX fixes from the Spec A acceptance-baseline (`opencastor-ops/operations/2026-05-11-bob-10min-baseline-post-spec-a.md`):

- **doctor manifest discovery** (#1 in baseline) — walk up from cwd to find ROBOT.md, matching `robot-md mcp`. Previously only checked `Path.cwd() / "ROBOT.md"`; running doctor from a sub-directory of the manifest dir reported "no ROBOT.md" even when one was one level up.
- **doctor dialout-group hint** (#3) — when `/dev/tty*` exists but is not RW, include the fix command (`sudo usermod -aG dialout \$USER` + relog) in the warn detail.
- **pendantd documentation** (#4) — extend the "pendantd not detected" message during init to explain what pendantd is + install hint (`pip install pendantd`). Substring "pendantd not detected" preserved for the existing test.
- **install-gateway idempotence** (#5) — `already_installed()` early-exit existed but never fired because `typer.Option(Path, ...)` defaulted to `readable=True` and rejected the default `--manifest` path (`/etc/robot-md-gateway/ROBOT.md`, owned by gateway user, unreadable to operator) before dispatch. Set `exists=False, readable=False` so `install_gateway()` handles path validation itself.

Verified on Bob: `robot-md install-gateway --yes` previously errored with "Invalid value for '--manifest' / '-m': Path '/etc/robot-md-gateway/ROBOT.md' is not readable" (exit 2); now reaches the idempotent code path.

## Test plan

- [x] `pytest -q` (cli/) — 1389 pass / 19 skip (was 1387 pre-fix; +2 new regression tests)
- [x] `ruff check src tests` — clean
- [x] `ruff format --check src tests` — clean
- [x] Manual: `robot-md install-gateway --yes` on Bob (gateway already active) no longer trips typer's readable check

🤖 Generated with [Claude Code](https://claude.com/claude-code)