### PR TITLE
feat: reset + abort (Spec B Task 11)

### DIFF
--- a/cli/src/robot_md/trial.py
+++ b/cli/src/robot_md/trial.py
@@ -147,14 +147,20 @@ def iteration_cmd(
         )
         raise typer.Exit(code=2)
 
+    state = json.loads((d / "start.json").read_text())
+    if state.get("aborted_at"):
+        typer.echo(f"error: trial aborted at {state['aborted_at']}")
+        raise typer.Exit(code=2)
+
     if capture_pre:
         _capture_pre(d)
         return
     if capture_post:
         _capture_post(d)
         return
-    # reset_confirmed handled in Task 11
-    raise typer.Exit(code=0)
+    if reset_confirmed:
+        _reset_confirmed(d)
+        return
 
 
 VERDICT_RULE = (
@@ -240,3 +246,32 @@ def _capture_post(d: pathlib.Path) -> None:
         f"iteration {state['iteration']}: verdict={'PASS' if red_in_bowl else 'FAIL'}"
         f" duration={duration_s:.1f}s"
     )
+
+
+def _reset_confirmed(d: pathlib.Path) -> None:
+    iters = sorted(d.glob("iter_*.json"), key=lambda p: int(p.stem.split("_")[1]))
+    if not iters:
+        typer.echo("error: no iteration to confirm reset for")
+        raise typer.Exit(code=2)
+    cur = iters[-1]
+    state = json.loads(cur.read_text())
+    state["operator_reset_confirmed_at"] = _utcnow_iso()
+    cur.write_text(json.dumps(state, indent=2) + "\n")
+    typer.echo(
+        f"iteration {state['iteration']}: reset confirmed at {state['operator_reset_confirmed_at']}"
+    )
+
+
+@trial_app.command("abort")
+def abort_cmd(
+    trial_id: str = typer.Option(..., "--trial"),
+) -> None:
+    """Abort a trial, preventing further iterations."""
+    d = _trial_dir(trial_id)
+    if not d.exists():
+        typer.echo(f"error: unknown trial: {trial_id}")
+        raise typer.Exit(code=2)
+    state = json.loads((d / "start.json").read_text())
+    state["aborted_at"] = _utcnow_iso()
+    (d / "start.json").write_text(json.dumps(state, indent=2) + "\n")
+    typer.echo(f"trial {trial_id} aborted at {state['aborted_at']}")

--- a/cli/tests/test_trial.py
+++ b/cli/tests/test_trial.py
@@ -397,6 +397,46 @@ def test_capture_post_fails_when_depth_delta_over_80mm(trial_home, monkeypatch):
     assert verdict["depth_delta_mm"] == 105
 
 
+# ---------------------------------------------------------------------------
+# Task 11: --reset-confirmed + abort
+# ---------------------------------------------------------------------------
+
+
+def test_reset_confirmed_writes_timestamp(trial_home):
+    d = _seed_trial(trial_home)
+    _seed_iter_pre(d)
+    # Mark iter as post-done so reset is the natural next step
+    iter1 = json.loads((d / "iter_1.json").read_text())
+    iter1["verdict"] = {"pass": True}
+    (d / "iter_1.json").write_text(json.dumps(iter1) + "\n")
+    from robot_md.trial import trial_app
+
+    result = CliRunner().invoke(trial_app, ["iteration", "--trial", d.name, "--reset-confirmed"])
+    assert result.exit_code == 0
+    iter1 = json.loads((d / "iter_1.json").read_text())
+    assert iter1["operator_reset_confirmed_at"].endswith("Z")
+
+
+def test_trial_abort_writes_aborted_at(trial_home):
+    d = _seed_trial(trial_home)
+    from robot_md.trial import trial_app
+
+    result = CliRunner().invoke(trial_app, ["abort", "--trial", d.name])
+    assert result.exit_code == 0
+    state = json.loads((d / "start.json").read_text())
+    assert state["aborted_at"].endswith("Z")
+
+
+def test_aborted_trial_rejects_further_iterations(trial_home, monkeypatch):
+    d = _seed_trial(trial_home)
+    from robot_md.trial import trial_app
+
+    CliRunner().invoke(trial_app, ["abort", "--trial", d.name])
+    result = CliRunner().invoke(trial_app, ["iteration", "--trial", d.name, "--capture-pre"])
+    assert result.exit_code != 0
+    assert "aborted" in result.output.lower()
+
+
 def test_capture_post_fails_when_post_red_not_found(trial_home, monkeypatch):
     from robot_md.trial import trial_app
 


### PR DESCRIPTION
## Summary
- Adds `trial iteration --reset-confirmed`: stamps `operator_reset_confirmed_at` on the latest `iter_N.json`
- Adds `trial abort --trial <id>`: writes `aborted_at` to `start.json`
- Gates `trial iteration` commands on `aborted_at` (exit 2 + error message if set)

## Test plan
- [x] 3 new tests: `test_reset_confirmed_writes_timestamp`, `test_trial_abort_writes_aborted_at`, `test_aborted_trial_rejects_further_iterations`
- [x] 17/17 tests pass locally
- [x] `ruff check` + `ruff format --check` both pass

Spec B Phase B Task 11.