### PR TITLE
release: 1.10.3 — cold-install UX fixes (closes #82)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,49 @@ Format follows [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 
 ---
 
+## [1.10.3] - 2026-05-11
+
+### Fixed
+- **Cold-install UX: serial-bus probe failures are no longer silent.**
+  Previously, when `/dev/ttyACM*` was hardened to gateway-only ownership
+  (the default udev rule on cert-bearing rigs), `robot-md init`'s
+  auto-discovery would catch the `PermissionError`, swallow it, and fall
+  back to `preset: minimal` — operator only noticed when the rendered
+  manifest had no `arm.pick` / `arm.place` capabilities. `_probe_servo_buses`
+  now catches `PermissionError` specifically, surfaces a stderr warning
+  with the exact remediation command, and appends to `scan.warnings`.
+  `scan_feetech` re-raises `PermissionError` unchanged instead of wrapping
+  it in a generic `RuntimeError`.
+- **`robot-md init --force` preserves `metadata.rrn` + `metadata.record_url`.**
+  Previously, `--force` regenerated the manifest from scratch via
+  `merge_preset_into_draft`, dropping the operator's already-minted RRN
+  and orphaning the signing keypair under `~/.robot-md/keys/<rrn>.signing.json`.
+  `phase_write_manifest` now reads the existing manifest's frontmatter
+  before regenerating and carries forward the two registration-identity
+  fields. A subsequent `robot-md register` run still overwrites them
+  (correct), but a `--force` re-init without re-register no longer
+  silently orphans the keypair.
+
+### Added
+- **`robot-md install-gateway` adds `$SUDO_USER` to the `robot-md-gateway` group.**
+  After the systemd unit is installed and the gateway is verified active,
+  the invoking user (`$SUDO_USER`) is added to the `robot-md-gateway` group
+  so that a subsequent `robot-md init` can read `/dev/ttyACM*` for serial-bus
+  auto-discovery. The operator must log out + back in (or run `newgrp
+  robot-md-gateway`) before the new group takes effect — `install-gateway`
+  prints this remediation. New `--no-add-user` flag opts out on locked-down
+  service hosts that intentionally keep operator accounts out of the
+  gateway group.
+
+### Notes
+- Closes #82. All three remediations from the issue ship together. Tested
+  end-to-end on Bob during Spec B Phase E T22 cold-install prep.
+- No code changes to the CLI surface that would affect existing manifests
+  or signing flows. The carry-forward only kicks in when `--force` is
+  passed and an existing manifest is present.
+
+---
+
 ## [1.10.2] - 2026-05-11
 
 ### Fixed

--- a/cli/pyproject.toml
+++ b/cli/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "hatchling.build"
 
 [project]
 name = "robot-md"
-version = "1.10.2"
+version = "1.10.3"
 description = "ROBOT.md — a single self-describing file so Claude can safely operate your robot."
 readme = "../README.md"
 requires-python = ">=3.10"

--- a/cli/src/robot_md/__main__.py
+++ b/cli/src/robot_md/__main__.py
@@ -1802,6 +1802,18 @@ def install_gateway_cmd(
         "-y",
         help="Skip the sudo confirmation prompt.",
     ),
+    no_add_user: bool = typer.Option(
+        False,
+        "--no-add-user",
+        help=(
+            "Do NOT add the invoking user ($SUDO_USER) to the "
+            "robot-md-gateway group. Use this on locked-down service hosts "
+            "where the operator account intentionally must not gain access "
+            "to /dev/ttyACM*. Without this flag, the user is added to the "
+            "group so that `robot-md init`'s serial-bus probe can read "
+            "/dev/ttyACM*."
+        ),
+    ),
 ) -> None:
     """Scaffold the robot-md-gateway systemd service on a fresh host (sudo).
 
@@ -1811,7 +1823,11 @@ def install_gateway_cmd(
     """
     from robot_md.install_gateway import install_gateway as _install_gateway
 
-    rc = _install_gateway(manifest_path=str(manifest), yes=yes)
+    rc = _install_gateway(
+        manifest_path=str(manifest),
+        yes=yes,
+        add_user_to_group=not no_add_user,
+    )
     if rc != 0:
         raise typer.Exit(code=rc)
 

