### PR TITLE
feat: capture-post + verdict (Spec B Task 10)

### DIFF
--- a/cli/src/robot_md/trial.py
+++ b/cli/src/robot_md/trial.py
@@ -150,8 +150,18 @@ def iteration_cmd(
     if capture_pre:
         _capture_pre(d)
         return
-    # capture_post and reset_confirmed handled in Tasks 10 + 11
+    if capture_post:
+        _capture_post(d)
+        return
+    # reset_confirmed handled in Task 11
     raise typer.Exit(code=0)
+
+
+VERDICT_RULE = (
+    "post.red_blob.centroid_px ∈ post.bowl_top.bbox_px AND "
+    "|post.red_blob.centroid_depth_mm - post.bowl_top.centroid_depth_mm| <= 80"
+)
+DEPTH_DELTA_TOLERANCE_MM = 80
 
 
 def _capture_pre(d: pathlib.Path) -> None:
@@ -170,3 +180,63 @@ def _capture_pre(d: pathlib.Path) -> None:
     }
     (d / f"iter_{n}.json").write_text(json.dumps(iter_state, indent=2) + "\n")
     typer.echo(f"iteration {n}: pre-state captured at {iter_state['started_at']}")
+
+
+def _capture_post(d: pathlib.Path) -> None:
+    iters = sorted(d.glob("iter_*.json"), key=lambda p: int(p.stem.split("_")[1]))
+    if not iters:
+        typer.echo("error: no iteration in progress; run --capture-pre first")
+        raise typer.Exit(code=2)
+    cur = iters[-1]
+    state = json.loads(cur.read_text())
+    if "post_state" in state:
+        typer.echo(f"error: iteration {state['iteration']} already has post_state")
+        raise typer.Exit(code=2)
+
+    red = _gateway_invoke("oak-d", "perceive", {"query": "red_blob"})
+    bowl = _gateway_invoke("oak-d", "perceive", {"query": "bowl_top"})
+    joints = _gateway_invoke("so-arm101", "read_state", {})
+
+    red_t = red.get("telemetry", {})
+    bowl_t = bowl.get("telemetry", {})
+
+    centroid_inside = False
+    depth_delta = None
+    pixel_distance = None
+    if red_t.get("found") and bowl_t.get("found"):
+        cu, cv = red_t["centroid_px"]
+        u0, v0, u1, v1 = bowl_t["bbox_px"]
+        centroid_inside = (u0 <= cu <= u1) and (v0 <= cv <= v1)
+        depth_delta = abs(int(red_t["centroid_depth_mm"]) - int(bowl_t["centroid_depth_mm"]))
+        bx, by = bowl_t["centroid_px"]
+        pixel_distance = int(((cu - bx) ** 2 + (cv - by) ** 2) ** 0.5)
+    depth_within = depth_delta is not None and depth_delta <= DEPTH_DELTA_TOLERANCE_MM
+    red_in_bowl = bool(centroid_inside and depth_within)
+
+    post_iso = _utcnow_iso()
+    started = dt.datetime.strptime(state["started_at"], "%Y-%m-%dT%H:%M:%SZ").replace(
+        tzinfo=dt.timezone.utc
+    )
+    ended = dt.datetime.strptime(post_iso, "%Y-%m-%dT%H:%M:%SZ").replace(tzinfo=dt.timezone.utc)
+    duration_s = (ended - started).total_seconds()
+
+    state["post_state"] = {
+        "joint_positions_rad": joints.get("telemetry", {}).get("positions", {}),
+        "perceive_red_blob": red_t,
+        "perceive_bowl_top": bowl_t,
+        "captured_at": post_iso,
+    }
+    state["duration_s"] = duration_s
+    state["verdict"] = {
+        "rule": VERDICT_RULE,
+        "red_in_bowl": red_in_bowl,
+        "centroid_inside_bbox": centroid_inside,
+        "pixel_distance_to_bowl_centroid_px": pixel_distance,
+        "depth_delta_mm": depth_delta,
+        "pass": red_in_bowl,
+    }
+    cur.write_text(json.dumps(state, indent=2) + "\n")
+    typer.echo(
+        f"iteration {state['iteration']}: verdict={'PASS' if red_in_bowl else 'FAIL'}"
+        f" duration={duration_s:.1f}s"
+    )

--- a/cli/tests/test_trial.py
+++ b/cli/tests/test_trial.py
@@ -223,3 +223,217 @@ def test_capture_pre_rejects_unknown_trial(trial_home):
     result = runner.invoke(trial_app, ["iteration", "--trial", "trial_nope", "--capture-pre"])
     assert result.exit_code != 0
     assert "unknown trial" in result.output.lower()
