### PR TITLE
release: 1.10.2 — tag-driven PyPI publish + republish 1.10.1 fix

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -96,9 +96,10 @@ jobs:
           release_tag: ${{ github.ref_name }}
 
   pypi-publish:
-    # Manual-only. Trigger via "Release" workflow → Run workflow →
-    # publish_pypi=true. Requires PYPI_TOKEN set in the pypi environment.
-    if: github.event_name == 'workflow_dispatch' && github.event.inputs.publish_pypi == 'true'
+    # Publishes on tag push automatically. Manual dispatch with
+    # publish_pypi=true still works as a re-publish escape hatch.
+    # Requires PYPI_TOKEN set in the pypi environment.
+    if: startsWith(github.ref, 'refs/tags/v') || (github.event_name == 'workflow_dispatch' && github.event.inputs.publish_pypi == 'true')
     runs-on: ubuntu-latest
     needs: build
     environment: pypi

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,24 @@ Format follows [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 
 ---
 
+## [1.10.2] - 2026-05-11
+
+### Fixed
+- Release workflow's `pypi-publish` job now fires on tag push, not only on
+  manual `workflow_dispatch`. The previous gate (added Apr 17 when
+  Trusted Publisher was unconfigured) was made vestigial by the later
+  switch to `PYPI_TOKEN`, but the gate stayed and silently skipped PyPI
+  upload for v1.10.1 — the GitHub release shipped while PyPI still
+  served 1.10.0. Manual dispatch with `publish_pypi=true` is preserved
+  as an explicit re-publish escape hatch.
+
+### Notes
+- This release is a no-code republish of 1.10.1's CLI payload to make
+  `pip install robot-md` actually deliver the `_gateway_invoke`
+  full-envelope fix (closes #69, originally shipped in 1.10.1).
+
+---
+
 ## [1.10.1] - 2026-05-11
 
 ### Fixed

--- a/cli/pyproject.toml
+++ b/cli/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "hatchling.build"
 
 [project]
 name = "robot-md"
-version = "1.10.1"
+version = "1.10.2"
 description = "ROBOT.md — a single self-describing file so Claude can safely operate your robot."
 readme = "../README.md"
 requires-python = ">=3.10"


### PR DESCRIPTION
## Summary

- `pypi-publish` workflow gate was `workflow_dispatch && publish_pypi=true` — added Apr 17 when Trusted Publisher wasn't configured. The later switch to `PYPI_TOKEN` made the gate vestigial, but the gate stayed and **silently skipped PyPI upload for v1.10.1** (GitHub release shipped, PyPI still serves 1.10.0).
- Adds `startsWith(github.ref, 'refs/tags/v')` to the `if:` so tag pushes auto-publish. Manual dispatch with `publish_pypi=true` is preserved as a re-publish escape hatch.
- Bumps to 1.10.2 (no code change vs 1.10.1) so PyPI gets a clean version with the `_gateway_invoke` full-envelope fix (#69).

## Why this matters

Spec B Phase E Task T22 (Bob cold install + 10-iteration pick-place trial + cert mint) does `pip install robot-md` after wiping `~/.robot-md/`. Without this fix the trial would re-install the broken 1.10.0 envelope shape and fail at the first `--capture-pre`.

## Test plan

- [ ] CI green on this PR.
- [ ] After merge: tag `v1.10.2`; confirm the `pypi-publish` job runs (not skipped) and PyPI ships `robot-md==1.10.2`.
- [ ] `pip index versions robot-md` shows `1.10.2`.
- [ ] Spot-check that v1.10.2 wheel's `robot_md/trial.py` has the full-envelope `_gateway_invoke` from #77.

🤖 Generated with [Claude Code](https://claude.com/claude-code)