### PR TITLE
feat: trial finalize (Spec B Task 12)

### DIFF
--- a/cli/src/robot_md/trial.py
+++ b/cli/src/robot_md/trial.py
@@ -262,6 +262,92 @@ def _reset_confirmed(d: pathlib.Path) -> None:
     )
 
 
+WALL_CLOCK_TARGET_S = 600  # 10 minutes
+EXPECTED_ITERATIONS = 10
+
+
+def _parse_utc(s: str) -> dt.datetime:
+    return dt.datetime.strptime(s, "%Y-%m-%dT%H:%M:%SZ").replace(tzinfo=dt.timezone.utc)
+
+
+@trial_app.command("finalize")
+def finalize_cmd(
+    trial_id: str = typer.Option(..., "--trial"),
+) -> None:
+    """Roll iter_*.json files into evidence.json with cold-install wall-clock verdict."""
+    d = _trial_dir(trial_id)
+    if not d.exists():
+        typer.echo(f"error: unknown trial: {trial_id}")
+        raise typer.Exit(code=2)
+    start = json.loads((d / "start.json").read_text())
+    iter_files = sorted(d.glob("iter_*.json"), key=lambda p: int(p.stem.split("_")[1]))
+    if len(iter_files) != EXPECTED_ITERATIONS:
+        typer.echo(f"error: trial has {len(iter_files)} iterations, expected {EXPECTED_ITERATIONS}")
+        raise typer.Exit(code=2)
+
+    iters = [json.loads(p.read_text()) for p in iter_files]
+    passed = sum(1 for it in iters if it.get("verdict", {}).get("pass"))
+    trial_duration_s = sum(float(it.get("duration_s") or 0) for it in iters)
+
+    cold_block: dict
+    iter1 = iters[0]
+    if iter1.get("verdict", {}).get("pass") and start.get("cold_install_start_marker"):
+        start_marker = start["cold_install_start_marker"]
+        end_marker = iter1["post_state"]["captured_at"]
+        elapsed_s = (_parse_utc(end_marker) - _parse_utc(start_marker)).total_seconds()
+        verdict = "PASS" if elapsed_s <= WALL_CLOCK_TARGET_S else "FAIL"
+        cold_block = {
+            "start_marker": start_marker,
+            "start_anchor": start.get("start_anchor", "claude_code_first_command"),
+            "end_marker": end_marker,
+            "end_anchor": "iteration_1_pass",
+            "elapsed_s": elapsed_s,
+            "claim": f"≤ {WALL_CLOCK_TARGET_S} s (10 min)",
+            "verdict": verdict,
+        }
+    else:
+        cold_block = {
+            "start_marker": start.get("cold_install_start_marker"),
+            "start_anchor": start.get("start_anchor", "robot_md_trial_start_only"),
+            "end_marker": None,
+            "end_anchor": "iteration_1_pass",
+            "elapsed_s": None,
+            "claim": f"≤ {WALL_CLOCK_TARGET_S} s (10 min)",
+            "verdict": "N/A",
+        }
+
+    evidence = {
+        "property": start["property"],
+        "rig": "bob-rig-2026",
+        "rrn": "RRN-000000000002",
+        "actuators": [
+            {"name": "so-arm101", "rpn": "RPN-000000000002"},
+            {"name": "oak-d", "rpn": "RPN-000000000003"},
+        ],
+        "captured_at": _utcnow_iso(),
+        "trial_duration_s": trial_duration_s,
+        "cold_install_wallclock": cold_block,
+        "total": EXPECTED_ITERATIONS,
+        "passed": passed,
+        "iterations": iters,
+        "scope_disclaimers": [
+            "Per-motion HiTL claim NOT made; envelopes batch-signed by bob-operator-2026.",
+            "Verification uses hardcoded HSV+depth thresholds;"
+            " not robust to non-standard lighting.",
+            "Camera mount: bird's-eye, ~30cm above table, pointing down.",
+            "Claude reasoning quality affects trial duration; per-iteration soft timeout is 30s.",
+            "Wall-clock anchor is operator-tagged; honor system.",
+        ],
+    }
+    (d / "evidence.json").write_text(json.dumps(evidence, indent=2) + "\n")
+    typer.echo(
+        f"Trial {trial_id} finalized."
+        f" {passed}/{EXPECTED_ITERATIONS} passed."
+        f" Total duration: {trial_duration_s:.0f}s."
+    )
+    typer.echo(f"Evidence at: {d / 'evidence.json'}")
+
+
 @trial_app.command("abort")
 def abort_cmd(
     trial_id: str = typer.Option(..., "--trial"),

--- a/cli/tests/test_trial.py
+++ b/cli/tests/test_trial.py
@@ -477,3 +477,96 @@ def test_capture_post_fails_when_post_red_not_found(trial_home, monkeypatch):
     iter1 = json.loads((d / "iter_1.json").read_text())
     verdict = iter1["verdict"]
     assert verdict["pass"] is False
+
+
+# ---------------------------------------------------------------------------
+# Task 12: trial finalize
+# ---------------------------------------------------------------------------
+
+
+def _seed_n_iters(d: pathlib.Path, n: int, all_pass: bool = True) -> None:
+    for i in range(1, n + 1):
+        state = {
+            "iteration": i,
+            "started_at": f"2026-05-11T14:0{i}:00Z",
+            "duration_s": 24.7,
+            "pre_state": {
+                "joint_positions_rad": {},
+                "perceive_red_blob": {},
+                "perceive_bowl_top": {},
+            },
+            "post_state": {
+                "joint_positions_rad": {},
+                "perceive_red_blob": {},
+                "perceive_bowl_top": {},
+                "captured_at": f"2026-05-11T14:0{i}:30Z",
+            },
+            "verdict": {
+                "pass": all_pass,
+                "red_in_bowl": all_pass,
+                "centroid_inside_bbox": all_pass,
+                "depth_delta_mm": 3,
+                "pixel_distance_to_bowl_centroid_px": 3,
+                "rule": "...",
+            },
+            "operator_reset_confirmed_at": f"2026-05-11T14:0{i}:45Z",
+        }
+        (d / f"iter_{i}.json").write_text(json.dumps(state) + "\n")
+
+
+def test_finalize_writes_evidence_json_with_passed_tally(trial_home):
+    d = _seed_trial(trial_home)
+    _seed_n_iters(d, 10)
+    from robot_md.trial import trial_app
+
+    result = CliRunner().invoke(trial_app, ["finalize", "--trial", d.name])
+    assert result.exit_code == 0, result.output
+    ev = json.loads((d / "evidence.json").read_text())
+    assert ev["property"] == "bob.local/PICK-PLACE-10"
+    assert ev["total"] == 10
+    assert ev["passed"] == 10
+    assert len(ev["iterations"]) == 10
+
+
+def test_finalize_records_wall_clock_pass_when_iter1_passes(trial_home):
+    d = _seed_trial(trial_home)
+    state = json.loads((d / "start.json").read_text())
+    state["cold_install_start_marker"] = "2026-05-11T13:52:00Z"
+    state["start_anchor"] = "claude_code_first_command"
+    (d / "start.json").write_text(json.dumps(state) + "\n")
+    _seed_n_iters(d, 10)
+    from robot_md.trial import trial_app
+
+    result = CliRunner().invoke(trial_app, ["finalize", "--trial", d.name])
+    assert result.exit_code == 0
+    ev = json.loads((d / "evidence.json").read_text())
+    assert ev["cold_install_wallclock"]["start_anchor"] == "claude_code_first_command"
+    assert ev["cold_install_wallclock"]["end_anchor"] == "iteration_1_pass"
+    assert ev["cold_install_wallclock"]["elapsed_s"] > 0
+    assert ev["cold_install_wallclock"]["verdict"] == "PASS"
+
+
+def test_finalize_records_wall_clock_na_when_iter1_fails(trial_home):
+    d = _seed_trial(trial_home)
+    state = json.loads((d / "start.json").read_text())
+    state["cold_install_start_marker"] = "2026-05-11T13:52:00Z"
+    state["start_anchor"] = "claude_code_first_command"
+    (d / "start.json").write_text(json.dumps(state) + "\n")
+    _seed_n_iters(d, 10, all_pass=False)
+    from robot_md.trial import trial_app
+
+    result = CliRunner().invoke(trial_app, ["finalize", "--trial", d.name])
+    assert result.exit_code == 0
+    ev = json.loads((d / "evidence.json").read_text())
+    assert ev["passed"] == 0
+    assert ev["cold_install_wallclock"]["verdict"] == "N/A"
+
+
+def test_finalize_refuses_partial_trial(trial_home):
+    d = _seed_trial(trial_home)
+    _seed_n_iters(d, 7)
+    from robot_md.trial import trial_app
+
+    result = CliRunner().invoke(trial_app, ["finalize", "--trial", d.name])
+    assert result.exit_code != 0
+    assert "10" in result.output  # complaint mentions expected count


### PR DESCRIPTION
## Summary

- Adds `trial finalize --trial <id>` subcommand to `trial_app`
- Rolls 10 `iter_*.json` files into a single `evidence.json` with full pass/fail tally and iteration list
- Computes cold-install wall-clock block: elapsed seconds from `cold_install_start_marker` → iter-1 `post_state.captured_at`, with PASS (≤600s) / FAIL / N/A verdict
- Refuses to finalize with a non-zero exit if iteration count != 10
- Extracts `_parse_utc()` helper (mirrors existing pattern in `_capture_post`)

## Test plan

- [ ] 4 new tests added and passing: `test_finalize_writes_evidence_json_with_passed_tally`, `test_finalize_records_wall_clock_pass_when_iter1_passes`, `test_finalize_records_wall_clock_na_when_iter1_fails`, `test_finalize_refuses_partial_trial`
- [ ] All 21 tests pass (`pytest cli/tests/test_trial.py -v`)
- [ ] `ruff check` + `ruff format --check` clean on both modified files

🤖 Generated with [Claude Code](https://claude.com/claude-code)