+
+
+# ---------------------------------------------------------------------------
+# --capture-post-and-verdict helpers + tests
+# ---------------------------------------------------------------------------
+
+
+def _seed_iter_pre(d: pathlib.Path, iter_num: int = 1) -> None:
+    iter_state = {
+        "iteration": iter_num,
+        "started_at": "2026-05-11T14:01:00Z",
+        "pre_state": {
+            "joint_positions_rad": {"gripper": 0.0},
+            "perceive_red_blob": {
+                "found": True,
+                "centroid_px": [612, 358],
+                "centroid_depth_mm": 327,
+                "bbox_px": [598, 344, 626, 372],
+                "pixel_count": 478,
+                "provenance": {},
+            },
+            "perceive_bowl_top": {
+                "found": True,
+                "centroid_px": [285, 412],
+                "centroid_depth_mm": 305,
+                "bbox_px": [220, 350, 350, 470],
+                "pixel_count": 9412,
+                "provenance": {},
+            },
+        },
+    }
+    (d / f"iter_{iter_num}.json").write_text(json.dumps(iter_state) + "\n")
+
+
+def test_capture_post_marks_pass_when_red_inside_bowl(trial_home, monkeypatch):
+    from robot_md.trial import trial_app
+
+    d = _seed_trial(trial_home)
+    _seed_iter_pre(d)
+
+    def _fake_invoke(actuator: str, tool: str, args: dict) -> dict:
+        if actuator == "oak-d" and args.get("query") == "red_blob":
+            return {
+                "telemetry": {
+                    "found": True,
+                    "centroid_px": [288, 410],
+                    "centroid_depth_mm": 308,
+                    "bbox_px": [275, 397, 301, 423],
+                    "pixel_count": 312,
+                    "provenance": {},
+                }
+            }
+        if actuator == "oak-d" and args.get("query") == "bowl_top":
+            return {
+                "telemetry": {
+                    "found": True,
+                    "centroid_px": [285, 412],
+                    "centroid_depth_mm": 305,
+                    "bbox_px": [220, 350, 350, 470],
+                    "pixel_count": 9412,
+                    "provenance": {},
+                }
+            }
+        if actuator == "so-arm101" and tool == "read_state":
+            return {"telemetry": {"positions": {"gripper": 0.0}}}
+        raise AssertionError(f"unexpected: {actuator}/{tool}/{args}")
+
+    monkeypatch.setattr("robot_md.trial._gateway_invoke", _fake_invoke)
+
+    result = CliRunner().invoke(
+        trial_app, ["iteration", "--trial", d.name, "--capture-post-and-verdict"]
+    )
+    assert result.exit_code == 0, result.output
+
+    iter1 = json.loads((d / "iter_1.json").read_text())
+    verdict = iter1["verdict"]
+    assert verdict["pass"] is True
+    assert verdict["red_in_bowl"] is True
+    assert verdict["depth_delta_mm"] == 3
+    assert iter1["duration_s"] >= 0
+
+
+def test_capture_post_fails_when_red_outside_bowl_bbox(trial_home, monkeypatch):
+    from robot_md.trial import trial_app
+
+    d = _seed_trial(trial_home)
+    _seed_iter_pre(d)
+
+    def _fake_invoke(actuator: str, tool: str, args: dict) -> dict:
+        if actuator == "oak-d" and args.get("query") == "red_blob":
+            return {
+                "telemetry": {
+                    "found": True,
+                    "centroid_px": [50, 50],
+                    "centroid_depth_mm": 308,
+                    "bbox_px": [40, 40, 60, 60],
+                    "pixel_count": 100,
+                    "provenance": {},
+                }
+            }
+        if actuator == "oak-d" and args.get("query") == "bowl_top":
+            return {
+                "telemetry": {
+                    "found": True,
+                    "centroid_px": [285, 412],
+                    "centroid_depth_mm": 305,
+                    "bbox_px": [220, 350, 350, 470],
+                    "pixel_count": 9412,
+                    "provenance": {},
+                }
+            }
+        if actuator == "so-arm101" and tool == "read_state":
+            return {"telemetry": {"positions": {}}}
+        raise AssertionError(f"unexpected: {actuator}/{tool}/{args}")
+
+    monkeypatch.setattr("robot_md.trial._gateway_invoke", _fake_invoke)
+
+    result = CliRunner().invoke(
+        trial_app, ["iteration", "--trial", d.name, "--capture-post-and-verdict"]
+    )
+    assert result.exit_code == 0, result.output
+
+    iter1 = json.loads((d / "iter_1.json").read_text())
+    verdict = iter1["verdict"]
+    assert verdict["pass"] is False
+    assert verdict["red_in_bowl"] is False
+
+
+def test_capture_post_fails_when_depth_delta_over_80mm(trial_home, monkeypatch):
+    from robot_md.trial import trial_app
+
+    d = _seed_trial(trial_home)
+    _seed_iter_pre(d)
+
+    def _fake_invoke(actuator: str, tool: str, args: dict) -> dict:
+        if actuator == "oak-d" and args.get("query") == "red_blob":
+            return {
+                "telemetry": {
+                    "found": True,
+                    "centroid_px": [288, 410],
+                    "centroid_depth_mm": 200,
+                    "bbox_px": [275, 397, 301, 423],
+                    "pixel_count": 312,
+                    "provenance": {},
+                }
+            }
+        if actuator == "oak-d" and args.get("query") == "bowl_top":
+            return {
+                "telemetry": {
+                    "found": True,
+                    "centroid_px": [285, 412],
+                    "centroid_depth_mm": 305,
+                    "bbox_px": [220, 350, 350, 470],
+                    "pixel_count": 9412,
+                    "provenance": {},
+                }
+            }
+        if actuator == "so-arm101" and tool == "read_state":
+            return {"telemetry": {"positions": {"gripper": 0.0}}}
+        raise AssertionError(f"unexpected: {actuator}/{tool}/{args}")
+
+    monkeypatch.setattr("robot_md.trial._gateway_invoke", _fake_invoke)
+
+    result = CliRunner().invoke(
+        trial_app, ["iteration", "--trial", d.name, "--capture-post-and-verdict"]
+    )
+    assert result.exit_code == 0, result.output
+
+    iter1 = json.loads((d / "iter_1.json").read_text())
+    verdict = iter1["verdict"]
+    assert verdict["pass"] is False
+    assert verdict["depth_delta_mm"] == 105
+
+
+def test_capture_post_fails_when_post_red_not_found(trial_home, monkeypatch):
+    from robot_md.trial import trial_app
+
+    d = _seed_trial(trial_home)
+    _seed_iter_pre(d)
+
+    def _fake_invoke(actuator: str, tool: str, args: dict) -> dict:
+        if actuator == "oak-d" and args.get("query") == "red_blob":
+            return {
+                "telemetry": {
+                    "found": False,
+                    "pixel_count": 0,
+                    "provenance": {},
+                }
+            }
+        if actuator == "oak-d" and args.get("query") == "bowl_top":
+            return {
+                "telemetry": {
+                    "found": True,
+                    "centroid_px": [285, 412],
+                    "centroid_depth_mm": 305,
+                    "bbox_px": [220, 350, 350, 470],
+                    "pixel_count": 9412,
+                    "provenance": {},
+                }
+            }
+        if actuator == "so-arm101" and tool == "read_state":
+            return {"telemetry": {"positions": {"gripper": 0.0}}}
+        raise AssertionError(f"unexpected: {actuator}/{tool}/{args}")
+
+    monkeypatch.setattr("robot_md.trial._gateway_invoke", _fake_invoke)
+
+    result = CliRunner().invoke(
+        trial_app, ["iteration", "--trial", d.name, "--capture-post-and-verdict"]
+    )
+    assert result.exit_code == 0, result.output
+
+    iter1 = json.loads((d / "iter_1.json").read_text())
+    verdict = iter1["verdict"]
+    assert verdict["pass"] is False


