### PR TITLE
feat: trial start subcommand (Spec B Task 8)

### DIFF
--- a/cli/src/robot_md/trial.py
+++ b/cli/src/robot_md/trial.py
@@ -14,11 +14,19 @@ Cold-install wall-clock anchor:
 from __future__ import annotations
 
 import datetime as dt
+import json
 import pathlib
+import secrets
 
 import typer
 
 trial_app = typer.Typer(help="Capture pick-and-place trial evidence for cert minting.")
+
+
+@trial_app.callback()
+def _trial_callback() -> None:
+    """Capture pick-and-place trial evidence for cert minting."""
+
 
 TRIALS_DIR = pathlib.Path.home() / ".robot-md" / "trials"
 COLD_INSTALL_START_FILE = pathlib.Path.home() / ".robot-md-cold-install-start.txt"
@@ -41,3 +49,47 @@ def _read_cold_install_start() -> str | None:
     except ValueError:
         return None
     return raw
+
+
+@trial_app.command("start")
+def start_cmd(
+    property_: str = typer.Option(
+        ...,
+        "--property",
+        help="Cert property name (e.g., bob.local/PICK-PLACE-10)",
+    ),
+) -> None:
+    """Begin a new trial. Writes start.json with timestamps + property."""
+    trial_id = "trial_" + secrets.token_hex(3)
+    d = _trial_dir(trial_id)
+    d.mkdir(parents=True, exist_ok=False)
+    (d / "frames").mkdir()
+    cold_install_start = _read_cold_install_start()
+    anchor = "claude_code_first_command" if cold_install_start else "robot_md_trial_start_only"
+    state = {
+        "trial_id": trial_id,
+        "property": property_,
+        "started_at": _utcnow_iso(),
+        "cold_install_start_marker": cold_install_start,
+        "start_anchor": anchor,
+        "iterations": [],
+        "aborted_at": None,
+    }
+    (d / "start.json").write_text(json.dumps(state, indent=2) + "\n")
+    typer.echo(f"Trial {property_} started at {state['started_at']}")
+    if cold_install_start:
+        typer.echo(
+            f"  cold_install_start_marker: {cold_install_start}  (from {COLD_INSTALL_START_FILE})"
+        )
+    else:
+        typer.echo(
+            f"  ({COLD_INSTALL_START_FILE} not found"
+            " — wall-clock anchor downgraded to post-install)"
+        )
+    typer.echo(f"Trial ID: {trial_id}")
+    typer.echo("→ Run your Claude Code session now. After each iteration:")
+    typer.echo(f"  robot-md trial iteration --trial {trial_id} --capture-pre")
+    typer.echo("  → Claude does its thing →")
+    typer.echo(f"  robot-md trial iteration --trial {trial_id} --capture-post-and-verdict")
+    typer.echo("  → reset brick →")
+    typer.echo(f"  robot-md trial iteration --trial {trial_id} --reset-confirmed")

--- a/cli/tests/test_trial.py
+++ b/cli/tests/test_trial.py
@@ -3,8 +3,10 @@
 from __future__ import annotations
 
 import importlib
+import json
 
 import pytest
+from typer.testing import CliRunner
 
 
 @pytest.fixture
@@ -36,3 +38,63 @@ def test_cold_install_start_file_path():
     from robot_md.trial import COLD_INSTALL_START_FILE
 
     assert COLD_INSTALL_START_FILE.name == ".robot-md-cold-install-start.txt"
+
+
+def test_trial_start_writes_start_json(trial_home):
+    from robot_md.trial import trial_app
+
+    runner = CliRunner()
+    result = runner.invoke(trial_app, ["start", "--property", "bob.local/PICK-PLACE-10"])
+    assert result.exit_code == 0, result.output
+
+    trials = list((trial_home / ".robot-md" / "trials").iterdir())
+    assert len(trials) == 1
+    d = trials[0]
+    assert d.name.startswith("trial_")
+    assert (d / "frames").is_dir()
+
+    state = json.loads((d / "start.json").read_text())
+    assert state["property"] == "bob.local/PICK-PLACE-10"
+    assert state["trial_id"] == d.name
+    assert state["started_at"].endswith("Z")
+    assert state["start_anchor"] == "robot_md_trial_start_only"  # no cold-install file
+    assert state["cold_install_start_marker"] is None
+    assert state["iterations"] == []
+    assert state["aborted_at"] is None
+
+
+def test_trial_start_reads_cold_install_marker(trial_home):
+    from robot_md.trial import trial_app
+
+    (trial_home / ".robot-md-cold-install-start.txt").write_text("2026-05-11T13:52:13Z\n")
+    runner = CliRunner()
+    result = runner.invoke(trial_app, ["start", "--property", "bob.local/PICK-PLACE-10"])
+    assert result.exit_code == 0
+    d = next((trial_home / ".robot-md" / "trials").iterdir())
+    state = json.loads((d / "start.json").read_text())
+    assert state["cold_install_start_marker"] == "2026-05-11T13:52:13Z"
+    assert state["start_anchor"] == "claude_code_first_command"
+
+
+def test_trial_start_ignores_malformed_cold_install_marker(trial_home):
+    from robot_md.trial import trial_app
+
+    (trial_home / ".robot-md-cold-install-start.txt").write_text("not-a-timestamp")
+    runner = CliRunner()
+    result = runner.invoke(trial_app, ["start", "--property", "bob.local/PICK-PLACE-10"])
+    assert result.exit_code == 0
+    d = next((trial_home / ".robot-md" / "trials").iterdir())
+    state = json.loads((d / "start.json").read_text())
+    assert state["cold_install_start_marker"] is None
+    assert state["start_anchor"] == "robot_md_trial_start_only"
+
+
+def test_trial_start_prints_trial_id_and_protocol(trial_home):
+    from robot_md.trial import trial_app
+
+    runner = CliRunner()
+    result = runner.invoke(trial_app, ["start", "--property", "bob.local/PICK-PLACE-10"])
+    assert "Trial ID: trial_" in result.output
+    assert "--capture-pre" in result.output
+    assert "--capture-post-and-verdict" in result.output
+    assert "--reset-confirmed" in result.output


### PR DESCRIPTION
## Summary

- Implements `robot-md trial start --property <name>` subcommand
- Writes `~/.robot-md/trials/<trial_id>/start.json` with property, timestamps, cold-install anchor, empty iterations, and null aborted_at
- Creates `frames/` subdirectory alongside start.json
- Reads `~/.robot-md-cold-install-start.txt` as wall-clock anchor; sets `start_anchor` to `claude_code_first_command` if present and valid, else `robot_md_trial_start_only`
- Added `@trial_app.callback()` no-op to force Typer 0.16.x multi-command mode (single registered command collapses to single-command app otherwise)

## Test plan

- [ ] `pytest cli/tests/test_trial.py -v` → 7 passed
- [ ] `ruff check cli/src/robot_md/trial.py cli/tests/test_trial.py` → all checks passed
- [ ] `ruff format --check cli/src/robot_md/trial.py cli/tests/test_trial.py` → 2 files already formatted

🤖 Generated with [Claude Code](https://claude.com/claude-code)