### PR TITLE
release: robot-md 1.10.0 (Spec B Task 15)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,23 @@ Format follows [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 
 ---
 
+## [1.10.0] - 2026-05-11
+
+### Added
+- `robot-md trial` subcommand family for capturing pick-and-place trial evidence:
+  - `trial start --property <name>` writes `~/.robot-md/trials/<id>/start.json` with cold-install wall-clock anchor.
+  - `trial iteration --trial <id> --capture-pre` records perceive + joint state via the gateway.
+  - `trial iteration --trial <id> --capture-post-and-verdict` computes the verdict (centroid ∈ bowl bbox AND |depth_delta| ≤ 80mm).
+  - `trial iteration --trial <id> --reset-confirmed` stamps operator reset confirmation.
+  - `trial abort --trial <id>` aborts a trial; further iterations are refused.
+  - `trial finalize --trial <id>` rolls 10 iterations into `evidence.json` with the 10-min cold-install wall-clock verdict block.
+- Skill `using-robot-md` gains a "Pick-place trial protocol" section guiding the agent through `oak-d perceive` + `so-arm101 move` sequencing.
+
+### Notes
+- Trial commands assume the gateway is reachable at `ROBOT_MD_GATEWAY_URL` (default `http://127.0.0.1:8080`) with `ROBOT_MD_GATEWAY_BEARER`. Phase E (#69) tracks the envelope-shape gap before Bob runs the physical trial.
+
+---
+
 ## [1.5.1] - 2026-05-01
 
 ### Notes

--- a/cli/pyproject.toml
+++ b/cli/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "hatchling.build"
 
 [project]
 name = "robot-md"
-version = "1.9.1"
+version = "1.10.0"
 description = "ROBOT.md — a single self-describing file so Claude can safely operate your robot."
 readme = "../README.md"
 requires-python = ">=3.10"


### PR DESCRIPTION
## Summary

- Bump `cli/pyproject.toml` version from `1.9.1` → `1.10.0`
- Add `## [1.10.0] - 2026-05-11` CHANGELOG entry covering all Spec B Phase B trial subcommands (Tasks 7–14) and the pick-place skill section

## Changes included in this release (Tasks 7–14 already on main)

- `robot-md trial` subcommand family: `start`, `iteration --capture-pre`, `iteration --capture-post-and-verdict`, `iteration --reset-confirmed`, `abort`, `finalize`
- Skill `using-robot-md` pick-place trial protocol section

## Test plan

- [x] Local `pytest tests/ -q` → 1455 passed, 19 skipped, 1 xfailed
- [x] `ruff check src/ tests/` → all checks passed
- [x] `ruff format --check src/ tests/` → 482 files already formatted
- [ ] CI green (8 checks)