--- a/cli/src/robot_md/autodetect.py
+++ b/cli/src/robot_md/autodetect.py
@@ -439,7 +439,9 @@ def _run(cmd: list[str]) -> str | None:
     return result.stdout
 
 
-def _probe_servo_buses(devices: list[Device]) -> list[Device]:
+def _probe_servo_buses(
+    devices: list[Device], warnings: list[str] | None = None
+) -> list[Device]:
     """Actively probe serial ports to discover their actual protocol.
 
     For each `/dev/ttyACM*` or `/dev/ttyUSB*` in `devices`, call
@@ -451,7 +453,13 @@ def _probe_servo_buses(devices: list[Device]) -> list[Device]:
     UARTs often host console/login gettys, and sending Feetech bytes to a
     login shell would be a mess). Opt out via env `ROBOT_MD_SKIP_BUS_PROBE=1`.
 
-    Silent no-op on: missing SDK, no servos, probe exception. Never raises.
+    `PermissionError` from a probe is **surfaced**, not swallowed: appended
+    to the optional `warnings` list and printed to stderr with a remediation
+    hint. The probe still returns no Feetech device for that port (preset
+    matching cannot proceed without bus access), but the operator now sees
+    *why* their SO-ARM101 wasn't auto-detected instead of silently getting
+    `preset: minimal`. Other exceptions (SDK missing, transient bus error)
+    remain silent — they are not actionable for the operator.
     """
     if os.environ.get("ROBOT_MD_SKIP_BUS_PROBE") == "1":
         return []
@@ -466,6 +474,21 @@ def _probe_servo_buses(devices: list[Device]) -> list[Device]:
             from robot_md.bus_scan import scan_feetech  # lazy
 
             servos = scan_feetech(d.path)
+        except PermissionError:
+            msg = (
+                f"{d.path} exists but is not readable by the current user "
+                "(likely owned by robot-md-gateway:robot-md-gateway, mode "
+                "crw-rw----). Auto-discovery cannot probe for actuators on "
+                "this bus, so preset matching will fall back to a minimal "
+                "shape with no `arm.pick` / `arm.place` capabilities. Fix: "
+                "`sudo usermod -aG robot-md-gateway $USER` then `newgrp "
+                "robot-md-gateway` (or log out + back in), then re-run "
+                "`robot-md init --force`."
+            )
+            if warnings is not None:
+                warnings.append(msg)
+            print(f"warning: {msg}", file=sys.stderr)
+            continue
         except Exception:
             continue
         if not servos:
@@ -511,7 +534,7 @@ def scan_system() -> Scan:
     # Active bus probe — if a serial tty responds to Feetech protocol, add
     # a synthetic Device(protocol="feetech") so preset matching can score
     # so-arm101 / so-arm101-leader above the alphabetical-first fallback.
-    scan.devices.extend(_probe_servo_buses(scan.devices))
+    scan.devices.extend(_probe_servo_buses(scan.devices, warnings=scan.warnings))
     # Compose typed probes (depthai → realsense → v4l2)
     cameras: list[DetectedCamera] = []
     cameras.extend(probe_depthai_cameras())

--- a/cli/src/robot_md/autodetect.py
+++ b/cli/src/robot_md/autodetect.py
@@ -439,9 +439,7 @@ def _run(cmd: list[str]) -> str | None:
     return result.stdout
 
 
