### PR TITLE
fix(register): auto-bind robot pq_kid as operator-envelope authority

### DIFF
--- a/cli/src/robot_md/register.py
+++ b/cli/src/robot_md/register.py
@@ -42,6 +42,7 @@ from robot_md.ruri import construct_ruri
 from robot_md.signing import generate_keypair, save_keypair, sign_body
 
 DEFAULT_ENDPOINT = "https://robotregistryfoundation.org/v2/robots/register"
+DEFAULT_AUTHORITIES_ENDPOINT = "https://robotregistryfoundation.org/v2/authorities/register"
 
 
 def _keystore_dir() -> Path:
@@ -409,6 +410,67 @@ def post_to_rrf(endpoint: str, body: dict[str, Any], *, timeout: float = 15.0) -
     )
 
 
+def post_envelope_authority(
+    endpoint: str, body: dict[str, Any], *, timeout: float = 15.0
+) -> dict[str, Any]:
+    """POST a signed authority body to /v2/authorities/register and return the
+    parsed response. Raises :class:`RuntimeError` on network or non-2xx.
+    """
+    data = json.dumps(body).encode("utf-8")
+    req = urllib.request.Request(
+        endpoint,
+        data=data,
+        method="POST",
+        headers={
+            "Content-Type": "application/json",
+            "Accept": "application/json",
+            "User-Agent": "robot-md-cli/0.1 (+https://robotmd.dev)",
+        },
+    )
+    try:
+        with urllib.request.urlopen(req, timeout=timeout) as resp:
+            text = resp.read().decode("utf-8")
+    except urllib.error.HTTPError as e:
+        err_text = e.read().decode("utf-8", errors="replace") if hasattr(e, "read") else str(e)
+        raise RuntimeError(
+            f"authorities/register returned {e.code}: {err_text.strip()[:500]}"
+        ) from e
+    except urllib.error.URLError as e:
+        raise RuntimeError(f"could not reach {endpoint}: {e.reason}") from e
+    try:
+        return json.loads(text)
+    except json.JSONDecodeError as e:
+        raise RuntimeError(f"authorities/register returned non-JSON: {text[:200]}") from e
+
+
+def _register_envelope_authority(
+    rrn: str,
+    kp: Any,
+    meta: dict[str, Any],
+    *,
+    authorities_endpoint: str = DEFAULT_AUTHORITIES_ENDPOINT,
+) -> dict[str, Any]:
+    """Bind the robot's pq_kid to an ``operator-envelope`` authority so the
+    gateway's ``/v2/keys/{pq_kid}`` resolver can find an Ed25519 PEM for it.
+
+    Without this step ``robot-md-gateway`` returns 403 on every
+    envelope-signed invoke after a fresh mint (closes #84). Mirrors the
+    manual ``scripts/register-operator-kid.ts`` flow, but signed by the
+    robot's own keypair via the public ``POST /v2/authorities/register``
+    endpoint — no admin auth or bulk-put needed.
+    """
+    ed_pub_b64 = base64.b64encode(kp.ed25519_pub).decode()
+    base_body: dict[str, Any] = {
+        "organization": str(meta.get("manufacturer") or meta.get("robot_name") or rrn),
+        "display_name": f"{meta.get('robot_name') or rrn} — envelope signer",
+        "purpose": "operator-envelope",
+        "signing_pub": ed_pub_b64,
+        "signing_alg": ["Ed25519", "ML-DSA-65"],
+    }
+    signed = sign_body(kp, base_body)
+    return post_envelope_authority(authorities_endpoint, signed)
+
+
 def write_rrn_to_manifest(manifest_path: Path, rrn: str, record_url: str) -> None:
     """Rewrite metadata.rrn and metadata.rcan_uri in the manifest.
 
@@ -552,6 +614,29 @@ def cli_register(
     api_key = result.raw.get("api_key")
     if api_key:
         _write_apikey(result.rrn, api_key)
+
+    # 4.5. Bind pq_kid → operator-envelope authority so the gateway's
+    # /v2/keys/<pq_kid> resolver can verify envelope signatures from this
+    # robot. Non-fatal: if the authorities POST fails, the manifest is
+    # still valid and the operator can re-publish later (closes #84).
+    authorities_endpoint = endpoint.replace("/robots/register", "/authorities/register")
+    try:
+        post_envelope_authority(
+            authorities_endpoint, sign_body(kp, {
+                "organization": str(meta.get("manufacturer") or meta.get("robot_name") or result.rrn),
+                "display_name": f"{meta.get('robot_name') or result.rrn} — envelope signer",
+                "purpose": "operator-envelope",
+                "signing_pub": base64.b64encode(kp.ed25519_pub).decode(),
+                "signing_alg": ["Ed25519", "ML-DSA-65"],
+            }),
+        )
+    except RuntimeError as e:
+        print(
+            f"  warning: could not register envelope-authority kid for {result.rrn}: {e}\n"
+            f"  gateway envelope verification will 404 until this is retried "
+            f"(re-run `robot-md register` won't help — manifest already has an RRN).",
+            file=sys.stderr,
+        )
 
     # 5. Write RRN back into manifest.
     try:

--- a/cli/src/robot_md/register.py
+++ b/cli/src/robot_md/register.py
@@ -620,11 +620,13 @@ def cli_register(
     # robot. Non-fatal: if the authorities POST fails, the manifest is
     # still valid and the operator can re-publish later (closes #84).
     authorities_endpoint = endpoint.replace("/robots/register", "/authorities/register")
+    org = str(meta.get("manufacturer") or meta.get("robot_name") or result.rrn)
+    display_name = f"{meta.get('robot_name') or result.rrn} — envelope signer"
     try:
         post_envelope_authority(
             authorities_endpoint, sign_body(kp, {
-                "organization": str(meta.get("manufacturer") or meta.get("robot_name") or result.rrn),
-                "display_name": f"{meta.get('robot_name') or result.rrn} — envelope signer",
+                "organization": org,
+                "display_name": display_name,
                 "purpose": "operator-envelope",
                 "signing_pub": base64.b64encode(kp.ed25519_pub).decode(),
                 "signing_alg": ["Ed25519", "ML-DSA-65"],

--- a/cli/src/robot_md/register.py
+++ b/cli/src/robot_md/register.py
@@ -624,13 +624,17 @@ def cli_register(
     display_name = f"{meta.get('robot_name') or result.rrn} — envelope signer"
     try:
         post_envelope_authority(
-            authorities_endpoint, sign_body(kp, {
-                "organization": org,
-                "display_name": display_name,
-                "purpose": "operator-envelope",
-                "signing_pub": base64.b64encode(kp.ed25519_pub).decode(),
-                "signing_alg": ["Ed25519", "ML-DSA-65"],
-            }),
+            authorities_endpoint,
+            sign_body(
+                kp,
+                {
+                    "organization": org,
+                    "display_name": display_name,
+                    "purpose": "operator-envelope",
+                    "signing_pub": base64.b64encode(kp.ed25519_pub).decode(),
+                    "signing_alg": ["Ed25519", "ML-DSA-65"],
+                },
+            ),
         )
     except RuntimeError as e:
         print(

--- a/cli/tests/test_register.py
+++ b/cli/tests/test_register.py
@@ -260,8 +260,16 @@ def test_cli_register_publishes_envelope_authority_after_mint(tmp_path, monkeypa
     assert captured["authority_endpoint"].endswith("/v2/authorities/register")
     auth = captured["authority"]
     # All 8 required fields per RRF functions/v2/authorities/register.ts
-    for key in ("organization", "display_name", "purpose", "signing_pub",
-                "pq_signing_pub", "pq_kid", "signing_alg", "sig"):
+    for key in (
+        "organization",
+        "display_name",
+        "purpose",
+        "signing_pub",
+        "pq_signing_pub",
+        "pq_kid",
+        "signing_alg",
+        "sig",
+    ):
         assert key in auth, f"missing required field: {key}"
     assert auth["purpose"] == "operator-envelope"
     assert auth["signing_alg"] == ["Ed25519", "ML-DSA-65"]

--- a/cli/tests/test_register.py
+++ b/cli/tests/test_register.py
@@ -243,7 +243,11 @@ def test_cli_register_publishes_envelope_authority_after_mint(tmp_path, monkeypa
     def fake_authority_post(endpoint, body, timeout=15.0):
         captured["authority_endpoint"] = endpoint
         captured["authority"] = body
-        return {"ran": "RAN-000000000042", "status": "active", "registered_at": "2026-05-11T21:00:01Z"}
+        return {
+            "ran": "RAN-000000000042",
+            "status": "active",
+            "registered_at": "2026-05-11T21:00:01Z",
+        }
 
     with (
         patch("robot_md.register.post_to_rrf", fake_post),

--- a/cli/tests/test_register.py
+++ b/cli/tests/test_register.py
@@ -217,6 +217,87 @@ def test_cli_register_saves_keypair_after_success(tmp_path, monkeypatch):
     assert apikey_path.exists()
 
 
+# ---- envelope-authority auto-registration (closes #84) ------------------
+
+
+def test_cli_register_publishes_envelope_authority_after_mint(tmp_path, monkeypatch):
+    """After a successful robot mint, register also POSTs to
+    /v2/authorities/register so the robot's pq_kid resolves at /v2/keys/{kid}.
+    Without this step gateway envelope auth 403s on first invoke."""
+    monkeypatch.setenv("HOME", str(tmp_path))
+    path = _write(tmp_path)
+
+    captured: dict[str, dict] = {}
+
+    def fake_post(endpoint, body, timeout=15.0):
+        from robot_md.register import MintResult
+
+        captured["mint"] = body
+        return MintResult(
+            rrn="RRN-000000000099",
+            registered_at="2026-05-11T21:00:00Z",
+            record_url="https://robotregistryfoundation.org/v2/robots/RRN-000000000099",
+            raw={"rrn": "RRN-000000000099", "api_key": "secret-xyz"},
+        )
+
+    def fake_authority_post(endpoint, body, timeout=15.0):
+        captured["authority_endpoint"] = endpoint
+        captured["authority"] = body
+        return {"ran": "RAN-000000000042", "status": "active", "registered_at": "2026-05-11T21:00:01Z"}
+
+    with (
+        patch("robot_md.register.post_to_rrf", fake_post),
+        patch("robot_md.register.post_envelope_authority", fake_authority_post),
+    ):
+        rc = cli_register(path, endpoint=DEFAULT_ENDPOINT)
+
+    assert rc == 0
+    # The authority POST went to the authorities/register endpoint
+    assert captured["authority_endpoint"].endswith("/v2/authorities/register")
+    auth = captured["authority"]
+    # All 8 required fields per RRF functions/v2/authorities/register.ts
+    for key in ("organization", "display_name", "purpose", "signing_pub",
+                "pq_signing_pub", "pq_kid", "signing_alg", "sig"):
+        assert key in auth, f"missing required field: {key}"
+    assert auth["purpose"] == "operator-envelope"
+    assert auth["signing_alg"] == ["Ed25519", "ML-DSA-65"]
+    # sig.ed25519_pub must equal signing_pub (RRF rejects otherwise)
+    assert auth["sig"]["ed25519_pub"] == auth["signing_pub"]
+    assert set(auth["sig"].keys()) == {"ml_dsa", "ed25519", "ed25519_pub"}
+    # pq_kid in the authority body matches the one minted on the robot record
+    assert auth["pq_kid"] == captured["mint"]["pq_kid"]
+    # Body self-verifies via the same primitive RRF uses (rcan-ts verifyBody)
+    assert verify_body(auth) is True
+
+
+def test_cli_register_succeeds_when_envelope_authority_post_fails(tmp_path, monkeypatch, capsys):
+    """If the authority POST fails (network error, RRF down, etc.), register
+    must still return 0 — the manifest already has a valid RRN. A warning is
+    printed; operator can re-publish via a later command."""
+    monkeypatch.setenv("HOME", str(tmp_path))
+    path = _write(tmp_path)
+
+    def fake_post(endpoint, body, timeout=15.0):
+        from robot_md.register import MintResult
+
+        return MintResult(
+            rrn="RRN-000000000099", registered_at="x", record_url="u", raw={"api_key": "k"}
+        )
+
+    def fake_authority_post_fails(endpoint, body, timeout=15.0):
+        raise RuntimeError("authorities/register returned 503: backend unavailable")
+
+    with (
+        patch("robot_md.register.post_to_rrf", fake_post),
+        patch("robot_md.register.post_envelope_authority", fake_authority_post_fails),
+    ):
+        rc = cli_register(path, endpoint=DEFAULT_ENDPOINT)
+
+    assert rc == 0
+    err = capsys.readouterr().err
+    assert "envelope" in err.lower() or "authority" in err.lower()
+
+
 def test_cli_register_already_registered_raises(tmp_path, monkeypatch):
     """Running register on a manifest that already has metadata.rrn is an error
     in v0.9.1 — rotation is a later release."""


### PR DESCRIPTION
Closes #84.

## Summary

After `robot-md register` (and `init --register`) mints an RRN, also POST to `/v2/authorities/register` with `purpose: operator-envelope`, signed by the robot's own keypair. Without this step the robot's `pq_kid` is not resolvable at `/v2/keys/{pq_kid}` — `robot-md-gateway`'s `RRFResolverFromEnv.resolve_public_key_pem(kid)` gets 404 and rejects every envelope-signed invoke with `403 kid <pq_kid> not registered`.

## Why this works (no RRF changes needed)

The `/v2/authorities/register` endpoint already supports `purpose: operator-envelope` (see `RobotRegistryFoundation/RobotRegistryFoundation functions/v2/authorities/register.ts:27` + `scripts/register-operator-kid.ts` for the manual flow that today registers operator kids like `bob-operator-2026`). It's just been a missing client-side step.

The fix mirrors that script's KV shape — `kid:<pq_kid>:<ts>` → `authority:<ran>` — but driven by the **public** signed-POST endpoint so no admin auth or bulk-put is required.

## What changed

- `register.py`:
  - `DEFAULT_AUTHORITIES_ENDPOINT` constant
  - `post_envelope_authority()` — POST wrapper for `/v2/authorities/register`
  - `_register_envelope_authority()` — builds + signs the authority body via existing `sign_body(kp, ...)`
  - Wire into `cli_register()` between `save_keypair` and `write_rrn_to_manifest`
  - **Non-fatal on failure**: prints a warning, register still returns 0 (manifest already has a valid RRN; operator can re-publish later)
- `test_register.py`:
  - `test_cli_register_publishes_envelope_authority_after_mint` — asserts correct body shape, `sig.ed25519_pub == signing_pub`, body self-verifies
  - `test_cli_register_succeeds_when_envelope_authority_post_fails` — graceful degradation

## Test plan

- [x] `pytest tests/test_register.py` — 25 passed (2 new + 23 existing)
- [x] Body shape matches `functions/v2/authorities/register.ts` 8 required fields
- [ ] Bob: cold install with this build → `curl /v2/keys/<pq_kid>` returns 200 (T22 v4 verification)

## Sibling fix in the same investigation

- robot-md#85 — `install-gateway` allowlist missing `perceive` (merged as #86)
- ~~robot-md-gateway#20~~ — closed as false alarm (`pip index versions` unreliable on piwheels)