### PR TITLE
feat: trial module scaffold (Spec B Task 7)

### DIFF
--- a/cli/src/robot_md/trial.py
+++ b/cli/src/robot_md/trial.py
@@ -1,0 +1,43 @@
+"""robot-md trial: capture pick-and-place trial evidence for cert minting.
+
+State directory layout (per trial):
+    ~/.robot-md/trials/<trial_id>/
+        start.json
+        iter_<N>.json
+        evidence.json     (written by `trial finalize`)
+        frames/iter_<N>_{pre,post}_{rgb,depth}.png
+
+Cold-install wall-clock anchor:
+    ~/.robot-md-cold-install-start.txt  (operator-written before cold install)
+"""
+from __future__ import annotations
+import datetime as dt
+import pathlib
+import secrets
+from typing import Optional
+
+import typer
+
+trial_app = typer.Typer(help="Capture pick-and-place trial evidence for cert minting.")
+
+TRIALS_DIR = pathlib.Path.home() / ".robot-md" / "trials"
+COLD_INSTALL_START_FILE = pathlib.Path.home() / ".robot-md-cold-install-start.txt"
+
+
+def _utcnow_iso() -> str:
+    return dt.datetime.now(dt.timezone.utc).strftime("%Y-%m-%dT%H:%M:%SZ")
+
+
+def _trial_dir(trial_id: str) -> pathlib.Path:
+    return TRIALS_DIR / trial_id
+
+
+def _read_cold_install_start() -> Optional[str]:
+    if not COLD_INSTALL_START_FILE.exists():
+        return None
+    raw = COLD_INSTALL_START_FILE.read_text().strip()
+    try:
+        dt.datetime.strptime(raw, "%Y-%m-%dT%H:%M:%SZ")
+    except ValueError:
+        return None
+    return raw

--- a/cli/src/robot_md/trial.py
+++ b/cli/src/robot_md/trial.py
@@ -10,6 +10,7 @@ State directory layout (per trial):
 Cold-install wall-clock anchor:
     ~/.robot-md-cold-install-start.txt  (operator-written before cold install)
 """
+
 from __future__ import annotations
 
 import datetime as dt

--- a/cli/src/robot_md/trial.py
+++ b/cli/src/robot_md/trial.py
@@ -11,10 +11,9 @@ Cold-install wall-clock anchor:
     ~/.robot-md-cold-install-start.txt  (operator-written before cold install)
 """
 from __future__ import annotations
+
 import datetime as dt
 import pathlib
-import secrets
-from typing import Optional
 
 import typer
 
@@ -32,7 +31,7 @@ def _trial_dir(trial_id: str) -> pathlib.Path:
     return TRIALS_DIR / trial_id
 
 
-def _read_cold_install_start() -> Optional[str]:
+def _read_cold_install_start() -> str | None:
     if not COLD_INSTALL_START_FILE.exists():
         return None
     raw = COLD_INSTALL_START_FILE.read_text().strip()

--- a/cli/tests/test_trial.py
+++ b/cli/tests/test_trial.py
@@ -1,26 +1,24 @@
 """Unit tests for robot-md trial subcommands."""
 from __future__ import annotations
-import json
-import pathlib
-import shutil
+
+import importlib
 
 import pytest
-from typer.testing import CliRunner
 
 
 @pytest.fixture
 def trial_home(tmp_path, monkeypatch):
     """Redirect ~/.robot-md/ to a temp dir for the test."""
     monkeypatch.setenv("HOME", str(tmp_path))
-    import importlib
     import robot_md.trial as trial_mod
     importlib.reload(trial_mod)
     yield tmp_path
 
 
 def test_trial_module_exposes_typer_app():
-    from robot_md.trial import trial_app
     import typer
+
+    from robot_md.trial import trial_app
     assert isinstance(trial_app, typer.Typer)
 
 

--- a/cli/tests/test_trial.py
+++ b/cli/tests/test_trial.py
@@ -1,0 +1,35 @@
+"""Unit tests for robot-md trial subcommands."""
+from __future__ import annotations
+import json
+import pathlib
+import shutil
+
+import pytest
+from typer.testing import CliRunner
+
+
+@pytest.fixture
+def trial_home(tmp_path, monkeypatch):
+    """Redirect ~/.robot-md/ to a temp dir for the test."""
+    monkeypatch.setenv("HOME", str(tmp_path))
+    import importlib
+    import robot_md.trial as trial_mod
+    importlib.reload(trial_mod)
+    yield tmp_path
+
+
+def test_trial_module_exposes_typer_app():
+    from robot_md.trial import trial_app
+    import typer
+    assert isinstance(trial_app, typer.Typer)
+
+
+def test_trials_dir_under_robot_md_home():
+    from robot_md.trial import TRIALS_DIR
+    assert TRIALS_DIR.name == "trials"
+    assert TRIALS_DIR.parent.name == ".robot-md"
+
+
+def test_cold_install_start_file_path():
+    from robot_md.trial import COLD_INSTALL_START_FILE
+    assert COLD_INSTALL_START_FILE.name == ".robot-md-cold-install-start.txt"

--- a/cli/tests/test_trial.py
+++ b/cli/tests/test_trial.py
@@ -1,4 +1,5 @@
 """Unit tests for robot-md trial subcommands."""
+
 from __future__ import annotations
 
 import importlib
@@ -11,6 +12,7 @@ def trial_home(tmp_path, monkeypatch):
     """Redirect ~/.robot-md/ to a temp dir for the test."""
     monkeypatch.setenv("HOME", str(tmp_path))
     import robot_md.trial as trial_mod
+
     importlib.reload(trial_mod)
     yield tmp_path
 
@@ -19,15 +21,18 @@ def test_trial_module_exposes_typer_app():
     import typer
 
     from robot_md.trial import trial_app
+
     assert isinstance(trial_app, typer.Typer)
 
 
 def test_trials_dir_under_robot_md_home():
     from robot_md.trial import TRIALS_DIR
+
     assert TRIALS_DIR.name == "trials"
     assert TRIALS_DIR.parent.name == ".robot-md"
 
 
 def test_cold_install_start_file_path():
     from robot_md.trial import COLD_INSTALL_START_FILE
+
     assert COLD_INSTALL_START_FILE.name == ".robot-md-cold-install-start.txt"


### PR DESCRIPTION
## Summary

- Scaffolds `cli/src/robot_md/trial.py` with `trial_app` typer and state-dir constants (`TRIALS_DIR`, `COLD_INSTALL_START_FILE`)
- Adds `cli/tests/test_trial.py` with 3 passing unit tests verifying the typer app type, trials dir path, and cold-install start file path
- Seeds the `robot-md trial` subcommand family; Tasks 8–12 will append commands to this module and Task 13 will wire it into the main CLI

## Test plan

- [x] `pytest cli/tests/test_trial.py -v` — 3 PASSED locally
- [ ] CI green on all Python matrix (3.10–3.13)

🤖 Generated with [Claude Code](https://claude.com/claude-code)