-def _probe_servo_buses(
-    devices: list[Device], warnings: list[str] | None = None
-) -> list[Device]:
+def _probe_servo_buses(devices: list[Device], warnings: list[str] | None = None) -> list[Device]:
     """Actively probe serial ports to discover their actual protocol.
 
     For each `/dev/ttyACM*` or `/dev/ttyUSB*` in `devices`, call

--- a/cli/src/robot_md/bus_scan.py
+++ b/cli/src/robot_md/bus_scan.py
@@ -85,6 +85,11 @@ def scan_feetech(port: str, baud: int = 1_000_000) -> list[ServoEntry]:
     try:
         ph = PortHandler(port)
         opened = ph.openPort()
+    except PermissionError:
+        # Re-raise unchanged — autodetect's probe loop catches this
+        # specifically and emits a remediation hint (the udev rule on
+        # cert-bearing rigs hardens /dev/ttyACM* to gateway-only).
+        raise
     except Exception as e:  # pyserial may raise SerialException on a bad port
         raise RuntimeError(
             f"failed to open {port}: {e} — is the gateway still holding the "

--- a/cli/src/robot_md/init_phases/write_manifest.py
+++ b/cli/src/robot_md/init_phases/write_manifest.py
@@ -13,6 +13,45 @@ from robot_md.init import (
 from robot_md.init_phases import PhaseResult
 
 
+def _carry_forward_registration_fields(out_path: Path) -> dict[str, str]:
+    """Read an existing manifest's frontmatter and extract identity fields
+    that the regenerator would otherwise drop.
+
+    `merge_preset_into_draft` builds a fresh frontmatter from preset + scan;
+    it has no knowledge of an RRN that the operator already minted against
+    the Robot Registry Foundation. If `init --force` is being used to
+    re-run hardware discovery (e.g., after fixing /dev/ttyACM permissions),
+    we must carry forward:
+
+      - metadata.rrn      — the assigned RRN; the keypair under
+                            ~/.robot-md/keys/<rrn>.signing.json is keyed
+                            to this and is orphaned the moment it drops.
+      - metadata.record_url — the human-resolvable URL paired with the RRN.
+
+    Returns the carry-forward dict (possibly empty). Silently returns
+    empty on any parse failure — re-init with --force on a corrupted
+    manifest still works, the operator just loses the RRN reference,
+    same as before this fix.
+    """
+    if not out_path.exists():
+        return {}
+    try:
+        from robot_md.parser import parse_file
+
+        parsed = parse_file(out_path)
+    except Exception:
+        return {}
+    md = parsed.frontmatter.get("metadata") or {}
+    carry: dict[str, str] = {}
+    rrn = md.get("rrn")
+    if rrn:
+        carry["rrn"] = rrn
+    record_url = md.get("record_url")
+    if record_url:
+        carry["record_url"] = record_url
+    return carry
+
+
 def phase_write_manifest(
     *,
     out_path: Path,
@@ -23,6 +62,12 @@ def phase_write_manifest(
 ) -> PhaseResult:
     """Write a validated ROBOT.md draft. Returns PhaseResult; never raises
     for recoverable errors. Fatal I/O errors (disk full) may still raise.
+
+    When `force=True` and `out_path` exists, this preserves
+    `metadata.rrn` + `metadata.record_url` from the existing manifest so
+    that `init --force` does not orphan an already-minted RRN. A
+    subsequent `robot-md register` run will overwrite these anyway; the
+    preservation only kicks in when --register is not being re-run.
     """
     if out_path.exists() and not force:
         return PhaseResult(
@@ -31,6 +76,8 @@ def phase_write_manifest(
             message=f"{out_path} already exists (pass --force to overwrite)",
             detail={"reason": "exists", "path": str(out_path)},
         )
+
+    carry_forward = _carry_forward_registration_fields(out_path) if force else {}
 
     presets = load_presets()
     if not presets:
@@ -71,6 +118,10 @@ def phase_write_manifest(
 
     name = robot_name or _default_robot_name()
     fm = merge_preset_into_draft(chosen.preset, name, scan)
+    if carry_forward:
+        fm.setdefault("metadata", {})
+        for k, v in carry_forward.items():
+            fm["metadata"][k] = v
     body_hints = chosen.preset.data.get("body_hints", {}) or {}
     text = render_draft(fm, body_hints)
     out_path.write_text(text)
@@ -85,5 +136,6 @@ def phase_write_manifest(
             "score": chosen.score,
             "reasons": chosen.reasons,
             "robot_name": name,
+            "carried_forward": sorted(carry_forward.keys()),
         },
     )

--- a/cli/src/robot_md/install_gateway.py
+++ b/cli/src/robot_md/install_gateway.py
@@ -99,7 +99,20 @@ def already_installed() -> bool:
     return result.returncode == 0 and result.stdout.strip() == "active"
 
 
-def install_gateway(*, manifest_path: str, yes: bool = False) -> int:
+def _invoking_user() -> str | None:
+    """Return the user who invoked sudo, or None when running unprivileged
+    or directly as root with no SUDO_USER. Used to grant the operator access
+    to the `robot-md-gateway` group during install so that `robot-md init`
+    can probe /dev/ttyACM* (which the udev rule hardens to gateway-only)."""
+    user = os.environ.get("SUDO_USER")
+    if user and user != "root":
+        return user
+    return None
+
+
+def install_gateway(
+    *, manifest_path: str, yes: bool = False, add_user_to_group: bool = True
+) -> int:
     """Full install sequence. Requires sudo. Returns 0 on success.
 
     Steps:
