### PR TITLE
feat(register): preflight /v2/robots/_next before mint

### DIFF
--- a/cli/src/robot_md/__main__.py
+++ b/cli/src/robot_md/__main__.py
@@ -352,7 +352,13 @@ def register(
     rcan_version: str | None = typer.Option(None, "--rcan-version"),
     dry_run: bool = typer.Option(False, "--dry-run", help="Sign + print body, don't POST."),
 ) -> None:
-    """Mint an RRN on Robot Registry Foundation with signed POST (RCAN 3.0)."""
+    """Mint an RRN on Robot Registry Foundation with signed POST (RCAN 3.0).
+
+    Before signing, prints the RRN the next mint will allocate (preflight
+    against `/v2/robots/_next`) so operators can see which slot they'll
+    receive. RRNs below the reserved floor are protected for canonical
+    robots and are not auto-minted.
+    """
     from robot_md.register import DEFAULT_ENDPOINT, cli_register
 
     rc = cli_register(

--- a/cli/src/robot_md/register.py
+++ b/cli/src/robot_md/register.py
@@ -332,6 +332,41 @@ def _extract_mint_fields(
 # -------------------------------------------------------------- network + side
 
 
+def peek_next_rrn(endpoint: str, *, timeout: float = 5.0) -> dict[str, Any] | None:
+    """GET <endpoint-base>/_next to preview the RRN the next mint will allocate.
+
+    `endpoint` is the mint endpoint (`.../v2/robots/register`); the peek lives
+    at `.../v2/robots/_next` (added 2026-05-11 — see RRF PR #101).
+
+    Returns the parsed JSON body on success or None on any failure (404 from
+    older RRF deployments, network error, malformed JSON). Preflight is
+    best-effort UX, never a mint gate — the caller must continue regardless.
+    """
+    if not endpoint.endswith("/register"):
+        return None
+    peek_url = endpoint.rsplit("/", 1)[0] + "/_next"
+    req = urllib.request.Request(
+        peek_url,
+        method="GET",
+        headers={
+            "Accept": "application/json",
+            "User-Agent": "robot-md-cli/0.1 (+https://robotmd.dev)",
+        },
+    )
+    try:
+        with urllib.request.urlopen(req, timeout=timeout) as resp:
+            text = resp.read().decode("utf-8")
+    except Exception:
+        return None
+    try:
+        obj = json.loads(text)
+    except json.JSONDecodeError:
+        return None
+    if not isinstance(obj, dict) or "next_rrn" not in obj:
+        return None
+    return obj
+
+
 def post_to_rrf(endpoint: str, body: dict[str, Any], *, timeout: float = 15.0) -> MintResult:
     """POST the mint body. Raises :class:`RuntimeError` on network or 5xx
     failures; returns :class:`MintResult` on both first-time (201) and
@@ -481,6 +516,18 @@ def cli_register(
 
     req.pq_kid = kp.pq_kid
     req.ruri = construct_ruri(parsed.frontmatter)
+
+    # 1.5. Preflight: surface the RRN the next mint will allocate so the
+    # operator can see it before signing. Best-effort — older RRF deployments
+    # without /_next return None and we proceed silently.
+    preview = peek_next_rrn(endpoint)
+    if preview is not None:
+        next_rrn = preview.get("next_rrn", "?")
+        reserved = preview.get("reserved_floor")
+        msg = f"  Next RRN: {next_rrn}"
+        if reserved:
+            msg += f" (RRNs below {reserved:012d} reserved for canonical robots)"
+        print(msg, file=sys.stderr)
 
     # 2. Sign canonical body.
     body = req.as_body()

--- a/cli/tests/test_register.py
+++ b/cli/tests/test_register.py
@@ -19,6 +19,7 @@ from robot_md.register import (
     MintRequest,
     _extract_mint_fields,
     cli_register,
+    peek_next_rrn,
     post_to_rrf,
 )
 from robot_md.signing import verify_body
@@ -406,3 +407,126 @@ def test_signed_register_body_carries_sibling_ids(tmp_path, monkeypatch):
     assert body["rhn_ids"] == ["RHN-000000000099"]
     # Signature covers the full body (body+ids canonical scheme)
     assert verify_body(body) is True
+
+
+# ---- preflight: peek_next_rrn + cli_register integration -----------------
+
+
+def test_peek_next_rrn_derives_peek_url_from_register_endpoint(monkeypatch):
+    """peek_next_rrn rewrites .../register to .../_next."""
+    captured = {}
+
+    class _Resp:
+        def __init__(self, payload):
+            self._payload = json.dumps(payload).encode()
+
+        def __enter__(self):
+            return self
+
+        def __exit__(self, *_a):
+            return False
+
+        def read(self):
+            return self._payload
+
+    def fake_urlopen(req, timeout=None):
+        captured["url"] = req.full_url
+        captured["headers"] = dict(req.header_items())
+        return _Resp({"next_rrn": "RRN-000000000010", "reserved_floor": 10})
+
+    with patch("urllib.request.urlopen", fake_urlopen):
+        result = peek_next_rrn(DEFAULT_ENDPOINT)
+
+    assert result == {"next_rrn": "RRN-000000000010", "reserved_floor": 10}
+    assert captured["url"].endswith("/v2/robots/_next")
+    # UA header must be set — Cloudflare blocks default Python-urllib UA at 403.
+    ua = next((v for k, v in captured["headers"].items() if k.lower() == "user-agent"), None)
+    assert ua is not None
+    assert "robot-md" in ua.lower()
+
+
+def test_peek_next_rrn_returns_none_on_404(monkeypatch):
+    """Older RRF deployments without /_next 404 — preflight must be silent."""
+    import urllib.error
+
+    def fake_urlopen(req, timeout=None):
+        raise urllib.error.HTTPError(req.full_url, 404, "Not Found", {}, None)
+
+    with patch("urllib.request.urlopen", fake_urlopen):
+        assert peek_next_rrn(DEFAULT_ENDPOINT) is None
+
+
+def test_peek_next_rrn_returns_none_on_malformed_endpoint():
+    """Endpoints that don't end in /register can't derive a peek URL."""
+    assert peek_next_rrn("https://example.com/api/mint") is None
+
+
+def test_peek_next_rrn_returns_none_on_malformed_json(monkeypatch):
+    class _Resp:
+        def __enter__(self):
+            return self
+
+        def __exit__(self, *_a):
+            return False
+
+        def read(self):
+            return b"not json"
+
+    with patch("urllib.request.urlopen", lambda *_a, **_kw: _Resp()):
+        assert peek_next_rrn(DEFAULT_ENDPOINT) is None
+
+
+def test_cli_register_prints_preflight_rrn_before_posting(tmp_path, monkeypatch, capsys):
+    """The next-RRN preview must land on stderr before sign+POST happens."""
+    monkeypatch.setenv("HOME", str(tmp_path))
+    path = _write(tmp_path)
+
+    def fake_peek(endpoint, timeout=5.0):
+        return {"next_rrn": "RRN-000000000042", "reserved_floor": 10}
+
+    def fake_post(endpoint, body, timeout=15.0):
+        from robot_md.register import MintResult
+
+        return MintResult(
+            rrn="RRN-000000000042",
+            registered_at="2026-05-11T00:00:00Z",
+            record_url="https://robotregistryfoundation.org/v2/robots/RRN-000000000042",
+            raw={"rrn": "RRN-000000000042", "api_key": "k"},
+        )
+
+    with (
+        patch("robot_md.register.peek_next_rrn", fake_peek),
+        patch("robot_md.register.post_to_rrf", fake_post),
+    ):
+        rc = cli_register(path, endpoint=DEFAULT_ENDPOINT)
+
+    assert rc == 0
+    err = capsys.readouterr().err
+    assert "Next RRN: RRN-000000000042" in err
+    assert "reserved for canonical robots" in err
+
+
+def test_cli_register_proceeds_silently_when_preflight_fails(tmp_path, monkeypatch, capsys):
+    """An older RRF (peek returns None) must not abort the mint."""
+    monkeypatch.setenv("HOME", str(tmp_path))
+    path = _write(tmp_path)
+
+    def fake_post(endpoint, body, timeout=15.0):
+        from robot_md.register import MintResult
+
+        return MintResult(
+            rrn="RRN-000000000099",
+            registered_at="x",
+            record_url="u",
+            raw={"api_key": "k"},
+        )
+
+    with (
+        patch("robot_md.register.peek_next_rrn", lambda *_a, **_kw: None),
+        patch("robot_md.register.post_to_rrf", fake_post),
+    ):
+        rc = cli_register(path, endpoint=DEFAULT_ENDPOINT)
+
+    assert rc == 0
+    # No "Next RRN:" line should have been printed.
+    assert "Next RRN:" not in capsys.readouterr().err


### PR DESCRIPTION
## Summary

Closes the operator-visibility half of Spec A baseline friction #2 (RRN collision on \`--register\`). Pairs with craigm26/RobotRegistryFoundation#101 which adds the reserved-floor + \`/v2/robots/_next\` endpoint server-side.

- New \`peek_next_rrn(endpoint)\` GETs \`<endpoint-base>/_next\` and returns parsed JSON or None.
- \`cli_register\` calls it between key-generation and body-signing, printing \`Next RRN: RRN-NNN... (RRNs below FLOOR reserved for canonical robots)\` to stderr so operators see which slot they'll receive before signing.
- Best-effort: older RRF deployments without \`/_next\` return None and the mint proceeds silently. Change is forward-only — no breakage if RRF PR #101 hasn't deployed yet.

## Dependency

RRF PR #101 deploys the \`/v2/robots/_next\` endpoint. Until that PR merges + Cloudflare Pages deploys, this CLI change is a silent no-op. After PR #101 is live, operators see the preview line.

## Test plan

- [x] \`pytest tests/test_register.py\` — 23 pass (+5 new)
- [x] Full \`pytest tests/\` (non-integration) — 1394 pass / 19 skip
- [x] \`ruff check src tests\` — clean
- [x] \`ruff format --check src tests\` — clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)