### PR TITLE
feat(claude-md, autodetect): trim CLAUDE.md template + widen v4l2 filter

### DIFF
--- a/cli/src/robot_md/autodetect.py
+++ b/cli/src/robot_md/autodetect.py
@@ -216,9 +216,18 @@ USB_DB: dict[tuple[str, str], dict[str, str]] = {
 # --------------------------------------------------------------------------- #
 # Known non-camera V4L2 device-name prefixes. Conservative: false positives
 # (hiding a real camera) are worse than false negatives (showing a probe
-# node). Each entry MUST be documented with provenance.
+# node). Each entry MUST be documented with provenance. The prefix matches
+# `str.startswith` semantics — bare names like "pispbe" match "pispbe-input"
+# and "pispbe-tdn-input" alike.
 V4L2_KNOWN_NON_CAMERA_PREFIXES = (
-    "pispbe-",  # Raspberry Pi ISP back-end probe nodes (provenance: Pi 5 + IMX708)
+    "pispbe",  # Raspberry Pi ISP back-end nodes (Pi 5 + IMX708). Covers both
+    # the "pispbe" bare model and "pispbe-input" / "pispbe-tdn-input" etc.
+    "pisp-fe",  # Raspberry Pi ISP front-end nodes (Pi 5).
+    "rpi-hevc-dec",  # Pi HEVC hardware decoder (not a camera).
+    "rpi-hevc-enc",  # Pi HEVC hardware encoder (not a camera).
+    "rpi-mfc",  # Pi multi-format codec (not a camera).
+    "bcm2835-codec",  # BCM2835/2837/2711 codec (not a camera).
+    "bcm2835-isp",  # BCM2835/2837/2711 ISP nodes.
 )
 
 # --------------------------------------------------------------------------- #

--- a/cli/src/robot_md/claude_md.py
+++ b/cli/src/robot_md/claude_md.py
@@ -23,45 +23,35 @@ from robot_md.robot_spec import RobotSpec
 
 _TEMPLATE_INLINE = """# CLAUDE.md — {{ROBOT_NAME}}
 
-> **Agent context file.** Drop this in the root of your robot's project (same directory as `ROBOT.md`) and Claude Code will read it at the start of every session.
+> **Agent context file — small, stable, intent → resource routing table.** The authoritative state lives in `ROBOT.md` (schema-validated YAML) and is reachable on-demand through `robot-md-mcp` resources at `robot-md://{{ROBOT_NAME}}/<slice>`. Prefer the narrowest slice that answers the intent; `/frontmatter` is the escape hatch, not the default.
 >
-> Template from [robot-md](https://github.com/RobotRegistryFoundation/robot-md) — customize everywhere you see `{{...}}` or `TODO`.
-
-This project is a **robot workspace**. The file `ROBOT.md` in this directory is the authoritative declaration of what the robot is and what it can do (identity, physics, drivers, capabilities, safety gates). Consult it before answering any question about the robot.
+> Template from [robot-md](https://github.com/RobotRegistryFoundation/robot-md). Why-is-it-shaped-this-way questions live in that repo's `spec/` + `docs/design/` — see the last row below.
 
 ## Recognizing robot-related intent
 
-When the operator asks any of the following, **you should act** — not ask clarifying questions first:
+When the operator asks any of the following, **act** — don't ask clarifying questions first:
 
-| Operator intent (examples) | What to do |
+| Operator intent | Route |
 |---|---|
-| "What can this robot do?" / "What are its capabilities?" | Read `robot-md://{{ROBOT_NAME}}/capabilities` (MCP) or run `robot-md render ROBOT.md` and extract `capabilities[]`. |
-| "What are its safety gates?" / "What's dangerous?" | Read `robot-md://{{ROBOT_NAME}}/safety` (MCP) or `robot-md render ROBOT.md` and extract `safety.hitl_gates`, `safety.estop`. |
-| "Something's wrong" / "It's not responding" / "Why is X broken" | Run `robot-md doctor --path ROBOT.md`. Report each non-pass check. |
-| "Is the manifest valid?" / "Did I break something?" | Run `robot-md validate ROBOT.md`. |
-| "Pose the arm at zero" / "Calibrate" | `robot-md calibrate --zero ROBOT.md`. Relay the interactive prompts to the operator. |
-| "Publish my robot" / "Give it a public URL" | `robot-md publish-discovery ROBOT.md --url <URL>` writes `.well-known/robot-md.json`. |
-| "Pick up the X" / any physical motion | Call `mcp__robot-md-{{ROBOT_NAME}}__execute_capability` (dry-run first). Check `safety.hitl_gates` for the cap's scope; if a gate with `require_auth: true` matches, request explicit operator approval before re-running without dry-run. |
-
-## Tooling available in this workspace
-
-```bash
-robot-md --help              # full verb list
-robot-md doctor              # diagnose install + manifest + drivers
-robot-md validate ROBOT.md   # schema conformance
-robot-md render ROBOT.md     # frontmatter → pure YAML (for parsing)
-robot-md context ROBOT.md    # Claude-ready context block (if no MCP)
-robot-md publish-discovery ROBOT.md --url <url>   # emit .well-known/robot-md.json
-```
-
-If `robot-md-mcp` is registered in this session (check with `/mcp`), prefer the MCP resources over shelling out — they stay in sync with the file on disk automatically:
-
-- `robot-md://{{ROBOT_NAME}}/frontmatter` — full parsed YAML
-- `robot-md://{{ROBOT_NAME}}/capabilities` — capabilities list
-- `robot-md://{{ROBOT_NAME}}/safety` — safety block
-- `robot-md://{{ROBOT_NAME}}/body` — prose
-
-MCP tools (also available): `validate`, `render`, `estop`, `estop_clear`, `execute_capability`, `execute_task`.
+| "What can this robot do?" / "What are its capabilities?" | resource `robot-md://{{ROBOT_NAME}}/capabilities` |
+| "What are its safety gates?" / "What's dangerous?" | resource `robot-md://{{ROBOT_NAME}}/safety` |
+| "Brief me on this robot" / "Give me the full context" | resource `robot-md://{{ROBOT_NAME}}/context` (on-demand only — this CLAUDE.md is the eager entry; don't auto-fetch `/context` at session start) |
+| "What's its name / RRN?" | resource `robot-md://{{ROBOT_NAME}}/identity` |
+| "What drivers? What port? What baud?" | resource `robot-md://{{ROBOT_NAME}}/drivers` |
+| "What's the workspace? IK provider? DoF?" | resource `robot-md://{{ROBOT_NAME}}/physics` |
+| "Servo_id of <joint>?" / joint limits / DH params | resource `robot-md://{{ROBOT_NAME}}/kinematics` |
+| "Camera extrinsic / intrinsic?" / "Is the OAK-D calibrated?" | resource `robot-md://{{ROBOT_NAME}}/cameras` |
+| "What joints does the `ready` pose set?" | resource `robot-md://{{ROBOT_NAME}}/poses` |
+| "What HSV range detects `red_lego`?" / declared visual targets | resource `robot-md://{{ROBOT_NAME}}/vision` |
+| "Read the prose body / README" | resource `robot-md://{{ROBOT_NAME}}/body` |
+| "Read the raw YAML" — fallback when no narrow slice fits | resource `robot-md://{{ROBOT_NAME}}/frontmatter` (escape hatch) |
+| "Is the manifest valid? Did I break it?" | tool `validate` (or `robot-md validate ROBOT.md` from the shell) |
+| "Give me the canonical YAML" | tool `render` (or `robot-md render ROBOT.md`) |
+| "Quick-check the robot" / "Something's wrong" | tool `doctor_summary` (manifest-only) or `robot-md doctor` (live: probes drivers + network) |
+| "Pose the arm at zero" / "Calibrate" | `robot-md calibrate --zero ROBOT.md` — relay the interactive prompts to the operator |
+| "Publish my robot" / "Give it a public URL" | `robot-md publish-discovery ROBOT.md --url <URL>` — writes `.well-known/robot-md.json` |
+| "Pick up the X" / any physical motion | tool `execute_capability` (dry-run first). Check `safety.hitl_gates` for the cap's scope; if a gate with `require_auth: true` matches, request explicit operator approval before re-running without dry-run. Software E-stop via tool `estop`; clear via `estop_clear`. Multi-step plans via tool `execute_task`. |
+| "Why is the manifest shaped this way?" / "What does the spec say?" | Browse [RobotRegistryFoundation/robot-md](https://github.com/RobotRegistryFoundation/robot-md) — see `spec/`, `docs/design/`. Not loaded into this session; one-hop reference only. |
 
 ## Safety posture
 

--- a/cli/tests/test_autodetect_v4l2_filter.py
+++ b/cli/tests/test_autodetect_v4l2_filter.py
@@ -26,6 +26,58 @@ def test_pispbe_video_nodes_are_filtered():
 
     models = [c.model for c in cams]
     assert "Logitech C920" in models
-    assert not any(m.startswith("pispbe-") for m in models), (
-        f"pispbe-* nodes leaked into camera list: {models}"
+    assert not any(m.startswith("pispbe") for m in models), (
+        f"pispbe nodes leaked into camera list: {models}"
     )
+
+
+def test_bare_pispbe_model_is_filtered():
+    """v4l2-ctl on some Pi configs reports "pispbe" without the "-input" suffix.
+
+    Bare-name matching previously slipped through (the old prefix included a
+    trailing dash). This regression test pins the broadened semantics.
+    """
+    fake_paths = ["/dev/video0", "/dev/video20"]
+    fake_caps = {
+        "/dev/video0": {"model": "Logitech C920", "width": 1280, "height": 720},
+        "/dev/video20": {"model": "pispbe", "width": 640, "height": 480},
+    }
+    with (
+        patch("robot_md.autodetect._v4l2_list_devices", return_value=fake_paths),
+        patch("robot_md.autodetect._v4l2_device_capabilities", side_effect=lambda p: fake_caps[p]),
+    ):
+        cams = probe_v4l2_cameras()
+    models = [c.model for c in cams]
+    assert "pispbe" not in models, f"bare pispbe node leaked: {models}"
+    assert "Logitech C920" in models
+
+
+def test_rpi_hevc_decoder_is_filtered():
+    """Pi's HEVC hardware decoder shows up as a v4l2 device but is not a camera."""
+    fake_paths = ["/dev/video0", "/dev/video19"]
+    fake_caps = {
+        "/dev/video0": {"model": "Logitech C920", "width": 1280, "height": 720},
+        "/dev/video19": {"model": "rpi-hevc-dec", "width": 1920, "height": 1080},
+    }
+    with (
+        patch("robot_md.autodetect._v4l2_list_devices", return_value=fake_paths),
+        patch("robot_md.autodetect._v4l2_device_capabilities", side_effect=lambda p: fake_caps[p]),
+    ):
+        cams = probe_v4l2_cameras()
+    models = [c.model for c in cams]
+    assert "rpi-hevc-dec" not in models, f"HEVC decoder leaked into cameras: {models}"
+    assert "Logitech C920" in models
+
+
+def test_pisp_fe_frontend_is_filtered():
+    """Pi 5 ISP front-end nodes (pisp-fe-*) are not cameras either."""
+    fake_paths = ["/dev/video36"]
+    fake_caps = {
+        "/dev/video36": {"model": "pisp-fe-image", "width": 1920, "height": 1080},
+    }
+    with (
+        patch("robot_md.autodetect._v4l2_list_devices", return_value=fake_paths),
+        patch("robot_md.autodetect._v4l2_device_capabilities", side_effect=lambda p: fake_caps[p]),
+    ):
+        cams = probe_v4l2_cameras()
+    assert cams == [], f"pisp-fe front-end nodes leaked: {[c.model for c in cams]}"


### PR DESCRIPTION
## Summary

Two harness-engineering hygiene fixes from applying OpenAI's [progressive-disclosure lens](https://openai.com/index/harness-engineering/) to the robot-md doc surface.

- **CLAUDE.md template trim** — standalone Tooling + MCP-resources sections collapsed into a single intent → resource routing table. Every line now either routes an intent or states an always-applicable fact. New routing rows for the narrow MCP slices (`/drivers`, `/physics`, `/kinematics`, `/cameras`, `/poses`, `/vision`) shipping in robot-md-mcp#13, plus a row routing the "why is this shaped this way?" intent to this repo's `spec/` + `docs/design/`. `/context` marked on-demand only. Net effect on a real robot: 75 → 65 lines despite **gaining** 8 routing rows.
- **V4L2 autodetect filter widening** — `V4L2_KNOWN_NON_CAMERA_PREFIXES` expanded from a single `"pispbe-"` entry (which missed bare-name nodes and didn't cover the HEVC decoder / ISP front-end / BCM codec nodes) to a documented set covering Pi 5 ISP back-end + front-end, HEVC dec/enc, MFC, and BCM2835 codec/ISP. Each entry has provenance.

## Real-world impact

Concrete failure mode caught: an operator's Pi 5 + so-arm101 manifest was 500 lines with 17 stale "cameras" (16 `pispbe-video*` + 1 `rpi-hevc-dec-video19`), all with empty extrinsic. The old filter only matched `"pispbe-"` (with dash) — bare `pispbe` slipped through, as did `rpi-hevc-dec`. Future manifests skip these; backfill for existing manifests tracked in #91.

## Test plan

- [x] `pytest cli/tests/test_claude_md.py` → 17/17 passing (no test changes; contracts preserved)
- [x] `pytest cli/tests/test_autodetect_v4l2_filter.py` → 4/4 passing (3 new regression tests for bare-pispbe, rpi-hevc-dec, pisp-fe)
- [x] `pytest cli/tests/test_autodetect*.py` → 30/30
- [x] Full suite (excl. hardware/integration/manual): 1224/1226 — 2 pre-existing SSL-timeout failures in `test_register.py` confirmed unrelated against main
- [x] Live regen: `robot-md claude-md` against a real ROBOT.md produces the new layout; `robot-md validate` confirms the trimmed manifest is schema-conformant
- [x] Existing tests `test_template_lists_all_six_mcp_tools` and `test_template_motion_row_points_at_execute_capability` still pass — all six python-MCP tool names (`validate`/`render`/`estop`/`estop_clear`/`execute_capability`/`execute_task`) still appear in the rendered output

## Follow-ups (not in this PR)

- #91 — `robot-md doctor --autofix-cameras`: backfill the v4l2 filter to existing manifests
- #92 — `robot-md docs` CLI verb: turn the spec breadcrumb into a real surface
- robot-md-mcp#13 — companion PR adding the narrow MCP slices this template now routes to

🤖 Generated with [Claude Code](https://claude.com/claude-code)