@@ -113,6 +126,14 @@ def install_gateway(*, manifest_path: str, yes: bool = False) -> int:
       8. sudo write /etc/systemd/system/robot-md-gateway.service
       9. sudo systemctl daemon-reload && systemctl enable --now robot-md-gateway
      10. Verify curl 127.0.0.1:8080 returns any HTTP response.
+     11. When add_user_to_group=True (default) and $SUDO_USER is set,
+         add the invoking user to the `robot-md-gateway` group so they
+         can probe /dev/ttyACM* during a later `robot-md init`. The udev
+         rule hardens those devices to gateway-only; without this step,
+         `robot-md init`'s auto-discovery silently misses serial actuators
+         and falls back to `preset: minimal`. Pass --no-add-user on
+         production rigs that intentionally keep the operator account out
+         of the gateway group.
     """
     if already_installed():
         print("robot-md-gateway already installed and active. Nothing to do.")
@@ -192,6 +213,32 @@ def install_gateway(*, manifest_path: str, yes: bool = False) -> int:
     except Exception as e:
         print(f"gateway started but health probe failed: {e}")
         return 1
+
+    if add_user_to_group:
+        invoker = _invoking_user()
+        if invoker:
+            r = subprocess.run(
+                [*sudo, "usermod", "-aG", "robot-md-gateway", invoker],
+                capture_output=True,
+                text=True,
+            )
+            if r.returncode == 0:
+                print(
+                    f"added '{invoker}' to robot-md-gateway group "
+                    "(needed for robot-md init's serial-bus probe)."
+                )
+                print(
+                    "  → log out + back in, OR run "
+                    "`newgrp robot-md-gateway` / `sg robot-md-gateway -c '<cmd>'`,\n"
+                    "    before `robot-md init` so /dev/ttyACM* is readable."
+                )
+            else:
+                print(
+                    f"warning: failed to add '{invoker}' to robot-md-gateway "
+                    f"group ({r.stderr.strip()}). robot-md init's serial probe "
+                    f"will fail with PermissionError until you run:\n"
+                    f"    sudo usermod -aG robot-md-gateway {invoker}"
+                )
 
     print("robot-md-gateway installed and active.")
     return 0

--- a/cli/tests/test_install_gateway.py
+++ b/cli/tests/test_install_gateway.py
@@ -1,6 +1,7 @@
 from unittest.mock import patch
 
 from robot_md.install_gateway import (
+    _invoking_user,
     already_installed,
     render_default_bearers,
     render_env_file,
@@ -56,3 +57,20 @@ def test_not_installed_when_venv_missing():
     """venv binary missing → False without invoking systemctl."""
     with patch("pathlib.Path.exists", return_value=False):
         assert already_installed() is False
+
+
+def test_invoking_user_returns_sudo_user_when_set():
+    with patch.dict("os.environ", {"SUDO_USER": "alice"}, clear=False):
+        assert _invoking_user() == "alice"
+
+
+def test_invoking_user_returns_none_when_sudo_user_unset():
+    with patch.dict("os.environ", {}, clear=True):
+        assert _invoking_user() is None
+
+
+def test_invoking_user_returns_none_when_sudo_user_is_root():
+    # Direct root login (no SUDO_USER set, or SUDO_USER=root) → don't try to
+    # add root to its own group; nothing meaningful to do.
+    with patch.dict("os.environ", {"SUDO_USER": "root"}, clear=False):
+        assert _invoking_user() is None

--- a/cli/tests/unit/test_autodetect_probe.py
+++ b/cli/tests/unit/test_autodetect_probe.py
@@ -67,6 +67,56 @@ def test_probe_exception_does_not_crash():
     assert result == []
 
 
+def test_permission_error_surfaces_to_warnings(capsys):
+    """PermissionError on /dev/ttyACM* must NOT be silently swallowed.
+    Caught on Bob during Spec B Phase E T22 cold install; tracked at #82."""
+    devices = [_tty("/dev/ttyACM0")]
+    warnings: list[str] = []
+    with patch(
+        "robot_md.bus_scan.scan_feetech",
+        side_effect=PermissionError(13, "Permission denied", "/dev/ttyACM0"),
+    ):
+        result = _probe_servo_buses(devices, warnings=warnings)
+
+    assert result == []
+    assert len(warnings) == 1
+    assert "/dev/ttyACM0" in warnings[0]
+    assert "robot-md-gateway" in warnings[0]
+    assert "usermod" in warnings[0]
+    captured = capsys.readouterr()
+    assert "/dev/ttyACM0" in captured.err
+    assert "usermod" in captured.err
+
+
+def test_permission_error_without_warnings_list_still_prints(capsys):
+    """Backward compat: legacy callers without a warnings list still get
+    the stderr remediation hint so the message cannot be lost."""
+    devices = [_tty("/dev/ttyACM0")]
+    with patch(
+        "robot_md.bus_scan.scan_feetech",
+        side_effect=PermissionError(13, "Permission denied", "/dev/ttyACM0"),
+    ):
+        result = _probe_servo_buses(devices)
+    assert result == []
+    captured = capsys.readouterr()
+    assert "/dev/ttyACM0" in captured.err
+
+
+def test_generic_exception_still_silent(capsys):
+    """Non-PermissionError exceptions remain silent — not operator-actionable."""
+    devices = [_tty("/dev/ttyACM0")]
+    warnings: list[str] = []
+    with patch(
+        "robot_md.bus_scan.scan_feetech",
+        side_effect=RuntimeError("scservo_sdk not installed"),
+    ):
+        result = _probe_servo_buses(devices, warnings=warnings)
+    assert result == []
+    assert warnings == []
+    captured = capsys.readouterr()
+    assert captured.err == ""
+
+
 def test_env_var_skip_disables_probe():
     devices = [_tty("/dev/ttyACM0")]
     with (

--- a/cli/tests/unit/test_init_phase_write_manifest.py
+++ b/cli/tests/unit/test_init_phase_write_manifest.py
@@ -98,3 +98,92 @@ def test_unknown_preset_returns_failed(tmp_path):
     assert result.status == "failed"
     assert "not found" in result.message.lower() or "nonexistent" in result.message
     assert not out.exists()
+
+
+def _existing_manifest_with_rrn(
+    path, *, rrn: str = "RRN-000000000010", record_url: str | None = None
+) -> None:
+    """Write a minimal valid ROBOT.md with metadata.rrn (+ optionally
+    record_url) so phase_write_manifest's carry-forward path has something
+    to read."""
+    record_line = f"  record_url: {record_url}\n" if record_url else ""
+    text = (
+        "---\n"
+        "rcan_version: '3.0'\n"
+        "schema: https://robotmd.dev/schema/v1/robot.schema.json\n"
+        "metadata:\n"
+        "  robot_name: bob\n"
+        "  manufacturer: bob\n"
+        "  model: SO-ARM101 follower\n"
+        "  version: '1.0'\n"
+        "  device_id: bob\n"
+        f"  rrn: {rrn}\n"
+        f"{record_line}"
+        "  license: Apache-2.0\n"
+        "drivers: []\n"
+        "---\n\n# bob\n"
+    )
+    path.write_text(text)
+
+
+def test_force_overwrite_preserves_metadata_rrn(tmp_path):
+    """init --force regenerates the manifest from scratch. The fresh
+    frontmatter merger has no knowledge of an already-minted RRN — without
+    this carry-forward, the operator silently loses the link between the
+    new manifest and `~/.robot-md/keys/<rrn>.signing.json`. Tracked at #82."""
+    from robot_md.init_phases import phase_write_manifest
+
+    out = tmp_path / "ROBOT.md"
+    _existing_manifest_with_rrn(
+        out,
+        rrn="RRN-000000000010",
+        record_url="https://rcan.dev/r/RRN-000000000010",
+    )
+
+    result = phase_write_manifest(
+        out_path=out,
+        robot_name="bob",
+        preset_name="so-arm101",
+        scan=_fake_so_arm101_scan(),
+        force=True,
+    )
+
+    assert result.status == "ok"
+    text = out.read_text()
+    assert "RRN-000000000010" in text, "rrn must be carried forward on --force"
+    assert "https://rcan.dev/r/RRN-000000000010" in text
+    assert sorted(result.detail["carried_forward"]) == ["record_url", "rrn"]
+
+
+def test_force_overwrite_carries_nothing_when_existing_lacks_rrn(tmp_path):
+    """No rrn to carry forward → fresh manifest has the standard empty
+    rrn placeholder; carried_forward detail is empty."""
+    from robot_md.init_phases import phase_write_manifest
+
+    out = tmp_path / "ROBOT.md"
+    _existing_manifest_with_rrn(out, rrn="")  # explicit empty
+    result = phase_write_manifest(
+        out_path=out,
+        robot_name="bob",
+        preset_name="so-arm101",
+        scan=_fake_so_arm101_scan(),
+        force=True,
+    )
+    assert result.status == "ok"
+    assert result.detail["carried_forward"] == []
+
+
+def test_no_force_no_carry(tmp_path):
+    """When out_path doesn't exist, there's nothing to carry forward."""
+    from robot_md.init_phases import phase_write_manifest
+
+    out = tmp_path / "ROBOT.md"  # does not exist
+    result = phase_write_manifest(
+        out_path=out,
+        robot_name="bob",
+        preset_name="so-arm101",
+        scan=_fake_so_arm101_scan(),
+        force=False,
+    )
+    assert result.status == "ok"
+    assert result.detail["carried_forward"] == []


### PR DESCRIPTION
## Summary

Three remediations from #82, all caught during Bob T22 cold-install prep (2026-05-11):

1. **install-gateway adds `$SUDO_USER` to robot-md-gateway group** — so `robot-md init` can read `/dev/ttyACM*` for serial-bus auto-discovery on the next session. `--no-add-user` opts out for locked-down service hosts.
2. **init no longer silently swallows `PermissionError`** — `_probe_servo_buses` surfaces a stderr warning + appends to `scan.warnings` with the exact `usermod` remediation. `scan_feetech` re-raises `PermissionError` unchanged.
3. **`init --force` preserves `metadata.rrn` + `metadata.record_url`** — reads existing manifest frontmatter before regenerating; carries the two registration-identity fields forward so the signing keypair isn't orphaned.

## Why

Without these, `pip install robot-md && robot-md install-gateway && robot-md init <name>` on a fresh host produces:
- gateway installed correctly, but
- operator's user not in `robot-md-gateway` group → `/dev/ttyACM*` is unreadable → 
- `robot-md init`'s serial probe gets PermissionError → silently swallowed →
- manifest renders with `preset: minimal`, `physics.type: sensor`, `dof: 0`, **no arm capabilities**

Operator only catches this by inspecting the rendered manifest; trial fails to start with "no `arm.pick` capability." That happened on Bob T22 today; documented at `feedback_cold_install_silent_perm_failure.md` + this PR closes the upstream UX gap so the next cold install doesn't hit the same wall.

## Test plan

- [x] 25 unit tests pass (3 new for `_invoking_user`, 3 new for PermissionError surfacing, 3 new for force-carry-forward; existing 16 still pass).
- [ ] CI green on this PR.
- [ ] After merge: tag `v1.10.3`; confirm `pypi-publish` job ships robot-md==1.10.3 to PyPI (now tag-driven per #81).
- [ ] Bob redo: `robot-md install-gateway` adds user to group → `newgrp` → `robot-md init <name>` succeeds first try with `physics.type: arm` and full capability set.

Closes #82.

🤖 Generated with [Claude Code](https://claude.com/claude-code)