### PR DESCRIPTION
## Summary

- Adds `_capture_post()` to `cli/src/robot_md/trial.py`: invokes `oak-d perceive` (red_blob + bowl_top) and `so-arm101 read_state` post-action, then computes a pass/fail verdict using the centroid-in-bbox AND depth-delta <= 80 mm rule
- Adds `VERDICT_RULE` and `DEPTH_DELTA_TOLERANCE_MM = 80` module-level constants
- Wires `--capture-post-and-verdict` flag in `iteration_cmd` to call `_capture_post`
- Adds `_seed_iter_pre` test helper and 4 new parameterized tests

## Test plan

- [ ] `pytest cli/tests/test_trial.py -v` → 14 passed, 0 failed
- [ ] `ruff check` and `ruff format --check` both clean
- [ ] `test_capture_post_marks_pass_when_red_inside_bowl` — centroid [288,410] inside bbox [220,350,350,470], depth_delta=3 → PASS
- [ ] `test_capture_post_fails_when_red_outside_bowl_bbox` — centroid [50,50] outside bowl → FAIL
- [ ] `test_capture_post_fails_when_depth_delta_over_80mm` — red depth 200 vs bowl 305 (delta 105) → FAIL
- [ ] `test_capture_post_fails_when_post_red_not_found` — `found: False` → FAIL

🤖 Generated with [Claude Code](https://claude.com/claude-code)