### PR TITLE
fix(install-gateway): add perceive to default ROBOT_MD_TOOL_ALLOWLIST

### DIFF
--- a/cli/src/robot_md/install_gateway.py
+++ b/cli/src/robot_md/install_gateway.py
@@ -63,7 +63,7 @@ def render_env_file(*, manifest_path: str) -> str:
 ROBOT_MD_PATH={manifest_path}
 ROBOT_MD_BEARERS_FILE=/etc/robot-md-gateway/bearers.yaml
 ROBOT_MD_LOG_LEVEL=INFO
-ROBOT_MD_TOOL_ALLOWLIST=mcp__robot__execute_capability,mcp__robot__render,mcp__robot__validate,move,home,read_state
+ROBOT_MD_TOOL_ALLOWLIST=mcp__robot__execute_capability,mcp__robot__render,mcp__robot__validate,move,home,read_state,perceive
 ROBOT_MD_REQUIRE_ENVELOPE_SIGNATURE=1
 """
 


### PR DESCRIPTION
Closes #85.

## Summary

- Add `perceive` to the default `ROBOT_MD_TOOL_ALLOWLIST` rendered by `install-gateway` into `/etc/robot-md-gateway/gateway.env`.

## Why

The Spec B trial flow (`robot-md trial iteration --capture-pre`) calls `_gateway_invoke("oak-d", "perceive", ...)` to snapshot red_blob / bowl_top pre-state via the camera actuator. Without `perceive` on the allowlist, the trial's first hardware call 403s on tool-allowlist after passing envelope auth, which blocks PICK-PLACE-10 cert minting end-to-end. Discovered during T22 v3 cold install (memory: `project_spec_b_phase_e_t22_prep_v3_2026_05_11`).

## Test plan

- [x] `pytest tests/test_install_gateway.py tests/test_install_gateway_integration.py tests/test_cli_install_gateway.py` — 12 passed
- [ ] Bob: on next `install-gateway` (or manual gateway.env edit + service restart), trial `perceive` invokes pass the allowlist gate