### PR TITLE
feat(register): --export-to flag for subagent-HOME credential capture (closes #79)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,29 @@ Format follows [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 
 ---
 
+## [1.10.5] - 2026-05-25
+
+### Added
+
+- **`register --export-to <path>`.** Writes copies of the minted
+  `<rrn>.signing.json` and `<rrn>.apikey` to a caller-supplied directory
+  in addition to `~/.robot-md/keys/`. Lets a subagent harness with an
+  isolated `HOME` persist credentials to the caller's filesystem before
+  teardown — the structural fix for the silent operator/RRF drift caught
+  during Spec B Phase E orientation (closes #79).
+
+  Files preserve their canonical names (`<rrn>.signing.json`,
+  `<rrn>.apikey`) so the natural restore path is `cp <export-dir>/* ~/.robot-md/keys/`.
+  Atomic write + mode 0o600, matching the in-place writers.
+
+  Fails loud (exit 4) if the export write fails after the RRF mint
+  succeeded: prints a recovery message naming the minted RRN and the
+  HOME path. Silently swallowing the failure would re-introduce the
+  drift bug. With `--dry-run`, surfaces a warning and skips the export
+  (nothing was minted).
+
+---
+
 ## [1.10.4] - 2026-05-11
 
 ### Fixed

--- a/cli/pyproject.toml
+++ b/cli/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "hatchling.build"
 
 [project]
 name = "robot-md"
-version = "1.10.4"
+version = "1.10.5"
 description = "ROBOT.md — a single self-describing file so Claude can safely operate your robot."
 readme = "../README.md"
 requires-python = ">=3.10"

--- a/cli/src/robot_md/__main__.py
+++ b/cli/src/robot_md/__main__.py
@@ -351,6 +351,13 @@ def register(
     firmware_version: str | None = typer.Option(None, "--firmware-version"),
     rcan_version: str | None = typer.Option(None, "--rcan-version"),
     dry_run: bool = typer.Option(False, "--dry-run", help="Sign + print body, don't POST."),
+    export_to: Path | None = typer.Option(
+        None,
+        "--export-to",
+        help="Also write the minted <rrn>.signing.json and <rrn>.apikey to this "
+        "directory (in addition to ~/.robot-md/keys/). Lets a subagent harness "
+        "with an isolated HOME persist credentials before teardown.",
+    ),
 ) -> None:
     """Mint an RRN on Robot Registry Foundation with signed POST (RCAN 3.0).
 
@@ -370,6 +377,7 @@ def register(
         firmware_version=firmware_version,
         rcan_version=rcan_version,
         dry_run=dry_run,
+        export_to=export_to,
     )
     if rc != 0:
         raise typer.Exit(code=rc)

--- a/cli/src/robot_md/register.py
+++ b/cli/src/robot_md/register.py
@@ -587,8 +587,7 @@ def cli_register(
 
     if dry_run and export_to is not None:
         print(
-            "warning: --export-to has no effect under --dry-run "
-            "(no credentials will be minted).",
+            "warning: --export-to has no effect under --dry-run (no credentials will be minted).",
             file=sys.stderr,
         )
 

--- a/cli/src/robot_md/register.py
+++ b/cli/src/robot_md/register.py
@@ -532,6 +532,34 @@ def _write_apikey(rrn: str, api_key: str) -> Path:
     return path
 
 
+def _export_credentials(export_dir: Path, rrn: str) -> None:
+    """Copy the just-written keypair + apikey from $HOME's keystore into
+    ``export_dir`` (mode 0o700) using the same atomic-write discipline as
+    the in-place writers. Filenames are preserved so the operator can
+    ``cp export_dir/* ~/.robot-md/keys/`` verbatim to restore.
+
+    Raises ``OSError`` (or subclass) on any failure — caller decides what
+    to surface to the operator.
+    """
+    export_dir.mkdir(parents=True, exist_ok=True)
+    with suppress(OSError):
+        os.chmod(export_dir, 0o700)
+    keystore = _keystore_dir()
+    for filename in (f"{rrn}.signing.json", f"{rrn}.apikey"):
+        src = keystore / filename
+        if not src.exists():
+            # apikey may legitimately be missing if RRF returned no api_key
+            # in raw (older deployments); the signing.json must always exist.
+            if filename.endswith(".apikey"):
+                continue
+            raise FileNotFoundError(f"expected {src} after mint, not found")
+        dst = export_dir / filename
+        tmp = dst.with_suffix(dst.suffix + ".tmp")
+        tmp.write_bytes(src.read_bytes())
+        os.chmod(tmp, 0o600)
+        tmp.replace(dst)
+
+
 def cli_register(
     manifest_path: Path | str,
     *,
@@ -542,12 +570,27 @@ def cli_register(
     firmware_version: str | None = None,
     rcan_version: str | None = None,
     dry_run: bool = False,
+    export_to: Path | str | None = None,
 ) -> int:
-    """Register a ROBOT.md with RRF, signing the POST body (v0.9.1)."""
+    """Register a ROBOT.md with RRF, signing the POST body (v0.9.1).
+
+    When ``export_to`` is set, copies of the minted ``<rrn>.signing.json``
+    and ``<rrn>.apikey`` are written to that directory in addition to the
+    normal ``$HOME/.robot-md/keys/`` write. Lets a subagent harness with
+    isolated ``HOME`` persist credentials to the caller's filesystem
+    before teardown (closes robot-md#79).
+    """
     path = Path(manifest_path)
     if not path.exists():
         print(f"error: {path} does not exist", file=sys.stderr)
         return 2
+
+    if dry_run and export_to is not None:
+        print(
+            "warning: --export-to has no effect under --dry-run "
+            "(no credentials will be minted).",
+            file=sys.stderr,
+        )
 
     parsed = parse_file(path)
     meta = parsed.frontmatter.get("metadata") or {}
@@ -614,6 +657,26 @@ def cli_register(
     api_key = result.raw.get("api_key")
     if api_key:
         _write_apikey(result.rrn, api_key)
+
+    # 4.25. If --export-to set, copy the minted material to the caller's
+    # filesystem (outside any subagent-isolated $HOME). Fail loud on error:
+    # the RRN is already minted on RRF, so a silent fallback would re-create
+    # the original drift bug (closes #79).
+    if export_to is not None:
+        export_dir = Path(export_to)
+        try:
+            _export_credentials(export_dir, result.rrn)
+        except OSError as e:
+            home_keys = _keystore_dir() / f"{result.rrn}.*"
+            print(
+                f"error: --export-to write failed: {e}\n"
+                f"  Credentials WERE minted on RRF (RRN={result.rrn}).\n"
+                f"  Recover from {home_keys} inside the subagent before it\n"
+                f"  terminates, or revoke {result.rrn} on RRF.",
+                file=sys.stderr,
+            )
+            return 4
+        print(f"  Exported keypair + apikey to {export_dir}", file=sys.stderr)
 
     # 4.5. Bind pq_kid → operator-envelope authority so the gateway's
     # /v2/keys/<pq_kid> resolver can verify envelope signatures from this

--- a/cli/tests/test_register.py
+++ b/cli/tests/test_register.py
@@ -623,3 +623,116 @@ def test_cli_register_proceeds_silently_when_preflight_fails(tmp_path, monkeypat
     assert rc == 0
     # No "Next RRN:" line should have been printed.
     assert "Next RRN:" not in capsys.readouterr().err
+
+
+# ---- --export-to (closes #79) -------------------------------------------
+
+
+def test_cli_register_export_to_copies_keypair_and_apikey(tmp_path, monkeypatch, capsys):
+    """When export_to is set, register writes copies of the minted keypair
+    and apikey to that directory in addition to the normal $HOME write.
+    Lets a subagent harness with isolated HOME persist credentials to the
+    caller's filesystem before teardown (closes robot-md#79).
+    """
+    monkeypatch.setenv("HOME", str(tmp_path / "isolated"))
+    path = _write(tmp_path)
+    export_dir = tmp_path / "operator-keys"
+
+    def fake_post(endpoint, body, timeout=15.0):
+        from robot_md.register import MintResult
+
+        return MintResult(
+            rrn="RRN-000000000099", registered_at="x", record_url="u", raw={"api_key": "k"}
+        )
+
+    with (
+        patch("robot_md.register.peek_next_rrn", lambda *_a, **_kw: None),
+        patch("robot_md.register.post_to_rrf", fake_post),
+        patch("robot_md.register.post_envelope_authority", lambda *_a, **_kw: {}),
+    ):
+        rc = cli_register(path, endpoint=DEFAULT_ENDPOINT, export_to=export_dir)
+
+    assert rc == 0
+
+    # HOME copies still exist (normal behavior unchanged).
+    home_keys = tmp_path / "isolated" / ".robot-md" / "keys"
+    assert (home_keys / "RRN-000000000099.signing.json").exists()
+    assert (home_keys / "RRN-000000000099.apikey").exists()
+
+    # Export copies exist with same filenames so `cp export/* ~/.robot-md/keys/`
+    # is the natural restore path.
+    exported_signing = export_dir / "RRN-000000000099.signing.json"
+    exported_apikey = export_dir / "RRN-000000000099.apikey"
+    assert exported_signing.exists()
+    assert exported_apikey.exists()
+
+    # Content matches between HOME and exported copies.
+    assert exported_signing.read_text() == (home_keys / "RRN-000000000099.signing.json").read_text()
+    assert exported_apikey.read_text() == (home_keys / "RRN-000000000099.apikey").read_text()
+
+    # Exported files are mode 0o600 (private — same as HOME copies).
+    import stat as _stat
+
+    assert _stat.S_IMODE(exported_signing.stat().st_mode) == 0o600
+    assert _stat.S_IMODE(exported_apikey.stat().st_mode) == 0o600
+
+    # Operator sees a single confirmation line on stderr.
+    err = capsys.readouterr().err
+    assert "Exported keypair + apikey to" in err
+    assert str(export_dir) in err
+
+
+def test_cli_register_export_to_fails_loud_when_path_unwritable(tmp_path, monkeypatch, capsys):
+    """If the --export-to write fails after RRF mint succeeded, return
+    non-zero with a recovery message that names the minted RRN and the HOME
+    path. Silent fallback would re-introduce the original drift bug.
+    """
+    monkeypatch.setenv("HOME", str(tmp_path / "isolated"))
+    path = _write(tmp_path)
+
+    # Parent of export_to is a regular file → mkdir(parents=True) will fail
+    # with NotADirectoryError. Robust across uid (chmod-based blocking can
+    # be bypassed by root in CI).
+    blocker = tmp_path / "blocker"
+    blocker.write_text("not a directory")
+    export_dir = blocker / "sub"
+
+    def fake_post(endpoint, body, timeout=15.0):
+        from robot_md.register import MintResult
+
+        return MintResult(
+            rrn="RRN-000000000099", registered_at="x", record_url="u", raw={"api_key": "k"}
+        )
+
+    with (
+        patch("robot_md.register.peek_next_rrn", lambda *_a, **_kw: None),
+        patch("robot_md.register.post_to_rrf", fake_post),
+    ):
+        rc = cli_register(path, endpoint=DEFAULT_ENDPOINT, export_to=export_dir)
+
+    assert rc != 0
+    err = capsys.readouterr().err
+    # Recovery message must surface enough for the operator to act.
+    assert "RRN-000000000099" in err
+    assert "--export-to" in err
+    # The HOME path is named so the operator can recover from inside the
+    # subagent before teardown.
+    assert ".robot-md/keys" in err
+
+
+def test_cli_register_dry_run_warns_when_export_to_set(tmp_path, monkeypatch, capsys):
+    """--dry-run returns before any persistence. If --export-to is also
+    set, warn explicitly so the harness author knows nothing will be
+    written.
+    """
+    monkeypatch.setenv("HOME", str(tmp_path / "isolated"))
+    path = _write(tmp_path)
+    export_dir = tmp_path / "operator-keys"
+
+    rc = cli_register(path, endpoint=DEFAULT_ENDPOINT, dry_run=True, export_to=export_dir)
+
+    assert rc == 0
+    err = capsys.readouterr().err
+    assert "--export-to" in err and "--dry-run" in err
+    # Nothing was actually exported.
+    assert not export_dir.exists()


### PR DESCRIPTION
## Summary

- Adds `robot-md register --export-to <path>` — writes copies of the minted `<rrn>.signing.json` and `<rrn>.apikey` to a caller-supplied directory in addition to `~/.robot-md/keys/`.
- Structural fix for the operator/RRF silent-drift bug filed as #79 from Spec B Phase E orientation. Mitigation that was already shipped: opencastor-ops PR #36 added §12.1 to the Spec A spec + `scripts/audit_orphan_rrns.py` + harness migration. This PR is the robot-md-side piece that lets a subagent harness with isolated `$HOME` persist credentials before teardown.
- Implements **Option A** from the issue body (deferred Options B/C — operational mitigation C is already in §12.1; B is defense-in-depth that doesn't actually fix the drift).
- Bumps to **1.10.5**.

## Design notes

- Wired in `cli_register`, **not** in `save_keypair` / `_write_apikey`. The keystore writers' contracts stay narrow; the export concern is isolated to the one call site that has the context.
- Atomic write + `chmod 0o600` via tmp-then-replace, matching the existing in-place writers exactly. Filenames preserved so the natural restore path is `cp <export-dir>/* ~/.robot-md/keys/`.
- **Fails loud (exit 4)** if the export write fails after the RRF mint succeeded. The recovery message names the minted RRN and the HOME path. Silently swallowing the failure would re-introduce the original drift.
- `--dry-run` + `--export-to` surfaces a warning at the top of `cli_register` and skips export (nothing was minted).

## Tests added (`cli/tests/test_register.py`)

1. `test_cli_register_export_to_copies_keypair_and_apikey` — happy path: both files exist at export dir AND at `$HOME`, contents match, modes are 0o600, single confirmation line on stderr.
2. `test_cli_register_export_to_fails_loud_when_path_unwritable` — uses a "parent is a regular file" blocker (robust under root in CI) and asserts non-zero exit + recovery message naming the RRN.
3. `test_cli_register_dry_run_warns_when_export_to_set` — warns to stderr, exports nothing.

## Test plan

- [ ] `cd cli && pytest tests/test_register.py -k "export_to or dry_run_warns"` — 3 new tests green
- [ ] `pytest tests/ --ignore=tests/test_register.py` — full sweep clean (1448 passed locally on Pi 5, 19 skipped hardware/platform, 1 xfailed pre-existing)
- [ ] `robot-md register --help` shows the new `--export-to PATH` row
- [ ] Manually verify with a throwaway endpoint: `robot-md register some.ROBOT.md --dry-run --export-to /tmp/x` prints the dry-run warning

## Out of scope (per advisor)

- `--export-to -` (stdout JSON bundle)
- `ROBOT_MD_EXPORT_TO` env var
- Multi-path export
- Defense-in-depth `--warn-on-isolated-home` (Option B)

## Refs

- Closes RobotRegistryFoundation/robot-md#79
- Opencastor-ops PR #36 (already-shipped operational mitigation + §12.1 caveat)
- Spec A §12.1: `opencastor-ops/docs/superpowers/specs/2026-05-10-spec-a-auto-discovery-and-install-wiring.md` lines 322-338

🤖 Generated with [Claude Code](https://claude.com/claude-code)