### PR TITLE
feat: register trial subcommand (Spec B Task 13)

### DIFF
--- a/cli/src/robot_md/__main__.py
+++ b/cli/src/robot_md/__main__.py
@@ -2589,10 +2589,12 @@ def dashboard_serve(
 from robot_md.hotplug.cli import app as hotplug_daemon_app  # noqa: E402
 from robot_md.hotplug.cli import operator_app as hotplug_operator_app  # noqa: E402
 from robot_md.spatial_eval.cli import app as spatial_eval_app  # noqa: E402
+from robot_md.trial import trial_app  # noqa: E402
 
 app.add_typer(hotplug_daemon_app, name="hotplug-daemon")
 app.add_typer(hotplug_operator_app, name="hotplug")
 app.add_typer(spatial_eval_app, name="spatial-eval")
+app.add_typer(trial_app, name="trial")
 
 
 if __name__ == "__main__":

--- a/cli/tests/test_trial.py
+++ b/cli/tests/test_trial.py
@@ -570,3 +570,13 @@ def test_finalize_refuses_partial_trial(trial_home):
     result = CliRunner().invoke(trial_app, ["finalize", "--trial", d.name])
     assert result.exit_code != 0
     assert "10" in result.output  # complaint mentions expected count
+
+
+def test_trial_subcommand_registered_in_main_cli():
+    """`robot-md trial --help` should list start/iteration/finalize/abort."""
+    import subprocess
+
+    result = subprocess.run(["robot-md", "trial", "--help"], capture_output=True, text=True)
+    assert result.returncode == 0, result.stderr
+    for cmd in ("start", "iteration", "finalize", "abort"):
+        assert cmd in result.stdout, f"trial {cmd} not registered"


### PR DESCRIPTION
## Summary

- Imports `trial_app` from `robot_md.trial` into `__main__.py` following the established `# noqa: E402` import pattern (same location as `hotplug_daemon_app`, `hotplug_operator_app`, `spatial_eval_app`)
- Registers it with `app.add_typer(trial_app, name="trial")` adjacent to the other late-import registrations
- Adds `test_trial_subcommand_registered_in_main_cli` smoke test that shells out to the installed `robot-md` console-script and asserts all four subcommands (start, iteration, finalize, abort) are listed in `--help`

## Test plan

- [ ] `pytest cli/tests/test_trial.py -v` → 22 passed
- [ ] `ruff check cli/src/robot_md/__main__.py cli/tests/test_trial.py` → all checks passed
- [ ] `ruff format --check cli/src/robot_md/__main__.py cli/tests/test_trial.py` → 2 files already formatted
- [ ] `robot-md trial --help` lists start / iteration / finalize / abort

🤖 Generated with [Claude Code](https://claude.com/claude-code)